### PR TITLE
Fix coverage job python matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       group: coverage-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ["self-hosted", "linux"]
+    strategy:
+      matrix:
+        python-version: ['3.12']
 
     steps:
       - name: Checkout code
@@ -106,7 +109,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
         run: |


### PR DESCRIPTION
## Summary
- configure `coverage` workflow to use a python-version matrix
- use the matrix variable when setting up Python

## Testing
- `poetry run ruff check . --config pyproject.toml`
- `poetry run mypy --config-file mypy.ini`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853235492a08326ad37be43e6e97bf2