### PR TITLE
Implement retry logic in background flush

### DIFF
--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -69,11 +69,26 @@ class VectorStore:
             return
 
         def _loop() -> None:
+            retries = 3
             while not self._flush_stop.wait(interval):
-                try:
-                    self.save()
-                except Exception:  # pragma: no cover - log and continue
-                    logger.exception("Background flush failed")
+                for attempt in range(retries):
+                    try:
+                        self.save()
+                        break
+                    except Exception:  # pragma: no cover - log and continue
+                        if attempt < retries - 1:
+                            logger.warning(
+                                "Background flush failed (attempt %s/%s), retrying",
+                                attempt + 1,
+                                retries,
+                            )
+                            time.sleep(0.1)
+                        else:
+                            logger.exception(
+                                "Background flush failed after %s attempts",
+                                retries,
+                            )
+                            break
 
         self._flush_stop.clear()
         self._flush_thread = threading.Thread(target=_loop, daemon=True)

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -7,6 +7,7 @@ import faiss
 import pytest
 from pathlib import Path
 from prometheus_client import Gauge, Histogram
+import logging
 
 
 def test_vector_store_add_and_query_cpu() -> None:
@@ -161,6 +162,34 @@ def test_background_flush_continues_on_save_error(tmp_path: Path) -> None:
     new_store = VectorStore(dim=2, use_gpu=False)
     new_store.load(str(path))
     assert new_store.query([1.0, 0.0], k=1) == ["c"]
+
+
+def test_background_flush_retries_on_save_error(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    path = tmp_path / "retry.faiss"
+    store = VectorStore(dim=2, use_gpu=False, path=str(path), flush_interval=0.05)
+
+    calls = 0
+    orig_save = store.save
+
+    def failing_save(p: str | None = None) -> None:
+        nonlocal calls
+        calls += 1
+        if calls <= 3:
+            raise RuntimeError("boom")
+        orig_save(p)
+
+    store.save = failing_save  # type: ignore[assignment]
+    store.add("d", [1.0, 0.0])
+    with caplog.at_level(logging.WARNING, logger="ume.vector_store"):
+        time.sleep(0.7)
+    store.stop_background_flush()
+
+    assert calls >= 4
+    assert any("retrying" in rec.message.lower() for rec in caplog.records)
+    assert any("after 3 attempts" in rec.message for rec in caplog.records)
+    new_store = VectorStore(dim=2, use_gpu=False)
+    new_store.load(str(path))
+    assert new_store.query([1.0, 0.0], k=1) == ["d"]
 
 
 def test_vector_store_metrics_init() -> None:


### PR DESCRIPTION
## Summary
- add retry mechanism for background flush saving with log messages
- test that background flush retries failed saves
- adjust test timing so retries succeed

## Testing
- `pre-commit run --files src/ume/vector_store.py tests/test_vector_store.py`
- `pytest tests/test_vector_store.py -k test_background_flush_retries_on_save_error -q`

------
https://chatgpt.com/codex/tasks/task_e_68557aaa636c83268ecce50791377505