### PR TITLE
Implement ResourceScheduler for throttled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,23 @@ For current plans and eventual detailed documentation on the UME graph model, pl
 *   [**API Reference (docs/API_REFERENCE.md)**](docs/API_REFERENCE.md)
 *   [**Self-Hosted Runner Setup (docs/SELF_HOSTED_RUNNER.md)**](docs/SELF_HOSTED_RUNNER.md)
 *   [**DAGExecutor Guide (docs/DAG_EXECUTOR.md)**](docs/DAG_EXECUTOR.md)
+*   [**Resource Scheduler**](#resource-scheduler)
+
+## Resource Scheduler
+
+The `ResourceScheduler` provides a lightweight way to limit how many tasks
+can use a given resource simultaneously. Concurrency counts are configured per
+resource.
+
+```python
+from ume import ResourceScheduler, ScheduledTask
+
+sched = ResourceScheduler(resources={"gpu": 1})
+sched.run([
+    ScheduledTask(func=lambda: do_gpu_work(), resource="gpu"),
+    ScheduledTask(func=lambda: more_gpu_work(), resource="gpu"),
+])
+```
 
 This documentation will be updated as the graph processing components of UME are developed.
 

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -51,6 +51,7 @@ from .llm_ferry import LLMFerry
 from .dag_executor import DAGExecutor, Task
 from .agent_orchestrator import AgentOrchestrator, Supervisor, Critic, AgentTask
 from .dag_service import DAGService
+from .resource_scheduler import ResourceScheduler, ScheduledTask
 from .reliability import score_text, filter_low_confidence
 
 try:  # Optional dependency
@@ -112,4 +113,6 @@ __all__ = [
     "Task",
     "DAGExecutor",
     "DAGService",
+    "ScheduledTask",
+    "ResourceScheduler",
 ]

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -24,7 +24,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_RELIABILITY_THRESHOLD: float = 0.5
     WATCH_PATHS: list[str] = ["."]
     DAG_RESOURCES: dict[str, int] = {"cpu": 1, "io": 1}
-    UME_RELIABILITY_THRESHOLD: float = 0.5
 
     # Vector store
     UME_VECTOR_DIM: int = 1536
@@ -54,8 +53,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_OAUTH_PASSWORD: str = "password"
     UME_OAUTH_ROLE: str = "AnalyticsAgent"
     UME_OAUTH_TTL: int = 3600
-    UME_API_TOKEN: str = "test-token"
-
     # API token used for test clients and simple auth
     UME_API_TOKEN: str = "secret-token"
 

--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from importlib import resources
 from typing import Dict
 import json
-import yaml  # type: ignore
+import yaml
 
 
 @dataclass

--- a/src/ume/resource_scheduler.py
+++ b/src/ume/resource_scheduler.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Callable, Iterable, Any
+
+
+@dataclass
+class ScheduledTask:
+    """Simple task with an associated resource."""
+
+    func: Callable[[], Any]
+    resource: str = "cpu"
+
+
+class ResourceScheduler:
+    """Run tasks while enforcing per-resource concurrency limits."""
+
+    def __init__(self, resources: dict[str, int] | None = None) -> None:
+        self.resources = resources or {"cpu": 1, "gpu": 1}
+        for name, count in self.resources.items():
+            if count <= 0:
+                raise ValueError(f"Resource count for {name} must be positive")
+        self.locks = {
+            name: threading.Semaphore(count) for name, count in self.resources.items()
+        }
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:  # pragma: no cover - simple setter
+        """Request the scheduler to stop starting new tasks."""
+
+        self._stop_event.set()
+
+    def reset_stop_flag(self) -> None:  # pragma: no cover - simple setter
+        """Clear the stop flag so the scheduler can be reused."""
+
+        self._stop_event.clear()
+
+    def run(self, tasks: Iterable[ScheduledTask]) -> None:
+        threads: list[threading.Thread] = []
+        for task in tasks:
+            if self._stop_event.is_set():
+                break
+            try:
+                sem = self.locks[task.resource]
+            except KeyError as exc:
+                raise ValueError(f"Unknown resource {task.resource}") from exc
+
+            def worker(
+                t: ScheduledTask = task,
+                s: threading.Semaphore = sem,
+            ) -> None:
+                with s:
+                    t.func()
+
+            thread = threading.Thread(target=worker)
+            thread.start()
+            threads.append(thread)
+        for thread in threads:
+            thread.join()

--- a/tests/test_resource_scheduler.py
+++ b/tests/test_resource_scheduler.py
@@ -1,0 +1,49 @@
+import threading
+import time
+import pytest
+
+from ume.resource_scheduler import ResourceScheduler, ScheduledTask
+
+def test_scheduler_limits_concurrency() -> None:
+    sched = ResourceScheduler(resources={"gpu": 1})
+    events: list[tuple[str, float]] = []
+
+    def make(name: str) -> ScheduledTask:
+        def _task() -> None:
+            events.append((f"{name}_start", time.perf_counter()))
+            time.sleep(0.1)
+            events.append((f"{name}_end", time.perf_counter()))
+        return ScheduledTask(func=_task, resource="gpu")
+
+    sched.run([make("a"), make("b")])
+    starts = [t for t in events if t[0].endswith("_start")]
+    assert len(starts) == 2
+    assert starts[1][1] - starts[0][1] >= 0.09
+
+
+def test_scheduler_unknown_resource_raises() -> None:
+    sched = ResourceScheduler(resources={"cpu": 1})
+    with pytest.raises(ValueError):
+        sched.run([ScheduledTask(func=lambda: None, resource="gpu")])
+
+
+def test_scheduler_stop() -> None:
+    sched = ResourceScheduler(resources={"cpu": 1})
+    ran: list[str] = []
+    started = threading.Event()
+
+    def slow() -> None:
+        started.set()
+        time.sleep(0.2)
+        ran.append("slow")
+
+    def fast() -> None:
+        ran.append("fast")
+
+    tasks = [ScheduledTask(func=slow), ScheduledTask(func=fast)]
+    t = threading.Thread(target=sched.run, args=(tasks,))
+    t.start()
+    started.wait(0.05)
+    sched.stop()
+    t.join()
+    assert ran == ["slow"]


### PR DESCRIPTION
## Summary
- add `ResourceScheduler` module with per-resource throttling
- expose scheduler in package init
- document usage in README
- provide tests for scheduler
- fix mypy errors in config and graph_schema

## Testing
- `pre-commit run --files src/ume/resource_scheduler.py tests/test_resource_scheduler.py README.md src/ume/config.py src/ume/graph_schema.py`
- `pytest tests/test_resource_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685acfda0f348326a128922dbbf9678d