### PR TITLE
Add GraphSchema validation tests

### DIFF
--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -1,0 +1,32 @@
+import json
+import yaml
+import pytest
+from ume.graph_schema import GraphSchema, load_default_schema
+from ume.processing import ProcessingError
+
+
+def test_load_bad_json(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{ invalid")
+    with pytest.raises(json.JSONDecodeError):
+        GraphSchema.load(str(path))
+
+
+def test_load_bad_yaml(tmp_path):
+    path = tmp_path / "bad.yaml"
+    path.write_text("foo: [1")
+    with pytest.raises(yaml.YAMLError):
+        GraphSchema.load(str(path))
+
+
+def test_validate_unknown_node_type():
+    schema = load_default_schema()
+    with pytest.raises(ProcessingError):
+        schema.validate_node_type("UnknownType")
+
+
+def test_validate_unknown_edge_label():
+    schema = load_default_schema()
+    with pytest.raises(ProcessingError):
+        schema.validate_edge_label("UnknownLabel")
+


### PR DESCRIPTION
## Summary
- test that malformed schema files raise JSON/YAML errors
- check ProcessingError for unknown node and edge types

## Testing
- `ruff check tests/test_graph_schema.py`
- `mypy --config-file mypy.ini --strict tests/test_graph_schema.py`
- `pytest -q tests/test_graph_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_685de06315088326b31a114cfac1186f