### PR TITLE
Add bulk edge addition method

### DIFF
--- a/src/ume/graph.py
+++ b/src/ume/graph.py
@@ -109,6 +109,11 @@ class MockGraph(IGraphAdapter):
             )
         self._edges.append((source_node_id, target_node_id, label))
 
+    def add_edges_bulk(self, edges: list[tuple[str, str, str]]) -> None:
+        """Add multiple edges sequentially using :meth:`add_edge`."""
+        for source, target, label in edges:
+            self.add_edge(source, target, label)
+
     def get_all_edges(self) -> List[Tuple[str, str, str]]:
         """
         Retrieves a list of all edges currently in the graph.

--- a/src/ume/graph_adapter.py
+++ b/src/ume/graph_adapter.py
@@ -163,6 +163,24 @@ class IGraphAdapter(ABC):
         pass
 
     @abstractmethod
+    def add_edges_bulk(self, edges: list[tuple[str, str, str]]) -> None:
+        """Adds multiple edges in one call.
+
+        Each edge is provided as a ``(source_node_id, target_node_id, label)`` tuple.
+
+        Implementations should ensure the same validations as :meth:`add_edge`
+        for every edge in the collection.
+
+        Args:
+            edges: A list of edge tuples to add.
+
+        Raises:
+            ProcessingError (or similar): If any edge would fail the
+                individual :meth:`add_edge` checks.
+        """
+        pass
+
+    @abstractmethod
     def get_all_edges(self) -> list[tuple[str, str, str]]:
         """
         Retrieves a list of all edges currently in the graph.

--- a/src/ume/snapshot.py
+++ b/src/ume/snapshot.py
@@ -126,6 +126,7 @@ def load_graph_from_file(path: Union[str, pathlib.Path]) -> MockGraph:
                     f"(source, target, label) must be strings."
                 )
             loaded_edges.append(tuple(edge_data))  # Convert to tuple for consistency
-        graph._edges = loaded_edges  # Direct assignment after validation
+        if loaded_edges:
+            graph.add_edges_bulk(loaded_edges)
 
     return graph

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -217,6 +217,25 @@ def test_add_edge_both_nodes_missing_raises_error(graph: MockGraph):
         graph.add_edge("nodeS_missing", "nodeT_missing", "IS_RELATED_TO")
 
 
+# --- add_edges_bulk tests ---
+def test_add_edges_bulk_success(graph: MockGraph):
+    """Add multiple edges in one call."""
+    graph.add_node("a", {})
+    graph.add_node("b", {})
+    graph.add_node("c", {})
+    edges = [("a", "b", "L1"), ("b", "c", "L2")]
+    graph.add_edges_bulk(edges)
+    assert set(graph.get_all_edges()) == set(edges)
+
+
+def test_add_edges_bulk_missing_node_raises_error(graph: MockGraph):
+    """Expect ProcessingError if any edge references a missing node."""
+    graph.add_node("a", {})
+    edges = [("a", "missing", "L1")]
+    with pytest.raises(ProcessingError):
+        graph.add_edges_bulk(edges)
+
+
 # --- get_all_edges tests (New) ---
 def test_get_all_edges_empty_graph(graph: MockGraph):
     """Test get_all_edges on a graph with no edges (and no nodes)."""

--- a/tests/test_graph_serialization.py
+++ b/tests/test_graph_serialization.py
@@ -42,9 +42,8 @@ def test_graph_serialization_roundtrip_with_nodes_and_edges():
     graph.add_node("c", {})  # Node with empty attributes
 
     # Add some edges
-    graph.add_edge("a", "b", "RELATES_TO")
-    graph.add_edge("b", "c", "LINKS_TO")
     expected_edges = [("a", "b", "RELATES_TO"), ("b", "c", "LINKS_TO")]
+    graph.add_edges_bulk(expected_edges)
 
     # Get the dump
     dumped_data = graph.dump()
@@ -208,8 +207,8 @@ def test_load_graph_from_file_success_populated_graph(tmp_path: pathlib.Path):
     attrs2 = {"name": "Node 2", "active": True}
     original_graph.add_node("n1", attrs1)
     original_graph.add_node("n2", attrs2)
-    original_graph.add_edge("n1", "n2", "CONNECTS_TO")
     expected_edges = [("n1", "n2", "CONNECTS_TO")]
+    original_graph.add_edges_bulk(expected_edges)
 
     snapshot_file = tmp_path / "populated_graph_to_load.json"
     snapshot_graph_to_file(original_graph, snapshot_file)


### PR DESCRIPTION
## Summary
- define `IGraphAdapter.add_edges_bulk`
- implement `add_edges_bulk` in `MockGraph`
- call the new API from `load_graph_from_file`
- test bulk edge creation and adjust serialization tests

## Testing
- `poetry run pytest -q`
- `poetry run ruff check src tests`
- `poetry run ruff format --check src tests`


------
https://chatgpt.com/codex/tasks/task_e_685da2e8176c8326a40da98e1ca81733