### PR TITLE
Add protobuf pin and fix vector store tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,14 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache Poetry and pip
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: ${{ runner.os }}-poetry-
       - name: Install dependencies
         if: steps.changes.outputs.run == 'true'
         run: |

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -129,7 +133,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 69
+        "line_number": 72
       }
     ],
     "tests/test_anonymizer.py": [
@@ -142,5 +146,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-26T23:00:47Z"
+  "generated_at": "2025-06-27T21:15:44Z"
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -273,6 +273,18 @@ tests = ["cloudpickle ; platform_python_implementation == \"CPython\"", "hypothe
 tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\"", "pytest-mypy-plugins ; platform_python_implementation == \"CPython\" and python_version >= \"3.10\""]
 
 [[package]]
+name = "backoff"
+version = "1.11.1"
+description = "Function decoration for backoff and retry"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+groups = ["main"]
+files = [
+    {file = "backoff-1.11.1-py2.py3-none-any.whl", hash = "sha256:61928f8fa48d52e4faa81875eecf308eccfb1016b018bb6bd21e05b5d90a96c5"},
+    {file = "backoff-1.11.1.tar.gz", hash = "sha256:ccb962a2378418c667b3c979b504fdeb7d9e0d29c0579e3b13b86467177728cb"},
+]
+
+[[package]]
 name = "backports-tarfile"
 version = "1.2.0"
 description = "Backport of CPython tarfile module"
@@ -983,6 +995,26 @@ files = [
 ]
 
 [[package]]
+name = "detect-secrets"
+version = "1.5.0"
+description = "Tool for detecting secrets in the codebase"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "detect_secrets-1.5.0-py3-none-any.whl", hash = "sha256:e24e7b9b5a35048c313e983f76c4bd09dad89f045ff059e354f9943bf45aa060"},
+    {file = "detect_secrets-1.5.0.tar.gz", hash = "sha256:6bb46dcc553c10df51475641bb30fd69d25645cc12339e46c824c1e0c388898a"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = "*"
+
+[package.extras]
+gibberish = ["gibberish-detector"]
+word-list = ["pyahocorasick"]
+
+[[package]]
 name = "distlib"
 version = "0.3.9"
 description = "Distribution utilities"
@@ -1453,6 +1485,24 @@ files = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.70.0"
+description = "Common protobufs used in Google APIs"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8"},
+    {file = "googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257"},
+]
+
+[package.dependencies]
+protobuf = ">=3.20.2,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<7.0.0"
+
+[package.extras]
+grpc = ["grpcio (>=1.44.0,<2.0.0)"]
+
+[[package]]
 name = "grpcio"
 version = "1.73.0"
 description = "HTTP/2-based RPC framework"
@@ -1677,12 +1727,12 @@ version = "8.7.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
-markers = "python_version < \"3.12\""
+groups = ["main", "dev"]
 files = [
     {file = "importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd"},
     {file = "importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000"},
 ]
+markers = {dev = "python_version < \"3.12\""}
 
 [package.dependencies]
 zipp = ">=3.20"
@@ -2583,6 +2633,129 @@ files = [
     {file = "numpy-2.2.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d042d24c90c41b54fd506da306759e06e568864df8ec17ccc17e9e884634fd00"},
     {file = "numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd"},
 ]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.34.1"
