### PR TITLE
Enhance reliability scoring

### DIFF
--- a/src/ume/reliability.py
+++ b/src/ume/reliability.py
@@ -2,19 +2,25 @@ from __future__ import annotations
 
 from typing import Iterable, List
 
+from langdetect import LangDetectException, detect_langs
+
 from .metrics import FALSE_TEXT_RATE, RESPONSE_CONFIDENCE
 
 
 def score_text(text: str) -> float:
-    """Return a naive confidence score for ``text``.
-
-    The score is the ratio of alphabetic characters to the total length
-    of the text. Empty strings yield a score of 0.0.
-    """
+    """Return a confidence score for ``text`` using language detection."""
     if not text:
         return 0.0
-    alpha = sum(1 for c in text if c.isalpha())
-    return alpha / len(text)
+
+    alpha_ratio = sum(1 for c in text if c.isalpha()) / len(text)
+
+    try:
+        detection = detect_langs(text)
+        prob = detection[0].prob if detection else 0.0
+    except LangDetectException:
+        prob = 0.0
+
+    return alpha_ratio * prob
 
 
 def filter_low_confidence(items: Iterable[str], threshold: float) -> List[str]:

--- a/tests/test_reliability_unit.py
+++ b/tests/test_reliability_unit.py
@@ -1,0 +1,42 @@
+from ume import reliability
+
+
+def test_score_text_edge_cases(monkeypatch):
+    class DummyLang:
+        def __init__(self, prob):
+            self.prob = prob
+
+    def fake_detect(text):
+        if not text or text.isdigit():
+            raise reliability.LangDetectException('empty', 'empty')
+        return [DummyLang(0.8)]
+
+    monkeypatch.setattr(reliability, 'detect_langs', fake_detect)
+
+    assert reliability.score_text('') == 0.0
+    assert reliability.score_text('123') == 0.0
+    assert reliability.score_text('abc123') == 0.4
+
+
+def test_filter_low_confidence_metrics(monkeypatch):
+    class DummyHist:
+        def __init__(self):
+            self.values = []
+        def observe(self, val):
+            self.values.append(val)
+    class DummyCounter:
+        def __init__(self):
+            self.count = 0
+        def inc(self):
+            self.count += 1
+
+    hist = DummyHist()
+    counter = DummyCounter()
+    monkeypatch.setattr(reliability, 'RESPONSE_CONFIDENCE', hist)
+    monkeypatch.setattr(reliability, 'FALSE_TEXT_RATE', counter)
+    monkeypatch.setattr(reliability, 'score_text', lambda t: 1.0 if t == 'good' else 0.0)
+
+    result = reliability.filter_low_confidence(['good', 'bad'], 0.5)
+    assert result == ['good']
+    assert hist.values == [1.0, 0.0]
+    assert counter.count == 1


### PR DESCRIPTION
## Summary
- implement language detection in `score_text`
- add unit tests for edge cases and metrics

## Testing
- `ruff check tests/test_reliability_unit.py src/ume/reliability.py`
- `pytest -q tests/test_reliability_unit.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_685b562772748326883fe711f46b078b