### PR TITLE
Add ontology concept graph utilities

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -49,6 +49,7 @@ else:  # pragma: no cover - optional dependency
 from .llm_ferry import LLMFerry
 from .dag_executor import DAGExecutor, Task
 from .dag_service import DAGService
+from .ontology import build_concept_graph, update_concept_graph_for_node
 
 
 try:  # Optional dependency
@@ -97,6 +98,8 @@ __all__ = [
     "LLMFerry",
 
     "generate_embedding",
+    "build_concept_graph",
+    "update_concept_graph_for_node",
     "Task",
     "DAGExecutor",
     "DAGService",

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -15,6 +15,7 @@ class EventType(str, Enum):
     UPDATE_NODE_ATTRIBUTES = "UPDATE_NODE_ATTRIBUTES"
     CREATE_EDGE = "CREATE_EDGE"
     DELETE_EDGE = "DELETE_EDGE"
+    CREATE_ONTOLOGY_RELATION = "CREATE_ONTOLOGY_RELATION"
 
 
 @dataclass(frozen=True)
@@ -139,7 +140,11 @@ def parse_event(data: Dict[str, Any]) -> Event:
             logger.error(msg)
             raise EventError(msg)
 
-    elif event_type in [EventType.CREATE_EDGE.value, EventType.DELETE_EDGE.value]:
+    elif event_type in [
+        EventType.CREATE_EDGE.value,
+        EventType.DELETE_EDGE.value,
+        EventType.CREATE_ONTOLOGY_RELATION.value,
+    ]:
         required_fields_for_edge = {"node_id", "target_node_id", "label"}
         missing_fields = required_fields_for_edge - data.keys()
         if missing_fields:

--- a/src/ume/ontology.py
+++ b/src/ume/ontology.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import logging
+import math
+import time
+from typing import Dict, List
+
+from .embedding import generate_embedding
+from .event import Event, EventType
+from .graph_adapter import IGraphAdapter
+from .processing import apply_event_to_graph
+
+logger = logging.getLogger(__name__)
+
+
+def _cosine_similarity(a: List[float], b: List[float]) -> float:
+    """Return the cosine similarity of two vectors."""
+    if len(a) != len(b):
+        raise ValueError("Vector length mismatch")
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def build_concept_graph(
+    graph: IGraphAdapter, *, threshold: float = 0.8
+) -> List[Event]:
+    """Generate ontology edges between similar nodes.
+
+    Nodes are compared using embeddings derived from their ``text`` or
+    ``name`` attribute. Existing embeddings are reused if present.
+    Returns the list of :class:`Event` objects applied to ``graph``.
+    """
+    node_ids = graph.get_all_node_ids()
+    embeddings: Dict[str, List[float]] = {}
+    for nid in node_ids:
+        data = graph.get_node(nid) or {}
+        emb = data.get("embedding")
+        if not isinstance(emb, list):
+            text = str(data.get("text") or data.get("name") or "")
+            if not text:
+                continue
+            emb = generate_embedding(text)
+        embeddings[nid] = emb
+
+    ids = list(embeddings.keys())
+    events: List[Event] = []
+    for i in range(len(ids)):
+        for j in range(i + 1, len(ids)):
+            e1 = embeddings[ids[i]]
+            e2 = embeddings[ids[j]]
+            sim = _cosine_similarity(e1, e2)
+            if sim >= threshold:
+                event = Event(
+                    event_type=EventType.CREATE_ONTOLOGY_RELATION,
+                    timestamp=int(time.time()),
+                    node_id=ids[i],
+                    target_node_id=ids[j],
+                    label="RELATES_TO",
+                    payload={"similarity": sim},
+                )
+                apply_event_to_graph(event, graph)
+                events.append(event)
+    logger.info("Created %s ontology relations", len(events))
+    return events
+
+
+def update_concept_graph_for_node(
+    graph: IGraphAdapter, node_id: str, *, threshold: float = 0.8
+) -> List[Event]:
+    """Update ontology relations for ``node_id`` against existing nodes."""
+    node = graph.get_node(node_id)
+    if not node:
+        return []
+    emb = node.get("embedding")
+    if not isinstance(emb, list):
+        text = str(node.get("text") or node.get("name") or "")
+        if not text:
+            return []
+        emb = generate_embedding(text)
+    events: List[Event] = []
+    for other_id in graph.get_all_node_ids():
+        if other_id == node_id:
+            continue
+        other = graph.get_node(other_id) or {}
+        other_emb = other.get("embedding")
+        if not isinstance(other_emb, list):
+            text = str(other.get("text") or other.get("name") or "")
+            if not text:
+                continue
+            other_emb = generate_embedding(text)
+        sim = _cosine_similarity(emb, other_emb)
+        if sim >= threshold:
+            event = Event(
+                event_type=EventType.CREATE_ONTOLOGY_RELATION,
+                timestamp=int(time.time()),
+                node_id=node_id,
+                target_node_id=other_id,
+                label="RELATES_TO",
+                payload={"similarity": sim},
+            )
+            apply_event_to_graph(event, graph)
+            events.append(event)
+    logger.info(
+        "Updated ontology for %s with %s relations", node_id, len(events)
+    )
+    return events

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -140,6 +140,30 @@ def apply_event_to_graph(
         for listener in get_registered_listeners():
             listener.on_edge_created(source_node_id, target_node_id, label)
 
+    elif event.event_type == EventType.CREATE_ONTOLOGY_RELATION:
+        source_node_id = event.node_id
+        target_node_id = event.target_node_id
+        label = event.label
+
+        if not (
+            isinstance(source_node_id, str)
+            and isinstance(target_node_id, str)
+            and isinstance(label, str)
+        ):
+            raise ProcessingError(
+                f"Invalid event structure for CREATE_ONTOLOGY_RELATION: source_node_id, target_node_id, "
+                f"and label must be strings. Event ID: {event.event_id}"
+            )
+
+        assert isinstance(source_node_id, str)
+        assert isinstance(target_node_id, str)
+        assert isinstance(label, str)
+        schema = DEFAULT_SCHEMA_MANAGER.get_schema(schema_version)
+        schema.validate_edge_label(label)
+        graph.add_edge(source_node_id, target_node_id, label)
+        for listener in get_registered_listeners():
+            listener.on_edge_created(source_node_id, target_node_id, label)
+
     elif event.event_type == EventType.DELETE_EDGE:
         # parse_event should have validated presence and type of node_id, target_node_id, label
         source_node_id = event.node_id

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -1,0 +1,42 @@
+import time
+from ume import Event, EventType, MockGraph, apply_event_to_graph
+from ume import ontology
+
+
+def test_build_concept_graph(monkeypatch):
+    graph = MockGraph()
+    now = int(time.time())
+    events = [
+        Event(
+            event_type=EventType.CREATE_NODE,
+            timestamp=now,
+            payload={"node_id": "n1", "attributes": {"text": "apple fruit"}},
+        ),
+        Event(
+            event_type=EventType.CREATE_NODE,
+            timestamp=now,
+            payload={"node_id": "n2", "attributes": {"text": "banana fruit"}},
+        ),
+        Event(
+            event_type=EventType.CREATE_NODE,
+            timestamp=now,
+            payload={"node_id": "n3", "attributes": {"text": "car vehicle"}},
+        ),
+    ]
+    for e in events:
+        apply_event_to_graph(e, graph)
+
+    def fake_embed(text: str):
+        if "apple" in text:
+            return [1.0, 0.0]
+        if "banana" in text:
+            return [0.9, 0.1]
+        return [0.0, 1.0]
+
+    monkeypatch.setattr(ontology, "generate_embedding", fake_embed)
+
+    rel_events = ontology.build_concept_graph(graph, threshold=0.8)
+    assert any(
+        ev.node_id == "n1" and ev.target_node_id == "n2" for ev in rel_events
+    )
+    assert ("n1", "n2", "RELATES_TO") in graph.get_all_edges()


### PR DESCRIPTION
## Summary
- add a new `ume.ontology` module for building a concept graph
- introduce `CREATE_ONTOLOGY_RELATION` event type
- handle ontology events in event parser and processor
- expose ontology helpers in package
- test ontology relation learning

## Testing
- `pre-commit run --files src/ume/ontology.py src/ume/__init__.py src/ume/event.py src/ume/processing.py tests/test_ontology.py`
- `pytest tests/test_ontology.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f8c411e48326854be2f9d3d9d481