### PR TITLE
Add RBAC tests for analytics and redaction endpoints

### DIFF
--- a/src/ume/rbac_adapter.py
+++ b/src/ume/rbac_adapter.py
@@ -69,9 +69,11 @@ class RoleBasedGraphAdapter(IGraphAdapter):
         self._adapter.delete_edge(source_node_id, target_node_id, label)
 
     def redact_node(self, node_id: str) -> None:
+        self._require_analytics_role()
         self._adapter.redact_node(node_id)
 
     def redact_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        self._require_analytics_role()
         self._adapter.redact_edge(source_node_id, target_node_id, label)
 
     def close(self) -> None:

--- a/tests/test_api_rbac.py
+++ b/tests/test_api_rbac.py
@@ -2,7 +2,7 @@ import os
 from fastapi.testclient import TestClient
 
 from ume.api import app, configure_graph
-from ume import MockGraph
+from ume import MockGraph, RoleBasedGraphAdapter
 from ume.config import settings
 
 
@@ -88,3 +88,57 @@ def test_shortest_path_forbidden_for_other_roles():
         headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
     )
     assert res.status_code == 403
+
+
+def test_path_forbidden_with_role_based_adapter():
+    graph = RoleBasedGraphAdapter(build_graph(), role="AutoDev")
+    configure_graph(graph)
+
+    client = TestClient(app)
+    payload = {"source": "a", "target": "b"}
+    res = client.post(
+        "/analytics/path",
+        json=payload,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 403
+
+
+def test_subgraph_forbidden_with_role_based_adapter():
+    graph = RoleBasedGraphAdapter(build_graph(), role="AutoDev")
+    configure_graph(graph)
+
+    client = TestClient(app)
+    sub = {"start": "a", "depth": 1}
+    res = client.post(
+        "/analytics/subgraph",
+        json=sub,
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 403
+
+
+def test_redact_node_forbidden_with_role_based_adapter():
+    graph = RoleBasedGraphAdapter(build_graph(), role="AutoDev")
+    configure_graph(graph)
+
+    client = TestClient(app)
+    res = client.post(
+        "/redact/node/a",
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 403
+
+
+def test_redact_edge_forbidden_with_role_based_adapter():
+    graph = RoleBasedGraphAdapter(build_graph(), role="AutoDev")
+    configure_graph(graph)
+
+    client = TestClient(app)
+    res = client.post(
+        "/redact/edge",
+        json={"source": "a", "target": "b", "label": "L"},
+        headers={"Authorization": f"Bearer {settings.UME_API_TOKEN}"},
+    )
+    assert res.status_code == 403
+


### PR DESCRIPTION
## Summary
- require analytics role for redaction in `RoleBasedGraphAdapter`
- add RBAC API tests covering path, subgraph and redaction endpoints

## Testing
- `ruff check tests/test_api_rbac.py src/ume/rbac_adapter.py`
- `pytest tests/test_api_rbac.py::test_path_forbidden_with_role_based_adapter -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca7c773348326b5521a928718535a