### PR TITLE
Implement memory aging scheduler

### DIFF
--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -130,6 +130,16 @@ The API runs a background task that calls this method once per day. The
 retention window defaults to 30 days and can be configured via the
 `UME_GRAPH_RETENTION_DAYS` environment variable.
 
+## Memory aging
+
+A separate scheduler periodically moves old events from the episodic graph into
+the semantic store. Facts are preserved while the episodic layer stays small.
+Embeddings associated with aged nodes are also checked for expiration and
+removed from the vector index to keep retrieval‑augmented generation fresh.
+Call :func:`ume.start_memory_aging_scheduler` with paired episodic and
+semantic memory objects to enable the process. Pass ``vector_age_seconds=None``
+to disable vector pruning.
+
 ## Schema Upgrades
 
 ### Migrating from version 1.0.0 to 2.0.0

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -10,6 +10,7 @@ from .auto_snapshot import (
     enable_snapshot_autosave_and_restore,
 )
 from .retention import start_retention_scheduler, stop_retention_scheduler
+from .memory_aging import start_memory_aging_scheduler, stop_memory_aging_scheduler
 from .graph_adapter import IGraphAdapter
 from .rbac_adapter import RoleBasedGraphAdapter, AccessDeniedError
 from .plugins.alignment import PolicyViolationError
