### PR TITLE
Skip CI on docs/comment-only commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,14 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4 # Updated to v4
 
+      - name: Fetch main
+        run: git fetch origin main --depth=1
+
+      - name: Detect code changes
+        id: changes
+        run: |
+          scripts/ci_should_run.py && echo "run=true" >> "$GITHUB_OUTPUT" || echo "run=false" >> "$GITHUB_OUTPUT"
+
       - name: Set up Python
         uses: actions/setup-python@v5 # Updated to v5
         with:
@@ -33,23 +41,28 @@ jobs:
           # --local flag makes this configuration specific to the current project
 
       - name: Install dependencies
+        if: steps.changes.outputs.run == 'true'
         run: |
           poetry install --no-interaction --no-ansi --with dev
           # --with dev ensures dev dependencies like pytest and ruff are installed
 
       - name: Run unit tests (pytest)
+        if: steps.changes.outputs.run == 'true'
         run: |
           poetry run pytest --maxfail=1 --disable-warnings -q tests/
 
       - name: Check coverage (pytest-cov)
+        if: steps.changes.outputs.run == 'true'
         run: |
           poetry run pytest --cov=src/ume --cov-report=xml --cov-report=term-missing tests/
           # Generates term-missing report for console and xml for potential external tools
 
       - name: Lint with Ruff
+        if: steps.changes.outputs.run == 'true'
         run: |
           poetry run ruff check src tests
 
       - name: Check formatting with Ruff
+        if: steps.changes.outputs.run == 'true'
         run: |
           poetry run ruff format --check src tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ If you find a bug or have an idea for a new feature, please check our issue trac
 
 - Ensure `pre-commit` hooks pass and that `pytest` succeeds before opening a PR.
 - All PRs are reviewed by a maintainer and must pass CI (tests, Ruff lint, and formatting checks) before merging.
+- The CI workflow automatically skips these checks when a pull request only modifies documentation or code comments.
 
 ## Development Setup
 

--- a/scripts/ci_should_run.py
+++ b/scripts/ci_should_run.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Determine whether CI should run for the current diff.
+
+Exit status ``0`` indicates code changes requiring tests and linting. A status
+of ``1`` means only documentation files or comment lines were modified, so CI
+can be safely skipped.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def run(cmd: list[str]) -> list[str]:
+    """Run a command and return the output split into lines."""
+
+    return subprocess.check_output(cmd).decode().splitlines()
+
+
+def docs_only(files: list[str]) -> bool:
+    """Return True if every file is a documentation file."""
+
+    doc_exts = (".md", ".rst", ".txt", ".yml", ".yaml")
+    for path in files:
+        if path.startswith("docs/"):
+            continue
+        if any(path.endswith(ext) for ext in doc_exts):
+            continue
+        return False
+    return True
+
+
+def code_diff_present(diff_lines: list[str]) -> bool:
+    """Return True if any added/removed line contains real code."""
+
+    for line in diff_lines:
+        if line.startswith("+++ ") or line.startswith("--- "):
+            continue
+        if line.startswith("@@"):
+            continue
+        if line.startswith("+") or line.startswith("-"):
+            content = line[1:].strip()
+            if not content:
+                continue
+            if content.startswith("#"):
+                continue
+            if content.startswith("//"):
+                continue
+            stripped = content.lstrip()
+            if stripped.startswith('"""') or stripped.startswith("'''"):
+                continue
+            return True
+    return False
+
+
+def main() -> int:
+    base = run(["git", "merge-base", "HEAD", "origin/main"])[0]
+    changed_files = run(["git", "diff", "--name-only", base, "HEAD"])
+
+    if docs_only(changed_files):
+        return 1
+
+    diff_lines = run(["git", "diff", "-U0", base, "HEAD"])
+    return 0 if code_diff_present(diff_lines) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ci_should_run.py
+++ b/tests/test_ci_should_run.py
@@ -1,0 +1,18 @@
+import scripts.ci_should_run as csr
+
+
+def test_docs_only():
+    assert csr.docs_only(["README.md", "docs/intro.rst"]) is True
+    assert csr.docs_only(["README.md", "src/foo.py"]) is False
+
+
+def test_code_diff_present():
+    diff = [
+        "@@ -1 +1 @@",
+        "-# old comment",
+        "+# new comment",
+    ]
+    assert csr.code_diff_present(diff) is False
+
+    diff2 = ["+print('hi')"]
+    assert csr.code_diff_present(diff2) is True


### PR DESCRIPTION
## Summary
- improve script used in CI to skip when only docs or comments changed
- add unit test for detection logic

## Testing
- `ruff check scripts/ci_should_run.py src tests`
- `pytest tests/test_ci_should_run.py -q`
- `pytest -q` *(fails: ImportError)*

------
https://chatgpt.com/codex/tasks/task_e_68486add97a083268f5f118c59c74771