### PR TITLE
Add detect-secrets pre-commit hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,5 @@ cython_debug/
 .pypirc
 ume_graph.db
 ume_snapshot.json
+.secrets.baseline
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,8 @@ repos:
       - id: mypy
         args: ["--config-file", "mypy.ini", "--strict"]
         additional_dependencies: ["types-PyYAML"]
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,146 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {
+    "tests/conftest.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/conftest.py",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 69
+      }
+    ],
+    "tests/test_anonymizer.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_anonymizer.py",
+        "hashed_secret": "30820eee19e8e0f5b8f88841c618bd79cbd5844a",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ]
+  },
+  "generated_at": "2025-06-26T23:00:47Z"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,16 @@ If you find a bug or have an idea for a new feature, please check our issue trac
   pre-commit run --all-files
   ```
 
+The pre-commit configuration includes a `detect-secrets` hook to prevent
+accidentally committing credentials. Generate or update the baseline with:
+```bash
+detect-secrets scan > .secrets.baseline
+```
+To scan specific files manually you can run:
+```bash
+pre-commit run detect-secrets --files path/to/file
+```
+
 ### Pull Requests
 
  - Ensure `pre-commit` hooks pass and that `pytest` succeeds before opening a PR. Coverage for the `ume` package must remain above 80%, verified with:
@@ -76,8 +86,10 @@ Please refer to the `README.md` for instructions on setting up your development 
    ```
 2. Install pre-commit hooks:
    ```bash
-   pre-commit install
-   ```
+ pre-commit install
+  ```
+   This installs the `detect-secrets` hook along with other checks.
+   If you update `.secrets.baseline`, commit the refreshed file so CI uses the latest baseline.
 3. Create a feature branch and implement your changes.
 4. Before committing, run the checks locally:
    ```bash

--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ checks as CI, execute:)
 ```bash
 pre-commit run --all-files
 ```
+(Optional) regenerate the detect-secrets baseline with:
+```bash
+detect-secrets scan > .secrets.baseline
+```
 (Note: `poetry install` by default installs dev dependencies unless `--no-dev` is specified. However, explicitly mentioning `--with dev` can be clearer for users who might have installed with `--no-dev` previously).
 
 To determine if your changes require running tests and linters, execute:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ redis = "*"
 fastapi-limiter = "*"
 
 pre-commit = "*"
+detect-secrets = "*"
 poetry-plugin-export = "^1.9.0"
 testcontainers = "*"
 respx = "^0.22.0"

--- a/tests/test_detect_secrets_hook.py
+++ b/tests/test_detect_secrets_hook.py
@@ -1,0 +1,15 @@
+import subprocess
+from pathlib import Path
+
+def test_detect_secrets_hook_blocks(tmp_path):
+    secret_file = tmp_path / "secret.txt"
+    secret_file.write_text("AWS_SECRET_ACCESS_KEY=abcd1234")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["pre-commit", "run", "detect-secrets", "--files", str(secret_file)],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1


### PR DESCRIPTION
## Summary
- integrate `detect-secrets` hook in pre-commit config
- add baseline to gitignore and dev dependencies
- document baseline management in the contribution guide and README
- add regression test for detecting secrets

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md tests/test_detect_secrets_hook.py .secrets.baseline pyproject.toml .gitignore README.md`
- `pytest tests/test_detect_secrets_hook.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685dcf3d2c8483268b66ace002fcdc47