### PR TITLE
Expose DAGExecutor and Task

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -26,6 +26,7 @@ from .config import Settings
 from .utils import ssl_config
 from .vector_store import VectorStore, VectorStoreListener
 from .llm_ferry import LLMFerry
+from .dag_executor import DAGExecutor, Task
 
 
 try:  # Optional dependency

--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -26,6 +26,8 @@ class VectorStore:
         use_gpu: bool | None = None,
         path: str | None = None,
         flush_interval: float | None = None,
+        query_latency_metric: Histogram | None = None,
+        index_size_metric: Gauge | None = None,
 
     ) -> None:
         self.path = path or settings.UME_VECTOR_INDEX
@@ -34,6 +36,9 @@ class VectorStore:
         self.gpu_resources = None
         self.use_gpu = use_gpu if use_gpu is not None else settings.UME_VECTOR_USE_GPU
         self.dim = dim
+
+        self.query_latency_metric = query_latency_metric
+        self.index_size_metric = index_size_metric
 
         self._flush_interval = flush_interval
         self._flush_thread: threading.Thread | None = None


### PR DESCRIPTION
## Summary
- expose `DAGExecutor` and `Task` at package level
- support optional metrics in `VectorStore` constructor
- update DAG executor tests to import from `ume`

## Testing
- `pre-commit run --files src/ume/__init__.py src/ume/vector_store.py tests/test_dag_executor.py`
- `pytest tests/test_dag_executor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685225f414188326a7cb012e159c1e7f