+description = "OpenTelemetry Python API"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "opentelemetry_api-1.34.1-py3-none-any.whl", hash = "sha256:b7df4cb0830d5a6c29ad0c0691dbae874d8daefa934b8b1d642de48323d32a8c"},
+    {file = "opentelemetry_api-1.34.1.tar.gz", hash = "sha256:64f0bd06d42824843731d05beea88d4d4b6ae59f9fe347ff7dfa2cc14233bbb3"},
+]
+
+[package.dependencies]
+importlib-metadata = ">=6.0,<8.8.0"
+typing-extensions = ">=4.5.0"
+
+[[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.11.1"
+description = "OpenTelemetry Collector Exporters"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "opentelemetry-exporter-otlp-1.11.1.tar.gz", hash = "sha256:c275fd2045bf28b8bfeef226f3c73ede7b5bb5d0f7c4669c508f19618a70409c"},
+    {file = "opentelemetry_exporter_otlp-1.11.1-py3-none-any.whl", hash = "sha256:2eeeb8e2f3f22958dd306da44f6d5920733b6dd5442ce47e424c920c8e548aa4"},
+]
+
+[package.dependencies]
+opentelemetry-exporter-otlp-proto-grpc = "1.11.1"
+opentelemetry-exporter-otlp-proto-http = "1.11.1"
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.11.1"
+description = "OpenTelemetry Collector Protobuf over gRPC Exporter"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "opentelemetry-exporter-otlp-proto-grpc-1.11.1.tar.gz", hash = "sha256:e34fc79c76e299622812da5fe37cfeffdeeea464007530488d824e6c413e6a58"},
+    {file = "opentelemetry_exporter_otlp_proto_grpc-1.11.1-py3-none-any.whl", hash = "sha256:7cabcf548604ab8156644bba0e9cb0a9c50561d621be39429e32581f5c8247a6"},
+]
+
+[package.dependencies]
+backoff = ">=1.10.0,<2.0.0"
+googleapis-common-protos = ">=1.52,<2.0"
+grpcio = ">=1.0.0,<2.0.0"
+opentelemetry-api = ">=1.3,<2.0"
+opentelemetry-proto = "1.11.1"
+opentelemetry-sdk = ">=1.11,<2.0"
+
+[package.extras]
+test = ["pytest-grpc"]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.11.1"
+description = "OpenTelemetry Collector Protobuf over HTTP Exporter"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "opentelemetry-exporter-otlp-proto-http-1.11.1.tar.gz", hash = "sha256:11a4a4c660f34ebc5cd455da10e405c763fb2e23ac634a9507f90bd244510a4f"},
+    {file = "opentelemetry_exporter_otlp_proto_http-1.11.1-py3-none-any.whl", hash = "sha256:53abdc27c7a0973194ac13f96a253c6f7430b921f904c288d7b62e873c3f5945"},
+]
+
+[package.dependencies]
+backoff = ">=1.10.0,<2.0.0"
+googleapis-common-protos = ">=1.52,<2.0"
+opentelemetry-api = ">=1.3,<2.0"
+opentelemetry-proto = "1.11.1"
+opentelemetry-sdk = ">=1.11,<2.0"
+requests = ">=2.7,<3.0"
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.11.1"
+description = "OpenTelemetry Python Proto"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+files = [
+    {file = "opentelemetry-proto-1.11.1.tar.gz", hash = "sha256:5df0ec69510a9e2414c0410d91a698ded5a04d3dd37f7d2a3e119e3c42a30647"},
+    {file = "opentelemetry_proto-1.11.1-py3-none-any.whl", hash = "sha256:4d4663123b4777823aa533f478c6cef3ecbcf696d8dc6ac7fd6a90f37a01eafd"},
+]
+
+[package.dependencies]
+protobuf = ">=3.13.0"
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.34.1"
+description = "OpenTelemetry Python SDK"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "opentelemetry_sdk-1.34.1-py3-none-any.whl", hash = "sha256:308effad4059562f1d92163c61c8141df649da24ce361827812c40abb2a1e96e"},
+    {file = "opentelemetry_sdk-1.34.1.tar.gz", hash = "sha256:8091db0d763fcd6098d4781bbc80ff0971f94e260739aa6afe6fd379cdf3aa4d"},
+]
+
+[package.dependencies]
+opentelemetry-api = "1.34.1"
+opentelemetry-semantic-conventions = "0.55b1"
+typing-extensions = ">=4.5.0"
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.55b1"
+description = "OpenTelemetry Semantic Conventions"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "opentelemetry_semantic_conventions-0.55b1-py3-none-any.whl", hash = "sha256:5da81dfdf7d52e3d37f8fe88d5e771e191de924cfff5f550ab0b8f7b2409baed"},
+    {file = "opentelemetry_semantic_conventions-0.55b1.tar.gz", hash = "sha256:ef95b1f009159c28d7a7849f5cbc71c4c34c845bb514d66adfdf1b3fff3598b3"},
+]
+
+[package.dependencies]
+opentelemetry-api = "1.34.1"
+typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "opentracing"
@@ -4983,12 +5156,12 @@ version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
-markers = "python_version < \"3.12\""
+groups = ["main", "dev"]
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
 ]
