### PR TITLE
Enable OpenTelemetry tracing

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -64,3 +64,23 @@ Here are a few Prometheus queries you can use when building graphs:
 
 You can combine these metrics in Grafana to visualize API performance and index
 growth over time.
+
+## Distributed Tracing with OpenTelemetry
+
+Set the `UME_OTLP_ENDPOINT` environment variable to enable trace export via OTLP.
+When configured, UME will emit spans for HTTP endpoints and graph operations.
+You can point this endpoint at an OpenTelemetry Collector or any backend that
+accepts OTLP over HTTP.
+
+Example collector service in `docker-compose.yml`:
+
+```yaml
+  collector:
+    image: otel/opentelemetry-collector-contrib
+    ports:
+      - "4318:4318"
+```
+
+Configure the collector to forward traces to Jaeger, Tempo, or another tracing
+backend. With the collector running and `UME_OTLP_ENDPOINT=http://localhost:4318`,
+traces will include spans for API calls and key graph operations.

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -3,7 +3,7 @@ from pydantic import Extra
 from typing import Any
 
 
-class Settings(BaseSettings):  # type: ignore[misc]
+class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", extra=Extra.ignore
     )
@@ -61,6 +61,9 @@ class Settings(BaseSettings):  # type: ignore[misc]
     # Remote OPA configuration
     OPA_URL: str | None = None
     OPA_TOKEN: str | None = None
+
+    # OpenTelemetry
+    UME_OTLP_ENDPOINT: str | None = None
 
     # LLM Ferry
     LLM_FERRY_API_URL: str = "https://example.com/api"

--- a/src/ume/factories.py
+++ b/src/ume/factories.py
@@ -7,6 +7,7 @@ from .vector_store import VectorStore, create_vector_store as _create_vector_sto
 from .memory import EpisodicMemory, SemanticMemory
 
 from .graph_adapter import IGraphAdapter
