### PR TITLE
Add vector age retention scheduler

### DIFF
--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_VECTOR_INDEX: str = "vectors.faiss"
     UME_VECTOR_USE_GPU: bool = False
     UME_VECTOR_GPU_MEM_MB: int = 256
+    UME_VECTOR_MAX_AGE_DAYS: int = 90
 
     # Neo4j connection for optional gRPC server
     NEO4J_URI: str = "bolt://localhost:7687"

--- a/src/ume/metrics.py
+++ b/src/ume/metrics.py
@@ -21,6 +21,10 @@ VECTOR_INDEX_SIZE = Gauge(
     "ume_vector_index_size",
     "Number of vectors stored in the VectorStore",
 )
+STALE_VECTOR_WARNINGS = Counter(
+    "ume_stale_vector_warning_total",
+    "Number of times stale vectors exceeded threshold",
+)
 
 # Reliability metrics
 RESPONSE_CONFIDENCE = Histogram(

--- a/src/ume/retention.py
+++ b/src/ume/retention.py
@@ -1,19 +1,28 @@
 import logging
 import threading
+import time
 from collections.abc import Callable
 
 from typing import Protocol
 from .config import settings
+from .metrics import STALE_VECTOR_WARNINGS
 
 logger = logging.getLogger(__name__)
 
 
 _retention_thread: threading.Thread | None = None
 _stop_event: threading.Event | None = None
+_vector_thread: threading.Thread | None = None
+_vector_stop: threading.Event | None = None
 
 
 class _SupportsPurge(Protocol):
     def purge_old_records(self, max_age_seconds: int) -> None:
+        ...
+
+
+class _SupportsVectorAge(Protocol):
+    def get_vector_timestamps(self) -> dict[str, int]:
         ...
 
 
@@ -68,3 +77,58 @@ def stop_retention_scheduler() -> None:
         _retention_thread.join()
     _retention_thread = None
     _stop_event = None
+
+
+def _check_stale_vectors(store: _SupportsVectorAge, *, log: bool, threshold: int) -> None:
+    max_age = settings.UME_VECTOR_MAX_AGE_DAYS * 86400
+    now = int(time.time())
+    timestamps = store.get_vector_timestamps()
+    stale = [vid for vid, ts in timestamps.items() if now - ts > max_age]
+    if len(stale) > threshold:
+        STALE_VECTOR_WARNINGS.inc()
+        if log:
+            logger.warning("%s stale vectors detected", len(stale))
+
+
+def start_vector_age_scheduler(
+    store: _SupportsVectorAge,
+    *,
+    interval_seconds: float = 24 * 3600,
+    warn_threshold: int = 0,
+    log: bool = False,
+) -> tuple[threading.Thread, Callable[[], None]]:
+    global _vector_thread, _vector_stop
+
+    if _vector_thread and _vector_thread.is_alive():
+        return _vector_thread, lambda: None
+
+    stop_event = threading.Event()
+
+    def _run() -> None:
+        while not stop_event.wait(interval_seconds):
+            try:
+                _check_stale_vectors(store, log=log, threshold=warn_threshold)
+            except Exception:
+                logger.exception("Failed to check vector age")
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    _vector_thread = thread
+    _vector_stop = stop_event
+
+    def stop() -> None:
+        stop_event.set()
+        thread.join()
+
+    return thread, stop
+
+
+def stop_vector_age_scheduler() -> None:
+    global _vector_thread, _vector_stop
+    if _vector_stop is not None:
+        _vector_stop.set()
+    if _vector_thread is not None:
+        _vector_thread.join()
+    _vector_thread = None
+    _vector_stop = None


### PR DESCRIPTION
## Summary
- monitor vector store for stale embeddings
- add stale vector warning metric
- persist vector timestamps in the store
- expose `UME_VECTOR_MAX_AGE_DAYS` setting
- test new scheduler with mock store

## Testing
- `pre-commit run --files src/ume/config.py src/ume/metrics.py src/ume/retention.py src/ume/vector_store.py tests/test_retention.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dcf36d7fc8326b767f1899546cfa0