### PR TITLE
Add frontend PII status & policy editor

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # UME Frontend
 
-This directory contains a small React dashboard for the UME API. It allows you to log in, view graph statistics and recent audit events, and toggle alignment policies.
+This directory contains a small React dashboard for the UME API. It allows you to log in, view graph statistics and recent audit events, toggle alignment policies, monitor PII redaction activity, and edit Rego policies.
 
 ## Development
 
@@ -17,6 +17,8 @@ npm run dev
 ```
 
 The app will be available at <http://localhost:5173>. The development server proxies requests to the running API at `http://localhost:8000`.
+
+The dashboard shows a counter of how many event payloads have been redacted for PII. It polls the `/pii/redactions` endpoint every second. Clicking a policy name opens an inline editor where you can modify the Rego code, validate it via the API, and save your changes.
 
 ## Building
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react';
+import PiiStatus from './PiiStatus';
+import PolicyEditor from './PolicyEditor';
 
 const POLICY_CONTENT = {
   'allow.rego': `package ume
@@ -49,6 +51,7 @@ function App() {
   const [stats, setStats] = useState(null);
   const [events, setEvents] = useState([]);
   const [policies, setPolicies] = useState([]);
+  const [editingPolicy, setEditingPolicy] = useState('');
 
   const login = async (e) => {
     e.preventDefault();
@@ -106,6 +109,10 @@ function App() {
     loadPolicies();
   };
 
+  const editPolicy = (name) => {
+    setEditingPolicy(name);
+  };
+
   if (!token) {
     return (
       <form onSubmit={login} style={{ padding: '20px' }}>
@@ -139,6 +146,7 @@ function App() {
       {events.length > 0 && (
         <pre style={{ background: '#eee', padding: '8px' }}>{JSON.stringify(events, null, 2)}</pre>
       )}
+      <PiiStatus token={token} />
       <h3>Policies</h3>
       <ul>
         {policies.map((p) => (
@@ -149,11 +157,14 @@ function App() {
                 checked={p.enabled}
                 onChange={() => togglePolicy(p.name)}
               />
-              {p.name}
+              <span onClick={() => editPolicy(p.name)} style={{ cursor: 'pointer' }}>
+                {p.name}
+              </span>
             </label>
           </li>
         ))}
       </ul>
+      <PolicyEditor token={token} policy={editingPolicy} onSaved={loadPolicies} />
     </div>
   );
 }

--- a/frontend/src/PiiStatus.jsx
+++ b/frontend/src/PiiStatus.jsx
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export default function PiiStatus({ token }) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!token) return;
+    const id = setInterval(async () => {
+      const res = await fetch('/pii/redactions', {
+        headers: { Authorization: 'Bearer ' + token },
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setCount(data.redacted);
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [token]);
+
+  return <div>Redacted events: {count}</div>;
+}

--- a/frontend/src/PolicyEditor.jsx
+++ b/frontend/src/PolicyEditor.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+
+export default function PolicyEditor({ token, policy, onSaved }) {
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    if (!token || !policy) return;
+    fetch(`/policies/${policy}`, {
+      headers: { Authorization: 'Bearer ' + token },
+    })
+      .then((r) => (r.ok ? r.text() : ''))
+      .then((t) => setContent(t));
+  }, [token, policy]);
+
+  if (!policy) return null;
+
+  const save = async () => {
+    const form = new FormData();
+    form.append('file', new Blob([content], { type: 'text/plain' }), policy);
+    await fetch(`/policies/${policy}`, {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer ' + token },
+      body: form,
+    });
+    if (onSaved) onSaved();
+  };
+
+  const validate = async () => {
+    const res = await fetch('/policies/validate', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer ' + token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ content }),
+    });
+    if (res.ok) alert('Policy is valid');
+    else alert('Policy has errors');
+  };
+
+  return (
+    <div style={{ marginTop: '8px' }}>
+      <h4>{policy}</h4>
+      <textarea
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        rows={10}
+        cols={60}
+      />
+      <br />
+      <button onClick={save}>Save</button>
+      <button onClick={validate} style={{ marginLeft: '4px' }}>
+        Validate
+      </button>
+    </div>
+  );
+}

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -284,6 +284,10 @@ class DocumentUploadRequest(BaseModel):
     content: str
 
 
+class PolicySource(BaseModel):
+    content: str
+
+
 @app.post("/analytics/shortest_path")
 def api_shortest_path(
     req: ShortestPathRequest,
@@ -583,6 +587,20 @@ def dashboard_recent_events(
     return list(reversed(entries[-limit:]))
 
 
+def _redaction_count() -> int:
+    """Return the number of payload redactions recorded in the audit log."""
+    entries = get_audit_entries()
+    return sum(
+        1 for e in entries if "payload_redacted" in str(e.get("reason", ""))
+    )
+
+
+@app.get("/pii/redactions")
+def pii_redactions(_: str = Depends(get_current_role)) -> Dict[str, int]:
+    """Return the total count of redacted payloads."""
+    return {"redacted": _redaction_count()}
+
+
 def _resolve_policy_path(name: str) -> Path:
     """Return absolute path for policy ``name`` within :data:`POLICY_DIR`."""
     path = Path(name)
@@ -620,4 +638,42 @@ def delete_policy(name: str, _: str = Depends(get_current_role)) -> Dict[str, st
     if not path.exists():
         raise HTTPException(status_code=404, detail="Policy not found")
     path.unlink()
+    return {"status": "ok"}
+
+
+@app.get("/policies/{name:path}")
+def get_policy(name: str, _: str = Depends(get_current_role)) -> Response:
+    """Return the raw contents of a policy file."""
+    path = _resolve_policy_path(name)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Policy not found")
+    return Response(path.read_text(encoding="utf-8"), media_type="text/plain")
+
+
+@app.put("/policies/{name:path}")
+async def update_policy(
+    name: str, file: UploadFile = File(...), _: str = Depends(get_current_role)
+) -> Dict[str, str]:
+    """Replace an existing policy file."""
+    path = _resolve_policy_path(name)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Policy not found")
+    content = await file.read()
+    with path.open("wb") as f:
+        f.write(content)
+    return {"status": "ok"}
+
+
+@app.post("/policies/validate")
+def validate_policy(req: PolicySource, _: str = Depends(get_current_role)) -> Dict[str, str]:
+    """Validate Rego policy text using regopy if available."""
+    try:
+        from regopy import Interpreter as RegoInterpreter  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise HTTPException(status_code=500, detail="Rego support not installed") from exc
+    interp = RegoInterpreter()
+    try:
+        interp.add_module("policy.rego", req.content)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "ok"}

--- a/tests/test_rego_policies.py
+++ b/tests/test_rego_policies.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from ume.api import app, configure_graph
 from ume.graph import MockGraph
 from ume.config import settings
+import pytest
 
 
 def setup_module(_: object) -> None:
@@ -47,3 +48,48 @@ def test_policy_upload_and_delete(tmp_path: Path, monkeypatch: Any) -> None:
     )
     assert res.status_code == 200
     assert not (tmp_path / "test.rego").exists()
+
+
+def test_policy_update_and_get(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setattr("ume.api.POLICY_DIR", tmp_path)
+    client = TestClient(app)
+    token = _token(client)
+    content = b"package test\nallow = true"
+    client.post(
+        "/policies/test.rego",
+        files={"file": ("test.rego", content)},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    new_content = b"package test\nallow = false"
+    client.put(
+        "/policies/test.rego",
+        files={"file": ("test.rego", new_content)},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    res = client.get(
+        "/policies/test.rego",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert "allow = false" in res.text
+
+
+def test_validate_policy(monkeypatch: Any) -> None:
+    pytest.importorskip("regopy")
+    client = TestClient(app)
+    token = _token(client)
+    res = client.post(
+        "/policies/validate",
+        json={"content": "package test\nallow = true"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+
+    res = client.post(
+        "/policies/validate",
+        json={"content": "package test\nallow ="},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- show real-time PII redaction count via new `/pii/redactions` endpoint
- implement REST endpoints to get/update/validate Rego policies
- add React components `PiiStatus` and `PolicyEditor`
- document new dashboard features
- test policy update and validation routes

## Testing
- `pre-commit run --files frontend/src/App.jsx frontend/src/PiiStatus.jsx frontend/src/PolicyEditor.jsx src/ume/api.py tests/test_rego_policies.py frontend/README.md`
- `pytest -q tests/test_rego_policies.py`

------
https://chatgpt.com/codex/tasks/task_e_685dcf37f2ac83269ea52579b13f5402