### PR TITLE
Add mypy check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,11 @@ jobs:
           poetry install --no-interaction --no-ansi --with dev
           # --with dev ensures dev dependencies like pytest and ruff are installed
 
+      - name: Install type stubs for mypy
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          pip install types-PyYAML types-pytz types-requests types-ujson
+
       - name: Run unit tests (pytest)
         if: steps.changes.outputs.run == 'true'
         run: |
@@ -78,3 +83,8 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         run: |
           poetry run ruff format --check src tests
+
+      - name: Static type check with mypy
+        if: steps.changes.outputs.run == 'true'
+        run: |
+          poetry run mypy

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,7 @@ If you find a bug or have an idea for a new feature, please check our issue trac
 
 - **Black** is used for code formatting. Run `black` on your changes before committing.
 - **Ruff** enforces linting rules and also checks formatting. The CI will fail if Ruff reports issues.
+- **Mypy** performs static type checking. The CI runs `poetry run mypy` and will fail on type errors.
 
 ### Branch Naming & Pre-commit Hooks
 
@@ -51,7 +52,7 @@ If you find a bug or have an idea for a new feature, please check our issue trac
 ### Pull Requests
 
 - Ensure `pre-commit` hooks pass and that `pytest` succeeds before opening a PR.
-- All PRs are reviewed by a maintainer and must pass CI (tests, Ruff lint, and formatting checks) before merging.
+- All PRs are reviewed by a maintainer and must pass CI (tests, Ruff lint, formatting checks, and mypy) before merging.
 - The CI workflow automatically skips these checks when a pull request only modifies documentation or code comments.
 
 ### Merge Queue

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
 ignore_missing_imports = True
+files = src, tests

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -1,6 +1,5 @@
 import json
 
-import pytest
 from presidio_analyzer import RecognizerResult
 
 from ume import privacy_agent
@@ -13,7 +12,7 @@ class FakeAnalyzer:
         return self._results
 
 
-def test_redact_event_payload_with_pii(privacy_agent, monkeypatch):
+def test_redact_event_payload_with_pii(monkeypatch):
     payload = {"email": "user@example.com"}
     results = [
         RecognizerResult(entity_type="EMAIL_ADDRESS", start=11, end=27, score=1.0)
@@ -24,7 +23,7 @@ def test_redact_event_payload_with_pii(privacy_agent, monkeypatch):
     assert redacted == {"email": "<EMAIL_ADDRESS>"}
 
 
-def test_redact_event_payload_without_pii(privacy_agent, monkeypatch):
+def test_redact_event_payload_without_pii(monkeypatch):
     payload = {"message": "hello"}
     monkeypatch.setattr(privacy_agent, "_ANALYZER", FakeAnalyzer([]))
     redacted, flag = privacy_agent.redact_event_payload(payload)
@@ -71,7 +70,7 @@ class FakeProducer:
         self.flush_calls += 1
 
 
-def test_privacy_agent_end_to_end(privacy_agent, monkeypatch):
+def test_privacy_agent_end_to_end(monkeypatch):
     payload = {"email": "user@example.com"}
     event = {
         "event_type": "CREATE_NODE",
@@ -112,7 +111,7 @@ def test_privacy_agent_end_to_end(privacy_agent, monkeypatch):
     assert producer.flush_calls == 1
 
 
-def test_privacy_agent_periodic_flush(privacy_agent, monkeypatch):
+def test_privacy_agent_periodic_flush(monkeypatch):
     payload = {"email": "user@example.com"}
     event = {
         "event_type": "CREATE_NODE",


### PR DESCRIPTION
## Summary
- run mypy in CI when tests run
- install type stubs in CI
- document mypy check in CONTRIBUTING
- configure mypy to default to `src` and `tests`
- fix unused-import issues in privacy agent tests

## Testing
- `poetry run mypy`
- `poetry run pytest -q`
- `ruff check src tests`


------
https://chatgpt.com/codex/tasks/task_e_68499d07f9fc83269f8bc3acb60064b2