### PR TITLE
Fix snapshot logging

### DIFF
--- a/src/ume/auto_snapshot.py
+++ b/src/ume/auto_snapshot.py
@@ -30,7 +30,7 @@ def enable_periodic_snapshot(
         try:
             snapshot_graph_to_file(graph, snapshot_path)
         except Exception:  # pragma: no cover - don't raise during shutdown
-            pass
+            logger.exception("Failed to snapshot graph to %s", snapshot_path)
 
     stop_event = threading.Event()
 

--- a/tests/test_auto_snapshot.py
+++ b/tests/test_auto_snapshot.py
@@ -21,11 +21,56 @@ def test_enable_snapshot_autosave_logs_warning(tmp_path, caplog, monkeypatch):
         lambda *args, **kwargs: (sentinel_thread, sentinel_stop),
     )
 
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.WARNING, logger="ume.auto_snapshot"):
         result = auto_snapshot.enable_snapshot_autosave_and_restore(graph, snapshot_file)
 
     assert result == (sentinel_thread, sentinel_stop)
     assert any("Failed to restore snapshot" in rec.message for rec in caplog.records)
+
+
+def test_periodic_snapshot_logs_error(tmp_path, caplog, monkeypatch):
+    import ume.auto_snapshot as auto_snapshot
+
+    graph = PersistentGraph(":memory:")
+    snapshot_file = tmp_path / "snapshot.json"
+
+    def raise_error(*args, **kwargs):
+        raise ValueError("snap error")
+
+    monkeypatch.setattr(auto_snapshot, "snapshot_graph_to_file", raise_error)
+
+    events: dict[str, bool] = {}
+
+    class DummyEvent:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def wait(self, timeout: float | None = None) -> bool:
+            self.calls += 1
+            return self.calls > 1
+
+        def set(self) -> None:
+            events["set"] = True
+
+    class DummyThread:
+        def __init__(self, target=None, daemon=None) -> None:
+            self._target = target
+
+        def start(self) -> None:
+            self._target()
+
+        def join(self) -> None:
+            events["joined"] = True
+
+    monkeypatch.setattr(auto_snapshot.threading, "Event", DummyEvent)
+    monkeypatch.setattr(auto_snapshot.threading, "Thread", DummyThread)
+
+    with caplog.at_level(logging.ERROR, logger="ume.auto_snapshot"):
+        auto_snapshot.enable_periodic_snapshot(graph, snapshot_file, 1)
+
+    auto_snapshot.disable_periodic_snapshot()
+
+    assert any("Failed to snapshot graph" in rec.message for rec in caplog.records)
 
 
 def test_disable_periodic_snapshot(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- log exceptions when periodic snapshot fails
- test that failures in periodic snapshot log an error
- clean up tests and narrow log capture

## Testing
- `pre-commit run --files src/ume/auto_snapshot.py tests/test_auto_snapshot.py`
- `pytest tests/test_auto_snapshot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b95ac97883269d0e886b9838f34a