+from .tracing import TracingGraphAdapter, is_tracing_enabled
 
 
 def create_graph_adapter(
@@ -15,7 +16,9 @@ def create_graph_adapter(
     role: str | None = None,
 ) -> IGraphAdapter:
     """Create the default :class:`IGraphAdapter` using configuration settings."""
-    base = PersistentGraph(db_path or settings.UME_DB_PATH)
+    base: IGraphAdapter = PersistentGraph(db_path or settings.UME_DB_PATH)
+    if is_tracing_enabled():
+        base = TracingGraphAdapter(base)
     role = role if role is not None else settings.UME_ROLE
     if role:
         return RoleBasedGraphAdapter(base, role=role)

--- a/src/ume/tracing.py
+++ b/src/ume/tracing.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, List
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+from .config import settings
+from .graph_adapter import IGraphAdapter
+
+tracer = trace.get_tracer("ume")
+_enabled = False
+
+
+def configure_tracing(endpoint: str | None = None) -> None:
+    """Configure OpenTelemetry tracing if an endpoint is provided."""
+    global _enabled
+    endpoint = endpoint or settings.UME_OTLP_ENDPOINT
+    if not endpoint:
+        return
+    provider = TracerProvider(resource=Resource.create({"service.name": "ume"}))
+    exporter = OTLPSpanExporter(endpoint=endpoint)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    _enabled = True
+
+
+def is_tracing_enabled() -> bool:
+    """Return ``True`` if tracing has been configured."""
+    return _enabled
+
+
+class TracingGraphAdapter(IGraphAdapter):
+    """Wrap another adapter and emit spans for graph operations."""
+
+    def __init__(self, adapter: IGraphAdapter, tracer: trace.Tracer = tracer) -> None:
+        self._adapter = adapter
+        self._tracer = tracer
+
+    # ---- Node methods -------------------------------------------------
+    def add_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        with self._tracer.start_as_current_span("graph.add_node"):
+            self._adapter.add_node(node_id, attributes)
+
+    def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        with self._tracer.start_as_current_span("graph.update_node"):
+            self._adapter.update_node(node_id, attributes)
+
+    def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        with self._tracer.start_as_current_span("graph.get_node"):
+            return self._adapter.get_node(node_id)
+
+    def node_exists(self, node_id: str) -> bool:
+        with self._tracer.start_as_current_span("graph.node_exists"):
+            return self._adapter.node_exists(node_id)
+
+    def dump(self) -> Dict[str, Any]:
+        with self._tracer.start_as_current_span("graph.dump"):
+            return self._adapter.dump()
+
+    def clear(self) -> None:
+        with self._tracer.start_as_current_span("graph.clear"):
+            self._adapter.clear()
+
+    def get_all_node_ids(self) -> List[str]:
+        with self._tracer.start_as_current_span("graph.get_all_node_ids"):
+            return self._adapter.get_all_node_ids()
+
+    def find_connected_nodes(self, node_id: str, edge_label: Optional[str] = None) -> List[str]:
+        with self._tracer.start_as_current_span("graph.find_connected_nodes"):
+            return self._adapter.find_connected_nodes(node_id, edge_label)
+
+    def add_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        with self._tracer.start_as_current_span("graph.add_edge"):
+            self._adapter.add_edge(source_node_id, target_node_id, label)
+
+    def get_all_edges(self) -> List[tuple[str, str, str]]:
+        with self._tracer.start_as_current_span("graph.get_all_edges"):
+            return self._adapter.get_all_edges()
+
+    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        with self._tracer.start_as_current_span("graph.delete_edge"):
+            self._adapter.delete_edge(source_node_id, target_node_id, label)
+
+    def redact_node(self, node_id: str) -> None:
+        with self._tracer.start_as_current_span("graph.redact_node"):
+            self._adapter.redact_node(node_id)
+
+    def redact_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        with self._tracer.start_as_current_span("graph.redact_edge"):
+            self._adapter.redact_edge(source_node_id, target_node_id, label)
+
+    def close(self) -> None:
+        with self._tracer.start_as_current_span("graph.close"):
+            self._adapter.close()
+
+    # ---- Traversal and pathfinding ---------------------------------
+    def shortest_path(self, source_id: str, target_id: str) -> List[str]:
+        with self._tracer.start_as_current_span("graph.shortest_path"):
+            return self._adapter.shortest_path(source_id, target_id)
+
+    def traverse(self, start_node_id: str, depth: int, edge_label: Optional[str] = None) -> List[str]:
+        with self._tracer.start_as_current_span("graph.traverse"):
+            return self._adapter.traverse(start_node_id, depth, edge_label)
+
+    def extract_subgraph(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+        since_timestamp: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        with self._tracer.start_as_current_span("graph.extract_subgraph"):
+            return self._adapter.extract_subgraph(start_node_id, depth, edge_label, since_timestamp)
+
+    def constrained_path(
+        self,
+        source_id: str,
+        target_id: str,
+        max_depth: int | None = None,
+        edge_label: str | None = None,
+        since_timestamp: int | None = None,
+    ) -> List[str]:
+        with self._tracer.start_as_current_span("graph.constrained_path"):
+            return self._adapter.constrained_path(
+                source_id, target_id, max_depth, edge_label, since_timestamp
+            )

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,37 @@
+from unittest.mock import MagicMock
+from typing import Any, Dict, List, Tuple
+
+import importlib.util
+import importlib
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1] / "src" / "ume"
+
+tracing_spec = importlib.util.spec_from_file_location("ume.tracing", root / "tracing.py")
+assert tracing_spec and tracing_spec.loader
+tracing = importlib.util.module_from_spec(tracing_spec)
+sys.modules[tracing_spec.name] = tracing
+tracing_spec.loader.exec_module(tracing)
+TracingGraphAdapter = tracing.TracingGraphAdapter
+
+
+class DummyGraph:
+    def __init__(self) -> None:
+        self.called_with: List[Tuple[str, Dict[str, Any]]] = []
+
+    def add_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        self.called_with.append((node_id, attributes))
+
+
+def test_tracing_adapter_creates_span() -> None:
+    base = DummyGraph()
+    tracer = MagicMock()
+    cm = MagicMock()
+    tracer.start_as_current_span.return_value = cm
+
+    adapter = TracingGraphAdapter(base, tracer)
+    adapter.add_node("n1", {})
+
+    tracer.start_as_current_span.assert_called_with("graph.add_node")
+    cm.__enter__.assert_called()


### PR DESCRIPTION
## Summary
- add configurable OTLP endpoint
- instrument FastAPI and graph operations with OpenTelemetry
- document tracing setup in `MONITORING.md`
- test span creation in `TracingGraphAdapter`

## Testing
- `ruff check src/ume/api.py src/ume/config.py src/ume/factories.py src/ume/tracing.py tests/test_tracing.py`
- `mypy --config-file mypy.ini src/ume/api.py src/ume/config.py src/ume/factories.py src/ume/tracing.py tests/test_tracing.py`
- `pytest tests/test_tracing.py`

------
https://chatgpt.com/codex/tasks/task_e_685dcf3dd35483268ed05c277d50f5fc