### PR TITLE
Add reflection agent and overseer loop

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -115,3 +115,18 @@ flowchart TD
 
 All core APIs are exposed over gRPC, enabling efficient streaming queries from
 external agents and services.
+
+## Agent Message Format
+
+Worker output is wrapped in a small JSON envelope before being processed by
+reflection and critic agents:
+
+```json
+{
+  "content": "string",
+  "meta": {"optional": "metadata"}
+}
+```
+
+The `ReflectionAgent` can modify this envelope (for example to filter
+hallucinated text) before the `Critic` scores the final `content`.

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -49,7 +49,14 @@ else:  # pragma: no cover - optional dependency
 
 from .llm_ferry import LLMFerry
 from .dag_executor import DAGExecutor, Task
-from .agent_orchestrator import AgentOrchestrator, Supervisor, Critic, AgentTask
+from .agent_orchestrator import (
+    AgentOrchestrator,
+    Supervisor,
+    Critic,
+    AgentTask,
+    MessageEnvelope,
+    ReflectionAgent,
+)
 from .dag_service import DAGService
 from .resource_scheduler import ResourceScheduler, ScheduledTask
 from .reliability import score_text, filter_low_confidence
@@ -121,6 +128,8 @@ __all__ = [
     "AgentOrchestrator",
     "Supervisor",
     "Critic",
+    "MessageEnvelope",
+    "ReflectionAgent",
     "Task",
     "DAGExecutor",
     "DAGService",


### PR DESCRIPTION
## Summary
- wrap agent messages in JSON envelope
- add ReflectionAgent and modify AgentOrchestrator to use it
- describe envelope in architecture docs
- test hallucination filtering

## Testing
- `pre-commit run --files src/ume/agent_orchestrator.py src/ume/__init__.py tests/test_agent_orchestrator.py`
- `pytest tests/test_agent_orchestrator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685dcf30cd1883269af963b759b67d07