### PR TITLE
Add pre-commit to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
         run: |
           pip install types-PyYAML types-pytz types-requests types-ujson
 
+      - name: Run pre-commit
+        if: steps.changes.outputs.run == 'true'
+        run: pre-commit run --all-files --color always
+
       - name: Run unit tests (pytest)
         if: steps.changes.outputs.run == 'true'
         run: |


### PR DESCRIPTION
## Summary
- run `pre-commit` in CI before tests and linters

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `poetry run ruff check src tests` *(fails: Undefined name `pytest` in tests)*
- `poetry run mypy` *(fails: Name `pytest` is not defined in tests)*
- `poetry run pytest -q` *(fails: NameError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_6849a6006b288326a5b1edad9659c746