### PR TITLE
Add policy validation in privacy agent

### DIFF
--- a/src/faust/types.py
+++ b/src/faust/types.py
@@ -1,0 +1,2 @@
+class StreamT(list):
+    pass

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -63,6 +63,11 @@ class Settings(BaseSettings):  # type: ignore[misc]
     LLM_FERRY_API_URL: str = "https://example.com/api"
     LLM_FERRY_API_KEY: str = ""
 
+    # Alignment / policy configuration
+    OPA_URL: str | None = None
+    REGO_POLICY_PATHS: list[str] | None = None
+    OPA_TOKEN: str | None = None
+
     def model_post_init(self, __context: Any) -> None:  # noqa: D401
         """Validate settings after initialization."""
         if self.UME_AUDIT_SIGNING_KEY == "default-key":

--- a/src/ume/plugins/alignment/rego_engine.py
+++ b/src/ume/plugins/alignment/rego_engine.py
@@ -8,6 +8,7 @@ from typing import Any, Iterable
 from . import AlignmentPlugin, PolicyViolationError, register_plugin
 from ...event import Event
 from ...policy.opa_client import OPAClient
+from ...config import settings
 
 try:  # Optional dependency
     from regopy import Interpreter as RegoInterpreter
@@ -70,5 +71,12 @@ class RegoPolicyEngine(AlignmentPlugin):
 
 # Register plugin automatically if regopy is installed
 if RegoInterpreter is not None:
-    default_dir = Path(__file__).with_name("policies")
-    register_plugin(RegoPolicyEngine(default_dir))
+    policy_paths = settings.REGO_POLICY_PATHS
+    opa_url = settings.OPA_URL
+    if opa_url:
+        client = OPAClient(base_url=opa_url, token=settings.OPA_TOKEN)
+        register_plugin(RegoPolicyEngine(policy_paths, opa_client=client))
+    else:
+        if policy_paths is None:
+            policy_paths = Path(__file__).with_name("policies")
+        register_plugin(RegoPolicyEngine(policy_paths))

--- a/src/ume/privacy_agent.py
+++ b/src/ume/privacy_agent.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import warnings
 from .pipeline.privacy_agent import *  # noqa: F401,F403
+from .pipeline import privacy_agent as _pa
+
+_ANALYZER = _pa._ANALYZER
+_ANONYMIZER = _pa._ANONYMIZER
 
 warnings.warn(
     "ume.privacy_agent is deprecated; use ume.pipeline.privacy_agent instead.",

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -159,7 +159,8 @@ def test_privacy_agent_audit_log_written(tmp_path, monkeypatch):
     monkeypatch.setenv("UME_AGENT_ID", "tester")
 
     import importlib
-    from ume import config, audit, privacy_agent
+    from ume import config, audit
+    from ume.pipeline import privacy_agent
 
     importlib.reload(config)
     importlib.reload(audit)

--- a/tests/test_privacy_agent_rego.py
+++ b/tests/test_privacy_agent_rego.py
@@ -1,0 +1,76 @@
+import json
+import pytest
+from types import SimpleNamespace
+
+from ume.pipeline import privacy_agent
+
+pytest.importorskip("regopy")
+
+class FakeAnalyzer:
+    def analyze(self, text: str, language: str = "en"):
+        return []
+
+class FakeAnonymizer:
+    def anonymize(self, text: str, analyzer_results):
+        return SimpleNamespace(text=text)
+
+class FakeMessage:
+    def __init__(self, value):
+        self._value = value
+
+    def value(self):
+        return self._value
+
+    def error(self):
+        return None
+
+class FakeConsumer:
+    def __init__(self, messages):
+        self._messages = messages
+
+    def poll(self, timeout=1.0):
+        if self._messages:
+            return self._messages.pop(0)
+        raise KeyboardInterrupt
+
+    def subscribe(self, topics):
+        pass
+
+    def close(self):
+        pass
+
+class FakeProducer:
+    def __init__(self):
+        self.produced = []
+        self.flush_calls = 0
+
+    def produce(self, topic, value, *args, **kwargs):
+        self.produced.append((topic, value))
+
+    def flush(self):
+        self.flush_calls += 1
+
+
+def test_rego_policy_denies_event(monkeypatch):
+    event = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "forbidden",
+        "payload": {"node_id": "forbidden", "attributes": {}},
+    }
+    msg = FakeMessage(json.dumps(event).encode("utf-8"))
+
+    consumer = FakeConsumer([msg])
+    producer = FakeProducer()
+
+    monkeypatch.setattr(privacy_agent, "Consumer", lambda conf: consumer)
+    monkeypatch.setattr(privacy_agent, "Producer", lambda conf: producer)
+    monkeypatch.setattr(privacy_agent, "_ANALYZER", FakeAnalyzer())
+    monkeypatch.setattr(privacy_agent, "_ANONYMIZER", FakeAnonymizer())
+    monkeypatch.setattr(privacy_agent.settings, "KAFKA_PRODUCER_BATCH_SIZE", 1)
+    monkeypatch.setattr(privacy_agent, "BATCH_SIZE", 1)
+
+    privacy_agent.run_privacy_agent()
+
+    assert not any(topic == privacy_agent.CLEAN_TOPIC for topic, _ in producer.produced)
+    assert producer.flush_calls == 1


### PR DESCRIPTION
## Summary
- integrate alignment plugins into privacy agent
- load policies from OPA or local rego files via configuration
- provide compatibility exports for private analyzer objects
- add minimal faust types stub for tests
- test rego policy enforcement in privacy agent
- update audit log test imports

## Testing
- `poetry run ruff check tests/test_privacy_agent.py src/ume/privacy_agent.py src/ume/pipeline/privacy_agent.py src/ume/plugins/alignment/rego_engine.py src/ume/config.py src/faust/types.py tests/test_privacy_agent_rego.py`
- `poetry run pytest tests/test_privacy_agent_rego.py tests/test_privacy_agent.py tests/test_privacy_agent_additional.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685acf38951c8326869b90d67413c988