### PR TITLE
Limit CI matrix to Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.12"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- update CI workflow to only test on Python 3.12

## Testing
- `poetry install --no-interaction --no-ansi --with dev`
- `poetry run ruff check . --config pyproject.toml`
- `poetry run mypy --config-file mypy.ini`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6852febb9710832682dbf90f24a3e81c