### PR TITLE
Update CLI snapshot load error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The events exchanged in the demo have a simple JSON structure. Here's an example
 
 ```json
 {
-  "type": "demo_event",
+  "event_type": "demo_event",
   "timestamp": 1678886400,
   "payload": {
     "message": "Hello from producer_demo!"
@@ -56,7 +56,7 @@ The events exchanged in the demo have a simple JSON structure. Here's an example
 
 **Fields:**
 
-*   `type` (string): Describes the kind of event. In the demo, this is hardcoded to `"demo_event"`.
+*   `event_type` (string): Describes the kind of event. In the demo, this is hardcoded to `"demo_event"`.
 *   `timestamp` (integer): A Unix timestamp (seconds since epoch) indicating when the event was generated.
 *   `payload` (object): A JSON object containing the actual data of the event. The structure of the payload can vary depending on the event type. For the demo, it includes a simple `message`.
 

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -6,7 +6,7 @@ from .event import Event, EventType, parse_event, EventError
 from .graph import MockGraph
 from .graph_adapter import IGraphAdapter
 from .processing import apply_event_to_graph, ProcessingError
-from .snapshot import snapshot_graph_to_file, load_graph_from_file, SnapshotError # Modify this import
+from .snapshot import snapshot_graph_to_file, load_graph_from_file, SnapshotError
 
 __all__ = [
     "Event", "EventType", "parse_event", "EventError",
@@ -14,6 +14,6 @@ __all__ = [
     "IGraphAdapter",
     "apply_event_to_graph", "ProcessingError",
     "snapshot_graph_to_file",
-    "load_graph_from_file", # Add this
-    "SnapshotError"         # Add this
+    "load_graph_from_file",
+    "SnapshotError"
 ]

--- a/src/ume/snapshot.py
+++ b/src/ume/snapshot.py
@@ -1,10 +1,11 @@
 # src/ume/snapshot.py
 import json
 from typing import Union, List, Tuple
-import pathlib # For type hinting path-like objects
+import pathlib  # For type hinting path-like objects
 
 # Ensure MockGraph is available for instantiation and type hinting
 from .graph import MockGraph
+from .processing import ProcessingError
 
 
 class SnapshotError(ValueError):
@@ -113,6 +114,11 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> MockGraph:
 
         # Use public API to add edges for consistency
         for src, tgt, lbl in loaded_edges:
-            graph.add_edge(src, tgt, lbl)
+            try:
+                graph.add_edge(src, tgt, lbl)
+            except ProcessingError as e:
+                raise SnapshotError(
+                    f"Error adding edge ({src}, {tgt}, {lbl}): {e}"
+                ) from e
 
     return graph

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -145,3 +145,16 @@ def test_cli_unknown_command(tmp_path): # tmp_path not used but is a standard fi
     assert "*** Unknown syntax: unknown_command_test" in stdout # Default Cmd behavior
     assert stderr == ""
 
+
+def test_cli_snapshot_load_invalid_snapshot(tmp_path):
+    """Loading a malformed snapshot should print a user-friendly error."""
+    bad_snapshot = tmp_path / "bad_snapshot.json"
+    # Write an invalid snapshot (nodes should be a dict)
+    bad_snapshot.write_text('{"nodes": []}')
+
+    commands = [f"snapshot_load {shlex.quote(str(bad_snapshot))}", "exit"]
+    stdout, stderr = run_cli_commands(commands)
+
+    assert "Error loading snapshot" in stdout
+    assert stderr == ""
+

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -3,8 +3,17 @@ import json
 import shlex
 import time # Added for timestamp in event creation
 from cmd import Cmd
-from ume import parse_event, apply_event_to_graph, load_graph_from_file, snapshot_graph_to_file
-from ume import MockGraph, ProcessingError, EventError, IGraphAdapter # Added IGraphAdapter for type hint
+from ume import (
+    parse_event,
+    apply_event_to_graph,
+    load_graph_from_file,
+    snapshot_graph_to_file,
+    MockGraph,
+    ProcessingError,
+    EventError,
+    SnapshotError,
+    IGraphAdapter,
+)
 
 # It's good practice to handle potential import errors if ume is not installed,
 # though for poetry run python ume_cli.py this should be fine.
@@ -209,8 +218,8 @@ class UMEPrompt(Cmd):
             print(f"Graph restored from {filepath}")
         except FileNotFoundError:
             print(f"Error: Snapshot file '{filepath}' not found.")
-        except (json.JSONDecodeError, EventError, ProcessingError) as e: # Catch specific load/parse errors
-             print(f"Error loading snapshot: {e}")
+        except (json.JSONDecodeError, EventError, ProcessingError, SnapshotError) as e:  # Catch specific load/parse errors
+            print(f"Error loading snapshot: {e}")
         except Exception as e:
             print(f"An unexpected error occurred during load: {e}")
 


### PR DESCRIPTION
## Summary
- import `SnapshotError` in CLI and catch it when loading snapshots
- document `event_type` field in README example
- test snapshot load error message in CLI

## Testing
- `ruff check .`
- `mypy src/ume`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68406de4261883269d678fba9959b3cd