### PR TITLE
Add structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,13 @@ Install the optional dependencies with:
 poetry install --with vector
 ```
 
+## Logging
+
+UME uses ``structlog`` for structured application logs. By default logs are
+formatted for human readability. Set ``UME_LOG_JSON=1`` to output JSON lines and
+``UME_LOG_LEVEL=DEBUG`` for verbose logging. These environment variables apply
+to the CLI, API server and demo scripts.
+
 ## Where to Get Help
 
 If you have questions, encounter issues, or want to discuss ideas related to UME, please feel free to:

--- a/examples/agent_integration.py
+++ b/examples/agent_integration.py
@@ -1,6 +1,7 @@
 """Demonstrates AutoDev -> UME -> Culture.ai event flow using :class:`UMEClient`."""
 
 import logging
+from ume.logging_utils import configure_logging
 import time
 
 from ume import Event, EventType
@@ -8,7 +9,7 @@ from ume.client import UMEClient
 from ume.config import Settings
 
 # Configure logging so we can observe the flow
-logging.basicConfig(level=logging.INFO)
+configure_logging()
 logger = logging.getLogger("agent_integration")
 
 
@@ -44,4 +45,3 @@ if __name__ == "__main__":
 
     # Step 3: Forward those events to Culture.ai (simulated)
     forward_to_culture(consumed)
-

--- a/poetry.lock
+++ b/poetry.lock
@@ -3801,6 +3801,18 @@ anyio = ">=3.6.2,<5"
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
+name = "structlog"
+version = "25.4.0"
+description = "Structured Logging for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "structlog-25.4.0-py3-none-any.whl", hash = "sha256:fe809ff5c27e557d14e613f45ca441aabda051d119ee5a0102aaba6ce40eed2c"},
+    {file = "structlog-25.4.0.tar.gz", hash = "sha256:186cd1b0a8ae762e29417095664adf1d6a31702160a46dacb7796ea82f7409e4"},
+]
+
+[[package]]
 name = "terminaltables"
 version = "3.1.10"
 description = "Generate simple tables in terminals from a nested list of strings."
@@ -4512,7 +4524,10 @@ cffi = {version = ">=1.11", markers = "platform_python_implementation == \"PyPy\
 [package.extras]
 cffi = ["cffi (>=1.11)"]
 
+[extras]
+vector = []
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "3cba0450d01de18cd3898114c87bd3aa1062744e0e06b2a3cf473a5fa6ae5c62"
+content-hash = "5327c79eea497937d434959d877879c1f053e73a2a6f5a02b94f8c3f9e34ccdf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ fastavro = ">=1.9"
 pyyaml = "*" # Using "*" for PyYAML as it's a common practice, but can be pinned down if needed.
 neo4j = "*"
 networkx = "*"
+# Structured logging
+structlog = "*"
 # FastAPI >=0.110 requires Pydantic v2 which is compatible with
 # pydantic-settings 2.x, so we pin within the current major release.
 fastapi = ">=0.110,<1"

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .config import settings
 import os
+from .logging_utils import configure_logging
 from typing import Any, Dict, List
 
 from fastapi import Depends, FastAPI, HTTPException, Header, Query
@@ -14,6 +15,8 @@ from .analytics import shortest_path
 from .rbac_adapter import RoleBasedGraphAdapter, AccessDeniedError
 from .graph_adapter import IGraphAdapter
 from .query import Neo4jQueryEngine
+
+configure_logging()
 
 API_TOKEN = settings.UME_API_TOKEN
 

--- a/src/ume/consumer_demo.py
+++ b/src/ume/consumer_demo.py
@@ -9,13 +9,13 @@ corresponding producer_demo.py script.
 
 import json
 import logging
+from ume.logging_utils import configure_logging
 from ume.config import settings
 from ume.utils import ssl_config
 from confluent_kafka import Consumer, KafkaException, KafkaError  # type: ignore
 from ume import parse_event, EventError  # Import parse_event and EventError
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+configure_logging()
 logger = logging.getLogger("consumer_demo")
 
 # Kafka broker and topic

--- a/src/ume/logging_utils.py
+++ b/src/ume/logging_utils.py
@@ -1,0 +1,49 @@
+import logging
+import os
+
+import structlog
+
+
+def configure_logging(
+    *, level: int | str | None = None, json_logs: bool | None = None
+) -> None:
+    """Configure structlog-based logging.
+
+    Parameters
+    ----------
+    level:
+        Logging level, e.g. ``logging.INFO`` or ``"DEBUG"``. Defaults to the
+        ``UME_LOG_LEVEL`` environment variable or ``INFO``.
+    json_logs:
+        If ``True``, use JSON formatted logs. Defaults to ``UME_LOG_JSON``
+        environment variable (``"1"``, ``"true"``).
+    """
+    if level is None:
+        level = os.getenv("UME_LOG_LEVEL", "INFO")
+    if isinstance(level, str):
+        level = getattr(logging, level.upper(), logging.INFO)
+
+    if json_logs is None:
+        json_env = os.getenv("UME_LOG_JSON", "0").lower()
+        json_logs = json_env in {"1", "true", "yes"}
+
+    processors: list[structlog.types.Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+    ]
+    renderer: structlog.types.Processor
+    if json_logs:
+        renderer = structlog.processors.JSONRenderer()
+    else:
+        renderer = structlog.dev.ConsoleRenderer()
+    processors.append(renderer)
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(level),
+        logger_factory=structlog.PrintLoggerFactory(),
+        cache_logger_on_first_use=True,
+    )
+
+    logging.basicConfig(level=level, format="%(message)s")

--- a/src/ume/privacy_agent.py
+++ b/src/ume/privacy_agent.py
@@ -6,6 +6,7 @@ import json
 import logging
 from typing import Dict, Tuple
 from .utils import ssl_config
+from .logging_utils import configure_logging
 
 from confluent_kafka import Consumer, Producer, KafkaException, KafkaError  # type: ignore
 from presidio_analyzer import AnalyzerEngine  # type: ignore
@@ -17,7 +18,7 @@ from .schema_utils import validate_event_dict
 from .audit import log_audit_entry
 
 
-logging.basicConfig(level=logging.INFO)
+configure_logging()
 logger = logging.getLogger(__name__)
 
 

--- a/src/ume/producer_demo.py
+++ b/src/ume/producer_demo.py
@@ -10,14 +10,14 @@ import json
 import logging
 from ume.utils import ssl_config
 from ume.config import settings
+from ume.logging_utils import configure_logging
 import time
 from confluent_kafka import Producer, KafkaException  # type: ignore
 from ume import Event
 from ume.schema_utils import validate_event_dict
 from jsonschema import ValidationError
 
-# Configure logging
-logging.basicConfig(level=logging.INFO)
+configure_logging()
 logger = logging.getLogger("producer_demo")
 
 # Kafka broker and topic

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -9,6 +9,7 @@ import sys
 import time  # Added for timestamp in event creation
 import warnings
 from pathlib import Path
+from ume.logging_utils import configure_logging
 
 # Ensure local package import when run directly without installation
 _src_path = Path(__file__).resolve().parent / "src"
@@ -186,9 +187,7 @@ class UMEPrompt(Cmd):
                 return
             source_id, target_id, label = parts
             self.graph.redact_edge(source_id, target_id, label)
-            print(
-                f"Edge ({source_id})->({target_id}) [{label}] redacted."
-            )
+            print(f"Edge ({source_id})->({target_id}) [{label}] redacted.")
         except ProcessingError as e:
             print(f"Error: {e}")
         except Exception as e:
@@ -349,7 +348,9 @@ class UMEPrompt(Cmd):
         if callable(close_method):
             try:
                 close_method()
-            except Exception as e:  # pragma: no cover - cleanup failure should not crash CLI
+            except (
+                Exception
+            ) as e:  # pragma: no cover - cleanup failure should not crash CLI
                 logging.getLogger(__name__).error("Error closing graph: %s", e)
         print("Goodbye!")
         return True  # returning True exits the Cmd loop
@@ -389,6 +390,8 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    configure_logging()
 
     _setup_warnings(args.show_warnings, args.warnings_log)
 


### PR DESCRIPTION
## Summary
- add `logging_utils.configure_logging` based on structlog
- integrate helper into CLI, API, privacy agent and demos
- document enabling JSON or verbose logs

## Testing
- `ruff format --quiet src/ examples/ ume_cli.py README.md pyproject.toml`
- `ruff check src tests examples ume_cli.py`
- `poetry run mypy`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6851950f26ac832688fcf64c6df4649c