@@ -92,6 +93,8 @@ __all__ = [
     "disable_periodic_snapshot",
     "start_retention_scheduler",
     "stop_retention_scheduler",
+    "start_memory_aging_scheduler",
+    "stop_memory_aging_scheduler",
     "validate_event_dict",
     "GraphSchema",
     "load_default_schema",

--- a/src/ume/factories.py
+++ b/src/ume/factories.py
@@ -39,3 +39,20 @@ def create_episodic_memory(
 def create_semantic_memory(db_path: str | None = None) -> SemanticMemory:
     """Instantiate :class:`SemanticMemory` using configuration defaults."""
     return SemanticMemory(db_path or settings.UME_DB_PATH)
+
+
+def create_tiered_memory(
+    *,
+    episodic_db: str | None = None,
+    semantic_db: str | None = None,
+    log_path: str | None = None,
+) -> tuple[EpisodicMemory, SemanticMemory]:
+    """Create paired episodic and semantic memory instances.
+
+    The returned objects can be passed to
+    :func:`ume.start_memory_aging_scheduler` to automatically migrate events
+    from the episodic layer to long-term storage.
+    """
+    episodic = create_episodic_memory(episodic_db, log_path=log_path)
+    semantic = create_semantic_memory(semantic_db)
+    return episodic, semantic

--- a/src/ume/memory_aging.py
+++ b/src/ume/memory_aging.py
@@ -1,0 +1,92 @@
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable
+
+from .memory import EpisodicMemory, SemanticMemory
+from .vector_store import VectorStore
+
+logger = logging.getLogger(__name__)
+
+_thread: threading.Thread | None = None
+_stop_event: threading.Event | None = None
+
+
+def start_memory_aging_scheduler(
+    episodic: EpisodicMemory,
+    semantic: SemanticMemory,
+    *,
+    vector_store: VectorStore | None = None,
+    event_age_seconds: int = 7 * 86400,
+    vector_age_seconds: int | None = 30 * 86400,
+    interval_seconds: float = 3600,
+) -> tuple[threading.Thread, Callable[[], None]]:
+    """Move aged events to long-term storage and prune stale vectors.
+
+    Pass ``vector_age_seconds=None`` to skip vector expiration checks.
+    """
+    global _thread, _stop_event
+
+    if _thread and _thread.is_alive():
+        return _thread, lambda: None
+
+    stop_event = threading.Event()
+
+    def _cycle() -> None:
+        cutoff = int(time.time()) - event_age_seconds
+        cur = episodic.graph.conn.execute(
+            "SELECT id, attributes FROM nodes WHERE created_at < ? AND redacted=0",
+            (cutoff,),
+        )
+        for row in cur.fetchall():
+            node_id = row["id"]
+            attrs = json.loads(row["attributes"])
+            semantic.add_fact(node_id, attrs)
+        cur = episodic.graph.conn.execute(
+            "SELECT source, target, label FROM edges WHERE created_at < ? AND redacted=0",
+            (cutoff,),
+        )
+        for src, tgt, label in cur.fetchall():
+            semantic.relate_facts(src, tgt, label)
+        episodic.graph.purge_old_records(event_age_seconds)
+        if vector_store is not None and vector_age_seconds is not None:
+            try:
+                vector_store.expire_vectors(vector_age_seconds)
+            except Exception:
+                logger.exception("Failed to expire vectors")
+
+    def _run() -> None:
+        try:
+            _cycle()
+        except Exception:
+            logger.exception("Memory aging cycle failed")
+        while not stop_event.wait(interval_seconds):
+            try:
+                _cycle()
+            except Exception:
+                logger.exception("Memory aging cycle failed")
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    _thread = thread
+    _stop_event = stop_event
+
+    def stop() -> None:
+        stop_event.set()
+        thread.join()
+
+    return thread, stop
+
+
+def stop_memory_aging_scheduler() -> None:
+    """Stop the memory aging scheduler if running."""
+    global _thread, _stop_event
+
+    if _stop_event is not None:
+        _stop_event.set()
+    if _thread is not None:
+        _thread.join()
+    _thread = None
+    _stop_event = None

--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -50,6 +50,7 @@ class VectorStore:
                 os.makedirs(dirpath, exist_ok=True)
         self.id_to_idx: Dict[str, int] = {}
         self.idx_to_id: List[str] = []
+        self.vector_ts: Dict[str, int] = {}
         self.gpu_resources = None
         self.use_gpu = use_gpu if use_gpu is not None else settings.UME_VECTOR_USE_GPU
         self.dim = dim
@@ -168,8 +169,46 @@ class VectorStore:
                 self.index.add(arr)
                 self.id_to_idx[item_id] = len(self.idx_to_id)
                 self.idx_to_id.append(item_id)
+            self.vector_ts[item_id] = int(time.time())
         if persist and self.path:
             self.save(self.path)
+
+    def delete(self, item_id: str) -> None:
+        """Remove a vector from the store if present."""
+        with self.lock:
+            idx = self.id_to_idx.pop(item_id, None)
+            if idx is None:
+                self.vector_ts.pop(item_id, None)
+                return
+            del self.idx_to_id[idx]
+            self.vector_ts.pop(item_id, None)
+            self.id_to_idx = {v: i for i, v in enumerate(self.idx_to_id)}
+            if hasattr(self.index, "vectors"):
+                vectors = [self.index.vectors[i] for i in range(self.index.ntotal) if i != idx]
+                self.index = faiss.IndexFlatL2(self.dim)
+                if vectors:
+                    self.index.add(np.asarray(vectors))
+            else:
+                try:
+                    cpu_index = faiss.index_gpu_to_cpu(self.index)
+                except AttributeError:
+                    cpu_index = self.index
+                vectors = [cpu_index.reconstruct(i) for i in range(cpu_index.ntotal) if i != idx]
+                new_index = faiss.IndexFlatL2(self.dim)
+                if vectors:
+                    new_index.add(np.asarray(vectors))
+                cpu_index = new_index
+                if self.use_gpu and self.gpu_resources is not None:
+                    self.index = faiss.index_cpu_to_gpu(self.gpu_resources, 0, cpu_index)
+                else:
+                    self.index = cpu_index
+
+    def expire_vectors(self, max_age_seconds: int) -> None:
+        """Delete vectors older than ``max_age_seconds``."""
+        cutoff = int(time.time()) - max_age_seconds
+        expired = [vid for vid, ts in self.vector_ts.items() if ts < cutoff]
+        for vid in expired:
+            self.delete(vid)
 
     def save(self, path: str | None = None) -> None:  # pragma: no cover - filesystem
         """Persist the FAISS index and metadata to ``path``."""
@@ -183,7 +222,7 @@ class VectorStore:
                 cpu_index = self.index
             faiss.write_index(cpu_index, path)
             with open(path + ".json", "w", encoding="utf-8") as f:
-                json.dump(self.idx_to_id, f)
+                json.dump({"ids": self.idx_to_id, "ts": self.vector_ts}, f)
 
     def load(self, path: str | None = None) -> None:  # pragma: no cover - filesystem
         """Load a FAISS index and metadata from ``path``."""
@@ -194,9 +233,16 @@ class VectorStore:
             self.index = faiss.read_index(path)
             try:
                 with open(path + ".json", "r", encoding="utf-8") as f:
-                    self.idx_to_id = json.load(f)
+                    data = json.load(f)
+                    if isinstance(data, list):
+                        self.idx_to_id = data
+                        self.vector_ts = {i: int(time.time()) for i in data}
+                    else:
+                        self.idx_to_id = data.get("ids", [])
+                        self.vector_ts = {k: int(v) for k, v in data.get("ts", {}).items()}
             except FileNotFoundError:
                 self.idx_to_id = []
+                self.vector_ts = {}
             self.id_to_idx = {v: i for i, v in enumerate(self.idx_to_id)}
             self.dim = self.index.d
             if self.use_gpu:

--- a/tests/test_memory_aging.py
+++ b/tests/test_memory_aging.py
@@ -1,0 +1,52 @@
+# mypy: ignore-errors
+import sqlite3
+import time
+
+import pytest
+
+from ume.memory import EpisodicMemory, SemanticMemory
+from ume.memory_aging import (
+    start_memory_aging_scheduler,
+    stop_memory_aging_scheduler,
+)
+
+
+def test_memory_aging_moves_old_events(monkeypatch: pytest.MonkeyPatch) -> None:
+    orig_connect = sqlite3.connect
+
+    def _connect(*a, **kw):  # type: ignore[no-redef]
+        return orig_connect(*a, check_same_thread=False, **kw)
+
+    monkeypatch.setattr(sqlite3, "connect", _connect)  # type: ignore[arg-type]
+
+    episodic = EpisodicMemory(db_path=":memory:")
+    semantic = SemanticMemory(db_path=":memory:")
+    episodic.graph.add_node("old", {"text": "hi"})
+    old_ts = int(time.time()) - 10
+    with episodic.graph.conn:
+        episodic.graph.conn.execute(
+            "UPDATE nodes SET created_at=? WHERE id='old'", (old_ts,)
+        )
+
+    start_memory_aging_scheduler(
+        episodic,
+        semantic,
+        event_age_seconds=0,
+        interval_seconds=0.05,
+    )
+    time.sleep(0.1)
+    stop_memory_aging_scheduler()
+
+    assert not episodic.graph.node_exists("old")
+    assert semantic.get_fact("old") == {"text": "hi"}
+
+
+def test_vector_store_expire_vectors() -> None:
+    pytest.importorskip("faiss")
+    from ume.vector_store import VectorStore
+
+    store = VectorStore(dim=2, use_gpu=False)
+    store.add("x", [0.0, 1.0])
+    store.vector_ts["x"] = int(time.time()) - 10
+    store.expire_vectors(5)
+    assert store.query([0.0, 1.0], k=1) == []


### PR DESCRIPTION
## Summary
- add a new `start_memory_aging_scheduler` to migrate old nodes from episodic to semantic memory
- store timestamps for vectors and support deleting/expiring them
- expose the scheduler in `__init__` and factory helpers
- add tests for aging scheduler and vector expiration
- document the memory aging process
- refine scheduler docs and factory description

## Testing
- `pre-commit run --files src/ume/memory_aging.py src/ume/factories.py docs/GRAPH_MODEL.md`
- `pytest -q tests/test_memory_aging.py`


------
https://chatgpt.com/codex/tasks/task_e_685dcf2a965c83268863488cb9c098f4