+markers = {dev = "python_version < \"3.12\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
@@ -5119,4 +5292,4 @@ vector = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "ed75edccb7a6d0a22a02ec3ad16cdafd256a74802021ee89c00d88fb86608c03"
+content-hash = "94743fa4a4cd632c00cd8cb893c1cbaefca0e500a6f8d4b2dbd3470892a04224"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ fastapi = ">=0.110,<1"
 jsonschema = "*"
 faust-streaming = "*"
 faiss-cpu = "*"
-protobuf = "*"
+protobuf = ">=6,<7"
 pydantic = ">=2"
 pydantic-settings = ">=2"
 presidio-analyzer = "^2.2.358"
@@ -40,6 +40,9 @@ fastapi-limiter = "*"
 sse-starlette = "*"
 python-multipart = "*"
 httpx = "*"
+opentelemetry-api = "*"
+opentelemetry-sdk = "*"
+opentelemetry-exporter-otlp = "*"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/faust/types.py
+++ b/src/faust/types.py
@@ -1,2 +1,4 @@
-class StreamT(list):
+class StreamT(list[object]):
+    """Simple list-based stream type for testing."""
+
     pass

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -26,6 +26,8 @@ from .schema_utils import validate_event_dict
 from .graph_schema import GraphSchema, load_default_schema
 from .schema_manager import GraphSchemaManager, DEFAULT_SCHEMA_MANAGER
 from .config import Settings
+from . import vector_store  # Make submodule available as attribute
+from . import config  # Make submodule available as attribute
 from .utils import ssl_config
 from .memory import EpisodicMemory, SemanticMemory
 from typing import TYPE_CHECKING
@@ -109,6 +111,8 @@ __all__ = [
     "DEFAULT_SCHEMA_MANAGER",
     "PolicyViolationError",
     "Settings",
+    "config",
+    "vector_store",
     "log_audit_entry",
     "get_audit_entries",
     "ssl_config",

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -3,7 +3,7 @@ from pydantic import Extra
 from typing import Any
 
 
-class Settings(BaseSettings):
+class Settings(BaseSettings):  # type: ignore[misc]
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", extra=Extra.ignore
     )

--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -292,7 +292,7 @@ class VectorStore:
     def get_vector_timestamps(self) -> Dict[str, int]:
         """Return mapping of item IDs to their last update timestamp."""
         with self.lock:
-            return dict(self.id_to_ts)
+            return dict(self.vector_ts)
 
 
 class VectorStoreListener(GraphListener):
@@ -342,3 +342,10 @@ def create_default_store() -> VectorStore:  # pragma: no cover - trivial wrapper
 # ``create_vector_store`` used to be exported. Provide an alias so older imports
 # continue to work without modification.
 create_vector_store = create_default_store
+
+# Ensure ``ume.vector_store`` is set when imported standalone
+if __name__ == "ume.vector_store":
+    import sys as _sys
+    parent = _sys.modules.get("ume")
+    if parent is not None and not hasattr(parent, "vector_store"):
+        parent.vector_store = _sys.modules[__name__]  # type: ignore[attr-defined]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@ import sys
 from pathlib import Path
 import os
 
+# Force pure-Python protobuf implementation for compatibility with Python 3.12
+os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
+
 try:
     from testcontainers.core.container import DockerContainer
     from testcontainers.neo4j import Neo4jContainer
@@ -37,19 +40,19 @@ def redpanda_service():
     if not _docker_enabled():
         pytest.skip("Docker-based tests disabled")
     container = DockerContainer("docker.redpanda.com/redpandadata/redpanda:latest")
-    container.with_exposed_ports(9092)
+    container.with_exposed_ports(9092)  # type: ignore[no-untyped-call]
     container.with_command(
         "redpanda start --smp 1 --overprovisioned --node-id 0 --check=false "
         "--kafka-addr PLAINTEXT://0.0.0.0:9092 "
         "--advertise-kafka-addr PLAINTEXT://127.0.0.1:9092"
     )
     try:
-        container.start()
+        container.start()  # type: ignore[no-untyped-call]
     except Exception as exc:  # pragma: no cover - environment issues
         pytest.skip(f"Redpanda not available: {exc}")
     broker = f"{container.get_container_host_ip()}:{container.get_exposed_port(9092)}"
     yield {"bootstrap_servers": broker}
-    container.stop()
+    container.stop()  # type: ignore[no-untyped-call]
 
 
 @pytest.fixture(scope="session")
@@ -58,9 +61,9 @@ def neo4j_service():
     if not _docker_enabled():
         pytest.skip("Docker-based tests disabled")
     container = Neo4jContainer("neo4j:5")
-    container.with_env("NEO4J_AUTH", "neo4j/test")
+    container.with_env("NEO4J_AUTH", "neo4j/test")  # type: ignore[no-untyped-call]
     try:
-        container.start()
+        container.start()  # type: ignore[no-untyped-call]
     except Exception as exc:  # pragma: no cover - environment issues
         pytest.skip(f"Neo4j not available: {exc}")
     yield {
@@ -68,5 +71,5 @@ def neo4j_service():
         "user": "neo4j",
         "password": "test",
     }
-    container.stop()
+    container.stop()  # type: ignore[no-untyped-call]
 

--- a/tests/test_sse.py
+++ b/tests/test_sse.py
@@ -7,6 +7,8 @@ import sys
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from ume import MockGraph
 from ume.config import settings
+from sse_starlette.sse import AppStatus
+import anyio
 import time
 import pytest
 
@@ -20,6 +22,8 @@ def setup_module(_: object) -> None:
     g.add_edge("a", "b", "L")
     object.__setattr__(settings, "UME_API_TOKEN", "")
     configure_graph(g)
+    AppStatus.should_exit = False
+    AppStatus.should_exit_event = anyio.Event()
 
 
 def _token(client: TestClient) -> str:
@@ -66,3 +70,8 @@ def test_backpressure() -> None:
         time.sleep(0.05)
         second = next(it)
         assert second == "data: b"
+
+
+def teardown_module(_: object) -> None:
+    AppStatus.should_exit_event = None
+    AppStatus.should_exit = False

--- a/tests/test_vector_store_unit.py
+++ b/tests/test_vector_store_unit.py
@@ -1,6 +1,5 @@
 # ruff: noqa: E402
 import pytest
-import time
 from pathlib import Path
 
 faiss = pytest.importorskip("faiss")
@@ -10,21 +9,44 @@ if not hasattr(faiss, "IndexFlatL2"):
 import importlib.util
 import sys
 import types
+from typing import Any, Type
 
 root = Path(__file__).resolve().parents[1]
-package = types.ModuleType("ume")
-package.__path__ = [str(root / "src" / "ume")]
-sys.modules["ume"] = package
+VectorStore: Type[Any]
 
-spec = importlib.util.spec_from_file_location(
-    "ume.vector_store",
-    root / "src" / "ume" / "vector_store.py",
-)
-assert spec and spec.loader
-module = importlib.util.module_from_spec(spec)
-sys.modules["ume.vector_store"] = module
-spec.loader.exec_module(module)
-VectorStore = module.VectorStore
+
+@pytest.fixture(scope="module", autouse=True)
+def vector_store_module():
+    orig_ume = sys.modules.get("ume")
+    orig_vs = sys.modules.get("ume.vector_store")
+
+    package = types.ModuleType("ume")
+    package.__path__ = [str(root / "src" / "ume")]
+    sys.modules["ume"] = package
+
+    spec = importlib.util.spec_from_file_location(
+        "ume.vector_store",
+        root / "src" / "ume" / "vector_store.py",
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["ume.vector_store"] = module
+    spec.loader.exec_module(module)
+    package.vector_store = module  # type: ignore[attr-defined]
+    global VectorStore
+    VectorStore = module.VectorStore
+
+    yield
+
+    if orig_ume is not None:
+        sys.modules["ume"] = orig_ume
+    else:
+        sys.modules.pop("ume", None)
+
+    if orig_vs is not None:
+        sys.modules["ume.vector_store"] = orig_vs
+    else:
+        sys.modules.pop("ume.vector_store", None)
 
 
 def test_add_dimension_mismatch():


### PR DESCRIPTION
## Summary
- cache Poetry and pip directories in CI
- expose `vector_store` module for easier imports
- use pure Python protobuf runtime in tests
- pin protobuf 6.x and adjust stub types
- fix `StreamT` generics and cleanup module patching in vector store tests
- guard SSE tests against global shutdown event leaking between loops

## Testing
- `pre-commit run --files tests/test_vector_store_unit.py tests/test_sse.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685de06d5580832690c7484ef2fc3ec4