### PR TITLE
Handle networkx errors more selectively

### DIFF
--- a/src/ume/analytics.py
+++ b/src/ume/analytics.py
@@ -109,7 +109,7 @@ def pagerank_centrality(graph: IGraphAdapter) -> Dict[str, float]:
     g = _to_networkx(graph)
     try:
         return nx.pagerank(g)
-    except Exception:
+    except nx.NetworkXException:
         # networkx>=3.5 relies on SciPy; fall back to a numpy implementation
         return _pagerank_numpy(g)
 
@@ -225,5 +225,5 @@ def time_varying_centrality(graph: IGraphAdapter, past_n_days: int) -> Dict[str,
         return {}
     try:
         return nx.pagerank(sub)
-    except Exception:
+    except nx.NetworkXException:
         return _pagerank_numpy(sub)


### PR DESCRIPTION
## Summary
- catch `nx.NetworkXException` when pagerank operations fail
- patch tests to avoid scipy dependency and simulate networkx errors
- add explicit fallback tests for centrality functions

## Testing
- `pre-commit run --files src/ume/analytics.py tests/test_analytics.py`
- `pytest tests/test_analytics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b95f818c83269856545615f3ed94