### PR TITLE
Add GPU option to VectorStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,8 @@ Set the following environment variables to configure the store:
 
 - `UME_VECTOR_DIM` – dimension of the embedding vectors (default `1536`).
 - `UME_VECTOR_INDEX` – path of the FAISS index file.
+- `UME_VECTOR_USE_GPU` – set to `true` to build the index on a GPU (requires
+  FAISS compiled with GPU support).
 
 Install the optional dependencies with:
 

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     # Vector store
     UME_VECTOR_DIM: int = 1536
     UME_VECTOR_INDEX: str = "vectors.faiss"
+    UME_VECTOR_USE_GPU: bool = False
 
     # Kafka/Redpanda
     KAFKA_BOOTSTRAP_SERVERS: str = "localhost:9092"

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -2,10 +2,12 @@ import time
 from ume import Event, EventType, MockGraph, apply_event_to_graph
 from ume.vector_store import VectorStore, VectorStoreListener
 from ume._internal.listeners import register_listener, unregister_listener
+import faiss
+import pytest
 
 
-def test_vector_store_add_and_query() -> None:
-    store = VectorStore(dim=2)
+def test_vector_store_add_and_query_cpu() -> None:
+    store = VectorStore(dim=2, use_gpu=False)
     store.add("a", [1.0, 0.0])
     store.add("b", [0.0, 1.0])
     res = store.query([1.0, 0.0], k=1)
@@ -13,7 +15,7 @@ def test_vector_store_add_and_query() -> None:
 
 
 def test_vector_store_listener_on_create() -> None:
-    store = VectorStore(dim=2)
+    store = VectorStore(dim=2, use_gpu=False)
     listener = VectorStoreListener(store)
     register_listener(listener)
     graph = MockGraph()
@@ -26,3 +28,9 @@ def test_vector_store_listener_on_create() -> None:
     unregister_listener(listener)
 
     assert store.query([1.0, 0.0], k=1) == ["n1"]
+
+
+def test_vector_store_gpu_init() -> None:
+    if not hasattr(faiss, "StandardGpuResources"):
+        pytest.skip("FAISS GPU not available")
+    VectorStore(dim=2, use_gpu=True)


### PR DESCRIPTION
## Summary
- allow `VectorStore` to run on GPU using FAISS
- expose `UME_VECTOR_USE_GPU` setting
- create helper `create_default_store`
- add GPU tests for vector store
- document GPU usage

## Testing
- `pre-commit run --files src/ume/vector_store.py src/ume/config.py tests/test_vector_store.py README.md`
- `pytest -q tests/test_vector_store.py`

------
https://chatgpt.com/codex/tasks/task_e_6851950b5ff0832692b1ffbfeb62c846