### PR TITLE
Refactor env handling for settings

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -67,6 +67,7 @@ below lists all available variables and their default values.
 | `UME_CLI_DB` | `ume_graph.db` | Database path used by the CLI. |
 | `UME_ROLE` | *(unset)* | Optional role for the CLI. |
 | `UME_API_ROLE` | *(unset)* | Optional role applied by the API server. |
+| `UME_RATE_LIMIT_REDIS` | *(unset)* | Redis URL for API rate limiting. |
 | `UME_VECTOR_DIM` | `1536` | Dimension of embedding vectors. |
 | `UME_VECTOR_INDEX` | `vectors.faiss` | FAISS index file path. |
 | `UME_VECTOR_USE_GPU` | `False` | Whether to build the index on a GPU. |
@@ -94,6 +95,9 @@ below lists all available variables and their default values.
 | `KAFKA_CLIENT_KEY` | *(unset)* | Client key for Kafka TLS. |
 | `LLM_FERRY_API_URL` | `https://example.com/api` | Endpoint for the `LLMFerry` listener. |
 | `LLM_FERRY_API_KEY` | *(unset)* | API key used by `LLMFerry` for authentication. |
+
+`UME_RATE_LIMIT_REDIS` may be set to a Redis URL to enable shared rate limiting.
+If unset, the API uses an in-memory limiter.
 
 ## Benchmark Hardware
 A single-node Dell PowerEdge R7625 with an EPYC 9254P CPU, 256 GB RAM and four NVMe drives was used when validating the Redpanda benchmark.

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import logging
 import time
 from typing import Any, Awaitable, Callable, Dict, List, cast, AsyncGenerator
@@ -21,6 +20,7 @@ from .logging_utils import configure_logging
 from uuid import uuid4
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, Response
+from sse_starlette.sse import EventSourceResponse
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
@@ -77,7 +77,7 @@ class _MemoryRedis:
 @app.on_event("startup")
 async def _init_limiter() -> None:
     """Initialize rate limiting using Redis or an in-memory fallback."""
-    url = os.getenv("UME_RATE_LIMIT_REDIS")
+    url = settings.UME_RATE_LIMIT_REDIS
     if url and redis:
         try:
             redis_client = redis.from_url(
@@ -135,8 +135,8 @@ except ImportError:  # pragma: no cover - optional dependency
 
 
 def configure_graph(graph: IGraphAdapter) -> None:
-    """Set ``app.state.graph`` applying RBAC if ``UME_API_ROLE`` is defined."""
-    role = os.getenv("UME_API_ROLE")
+    """Set ``app.state.graph`` applying RBAC if ``settings.UME_API_ROLE`` is defined."""
+    role = settings.UME_API_ROLE
     if role:
         graph = RoleBasedGraphAdapter(graph, role=role)
     app.state.graph = graph

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -18,13 +18,13 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_CLI_DB: str = "ume_graph.db"
     UME_ROLE: str | None = None
     UME_API_ROLE: str | None = None
+    UME_RATE_LIMIT_REDIS: str | None = None
     UME_LOG_LEVEL: str = "INFO"
     UME_LOG_JSON: bool = False
     UME_GRAPH_RETENTION_DAYS: int = 30
     UME_RELIABILITY_THRESHOLD: float = 0.5
     WATCH_PATHS: list[str] = ["."]
     DAG_RESOURCES: dict[str, int] = {"cpu": 1, "io": 1}
-    UME_RELIABILITY_THRESHOLD: float = 0.5
 
     # Vector store
     UME_VECTOR_DIM: int = 1536
@@ -54,7 +54,6 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_OAUTH_PASSWORD: str = "password"
     UME_OAUTH_ROLE: str = "AnalyticsAgent"
     UME_OAUTH_TTL: int = 3600
-    UME_API_TOKEN: str = "test-token"
 
     # API token used for test clients and simple auth
     UME_API_TOKEN: str = "secret-token"

--- a/src/ume/embedding.py
+++ b/src/ume/embedding.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import List, TYPE_CHECKING, cast
 
 from .config import settings
@@ -14,7 +13,7 @@ _MODEL_CACHE: dict[str, "SentenceTransformer"] = {}
 def _get_model() -> "SentenceTransformer":
     from sentence_transformers import SentenceTransformer
 
-    model_name = os.getenv("UME_EMBED_MODEL", settings.UME_EMBED_MODEL)
+    model_name = settings.UME_EMBED_MODEL
     model = _MODEL_CACHE.get(model_name)
     if model is None:
         model = SentenceTransformer(model_name)

--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from importlib import resources
 from typing import Dict
 import json
-import yaml  # type: ignore
+import yaml
 
 
 @dataclass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,3 +13,15 @@ def test_audit_key_custom(monkeypatch):
     monkeypatch.setenv("UME_AUDIT_SIGNING_KEY", "mykey")
     s = Settings()
     assert s.UME_AUDIT_SIGNING_KEY == "mykey"
+
+
+def test_rate_limit_default(monkeypatch):
+    monkeypatch.delenv("UME_RATE_LIMIT_REDIS", raising=False)
+    s = Settings()
+    assert s.UME_RATE_LIMIT_REDIS is None
+
+
+def test_rate_limit_env(monkeypatch):
+    monkeypatch.setenv("UME_RATE_LIMIT_REDIS", "redis://localhost:6379/0")
+    s = Settings()
+    assert s.UME_RATE_LIMIT_REDIS == "redis://localhost:6379/0"

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,6 +1,11 @@
 # mypy: ignore-errors
+from __future__ import annotations
+
 import sys
 from pathlib import Path
+import pytest
+import types
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 import time


### PR DESCRIPTION
## Summary
- swap os.getenv calls with settings properties
- document UME_RATE_LIMIT_REDIS
- test config defaults and overrides
- ensure retention tests import required helpers

## Testing
- `pre-commit run --files docs/CONFIG_TEMPLATES.md src/ume/api.py src/ume/config.py src/ume/embedding.py src/ume/graph_schema.py tests/test_api_rbac.py tests/test_config.py tests/test_retention.py`
- `pytest -q tests/test_config.py tests/test_api_rbac.py tests/test_retention.py`

------
https://chatgpt.com/codex/tasks/task_e_685acf49c9d883268f650fc5da74c990