### PR TITLE
Add doc for codex setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,15 @@ run the helper script:
 ```bash
 ./codex_setup.sh
 ```
+This script installs Python 3.12 if missing, upgrades `pip` and `poetry`,
+installs development dependencies, and sets up the `pre-commit` hooks. It also
+downloads the optional `en_core_web_lg` spaCy model when available.
+
+After setup you can verify whether tests and linters need to run for your
+changes with:
+```bash
+python scripts/ci_should_run.py && echo "Run tests" || echo "Docs only, skipping"
+```
 
 ### 2. Start Redpanda (Kafka) via Docker
 ```bash


### PR DESCRIPTION
## Summary
- note what `codex_setup.sh` installs
- mention `ci_should_run.py` for checking if tests need to run

## Testing
- `pre-commit run --files codex_setup.sh README.md`
- `PYTHONPATH=src poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b29d296bc8326b652e805e33acd43