### PR TITLE
Implement periodic flushing for privacy agent

### DIFF
--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -1,7 +1,10 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file='.env', env_file_encoding='utf-8', extra='ignore')
+    model_config = SettingsConfigDict(
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
 
     # UME Core
     UME_DB_PATH: str = "ume_graph.db"
@@ -19,10 +22,12 @@ class Settings(BaseSettings):
     KAFKA_NODE_TOPIC: str = "ume_nodes"
     KAFKA_GROUP_ID: str = "ume_client_group"
     KAFKA_PRIVACY_AGENT_GROUP_ID: str = "ume-privacy-agent-group"
+    # Flush interval for Kafka producer in privacy agent
+    KAFKA_PRODUCER_FLUSH_INTERVAL: int = 1
 
     # API
     UME_API_TOKEN: str = "secret-token"
 
+
 # Create a single, importable instance
 settings = Settings()
-

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -1,6 +1,36 @@
-from presidio_analyzer import RecognizerResult
-from ume import privacy_agent
+import importlib.util
 import json
+from pathlib import Path
+import sys
+import types
+
+from presidio_analyzer import RecognizerResult
+
+root_dir = Path(__file__).resolve().parents[1]
+# Build a minimal 'ume' package so privacy_agent can be imported
+pkg = types.ModuleType("ume")
+pkg.__path__ = [str(root_dir / "src/ume")]
+sys.modules["ume"] = pkg
+
+schemas_spec = importlib.util.spec_from_file_location(
+    "ume.schemas",
+    root_dir / "src/ume/schemas/__init__.py",
+    submodule_search_locations=[str(root_dir / "src/ume/schemas")],
+)
+schemas_mod = importlib.util.module_from_spec(schemas_spec)
+assert schemas_spec.loader is not None
+sys.modules["ume.schemas"] = schemas_mod
+schemas_spec.loader.exec_module(schemas_mod)
+
+pa_spec = importlib.util.spec_from_file_location(
+    "ume.privacy_agent",
+    root_dir / "src/ume/privacy_agent.py",
+    submodule_search_locations=[str(root_dir / "src/ume")],
+)
+privacy_agent = importlib.util.module_from_spec(pa_spec)
+assert pa_spec.loader is not None
+sys.modules["ume.privacy_agent"] = privacy_agent
+pa_spec.loader.exec_module(privacy_agent)
 
 
 class FakeAnalyzer:
@@ -13,7 +43,9 @@ class FakeAnalyzer:
 
 def test_redact_event_payload_with_pii(monkeypatch):
     payload = {"email": "user@example.com"}
-    results = [RecognizerResult(entity_type="EMAIL_ADDRESS", start=11, end=27, score=1.0)]
+    results = [
+        RecognizerResult(entity_type="EMAIL_ADDRESS", start=11, end=27, score=1.0)
+    ]
     monkeypatch.setattr(privacy_agent, "_ANALYZER", FakeAnalyzer(results))
     redacted, flag = privacy_agent.redact_event_payload(payload)
     assert flag is True
@@ -58,12 +90,13 @@ class FakeConsumer:
 class FakeProducer:
     def __init__(self):
         self.produced = []
+        self.flush_calls = 0
 
     def produce(self, topic, value, *args, **kwargs):
         self.produced.append((topic, value))
 
     def flush(self):
-        pass
+        self.flush_calls += 1
 
 
 def test_privacy_agent_end_to_end(monkeypatch):
@@ -78,12 +111,16 @@ def test_privacy_agent_end_to_end(monkeypatch):
 
     consumer = FakeConsumer([msg])
     producer = FakeProducer()
-    results = [RecognizerResult(entity_type="EMAIL_ADDRESS", start=11, end=27, score=1.0)]
+    results = [
+        RecognizerResult(entity_type="EMAIL_ADDRESS", start=11, end=27, score=1.0)
+    ]
 
     monkeypatch.setattr(privacy_agent, "_ANALYZER", FakeAnalyzer(results))
     monkeypatch.setattr(privacy_agent, "Consumer", lambda conf: consumer)
     monkeypatch.setattr(privacy_agent, "Producer", lambda conf: producer)
     monkeypatch.setattr(privacy_agent, "log_audit_entry", lambda *a, **k: None)
+    monkeypatch.setattr(privacy_agent.settings, "KAFKA_PRODUCER_FLUSH_INTERVAL", 10)
+    monkeypatch.setattr(privacy_agent, "FLUSH_INTERVAL", 10)
 
     privacy_agent.run_privacy_agent()
 
@@ -91,7 +128,13 @@ def test_privacy_agent_end_to_end(monkeypatch):
     quarantine_topic = privacy_agent.QUARANTINE_TOPIC
 
     clean_msg = next(val for (topic, val) in producer.produced if topic == clean_topic)
-    quarantine_msg = next(val for (topic, val) in producer.produced if topic == quarantine_topic)
+    quarantine_msg = next(
+        val for (topic, val) in producer.produced if topic == quarantine_topic
+    )
 
-    assert json.loads(clean_msg.decode("utf-8"))["payload"] == {"email": "<EMAIL_ADDRESS>"}
+    assert json.loads(clean_msg.decode("utf-8"))["payload"] == {
+        "email": "<EMAIL_ADDRESS>"
+    }
     assert json.loads(quarantine_msg.decode("utf-8")) == {"original": payload}
+    # Flush should only be called once at shutdown
+    assert producer.flush_calls == 1


### PR DESCRIPTION
## Summary
- add `KAFKA_PRODUCER_FLUSH_INTERVAL` setting
- flush Kafka producer in privacy agent only after a configured number of messages
- update privacy agent tests to avoid importing heavy modules

## Testing
- `ruff check src/ume/privacy_agent.py src/ume/config.py tests/test_privacy_agent.py`
- `ruff format --check src/ume/config.py src/ume/privacy_agent.py tests/test_privacy_agent.py`
- `PYTHONPATH=src pytest tests/test_privacy_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848649d926c8326bebb02d680805087