### PR TITLE
Enhance graph traversal helpers

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -21,6 +21,7 @@ from .analytics import (
     time_varying_centrality,
 )
 from . import query_helpers
+from .query_helpers import constrained_path
 from . import graph_queries
 from .anonymizer import anonymize_email
 from .api import app as api_app
@@ -62,6 +63,7 @@ __all__ = [
     "enable_periodic_snapshot",
     "Neo4jQueryEngine",
     "shortest_path",
+    "constrained_path",
     "find_communities",
     "temporal_node_counts",
     "temporal_community_detection",

--- a/src/ume/graph_adapter.py
+++ b/src/ume/graph_adapter.py
@@ -208,6 +208,7 @@ class IGraphAdapter(ABC):
 
         Implementations should return an empty list if no path exists.
         """
+        pass
 
     @abstractmethod
     def traverse(
@@ -222,6 +223,7 @@ class IGraphAdapter(ABC):
         given label. The return value is a list of visited node IDs in BFS
         order.
         """
+        pass
 
     @abstractmethod
     def extract_subgraph(

--- a/src/ume/query_helpers.py
+++ b/src/ume/query_helpers.py
@@ -29,3 +29,21 @@ def extract_subgraph(
 ) -> Dict[str, Any]:
     """Wrapper around :meth:`IGraphAdapter.extract_subgraph`."""
     return graph.extract_subgraph(start_node_id, depth, edge_label, since_timestamp)
+
+
+def constrained_path(
+    graph: IGraphAdapter,
+    source_id: str,
+    target_id: str,
+    max_depth: Optional[int] = None,
+    edge_label: Optional[str] = None,
+    since_timestamp: Optional[int] = None,
+) -> List[str]:
+    """Wrapper around :meth:`IGraphAdapter.constrained_path`."""
+    return graph.constrained_path(
+        source_id,
+        target_id,
+        max_depth=max_depth,
+        edge_label=edge_label,
+        since_timestamp=since_timestamp,
+    )


### PR DESCRIPTION
## Summary
- explicitly mark new traversal methods in `IGraphAdapter`
- expose a `constrained_path` helper alongside other wrappers
- re-export `constrained_path` from package

## Testing
- `ruff check src/ume/graph_adapter.py src/ume/query_helpers.py src/ume/__init__.py`
- `mypy src/ume/graph_adapter.py src/ume/query_helpers.py src/ume/__init__.py`
- `pytest tests/test_traversal_methods.py -q` *(fails: ModuleNotFoundError: No module named 'ume')*

------
https://chatgpt.com/codex/tasks/task_e_68482cfe2d5c8326b11edb116c53855c