### PR TITLE
Move test job to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ concurrency:
 
 jobs:
   test-and-lint:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - linux
     outputs:
       run: ${{ steps.changes.outputs.run }}
     strategy:


### PR DESCRIPTION
## Summary
- shift the `test-and-lint` job to run on the self-hosted Linux runner

## Testing
- `poetry run pre-commit run --files .github/workflows/ci.yml`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_685364be15688326a2c02df4f51a80cd