### PR TITLE
Implement consent ledger and enforce policy

### DIFF
--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -51,3 +51,18 @@ UME_ROLE=UserService ume-cli new_node UserProfile.123 '{}'
 ```
 
 Without the `UserService` role the command raises `AccessDeniedError`.
+
+## User Consent Ledger
+
+The privacy agent checks user consent before forwarding sanitized events.
+Consent records are stored in a lightweight SQLite ledger located at
+`UME_CONSENT_LEDGER_PATH` (default `consent_ledger.db`). Each entry records the
+`user_id`, the consent `scope`, and the time consent was granted.
+
+When processing events the privacy agent looks for `user_id` and `scope` fields
+in the event payload. If no matching consent entry is found, the sanitized event
+is published to the quarantine topic instead of the clean events topic. Rego
+policies can reference this status via the `input.consent` value.
+
+Consent can be granted or revoked programmatically using the
+`ConsentLedger` class from `ume.consent_ledger`.

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -25,6 +25,7 @@ except Exception:  # pragma: no cover - allow import without environment setup
         UME_SNAPSHOT_PATH="ume_snapshot.json",
         UME_AUDIT_LOG_PATH="/tmp/audit.log",
         UME_AUDIT_SIGNING_KEY="stub",
+        UME_CONSENT_LEDGER_PATH="consent_ledger.db",
         UME_AGENT_ID="SYSTEM",
         UME_EMBED_MODEL="all-MiniLM-L6-v2",
         UME_CLI_DB="ume_graph.db",

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -13,6 +13,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_SNAPSHOT_PATH: str = "ume_snapshot.json"
     UME_AUDIT_LOG_PATH: str = "audit.log"
     UME_AUDIT_SIGNING_KEY: str = "default-key"
+    UME_CONSENT_LEDGER_PATH: str = "consent_ledger.db"
     UME_AGENT_ID: str = "SYSTEM"
     UME_EMBED_MODEL: str = "all-MiniLM-L6-v2"
     UME_CLI_DB: str = "ume_graph.db"

--- a/src/ume/consent_ledger.py
+++ b/src/ume/consent_ledger.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+from .config import settings
+
+
+class ConsentLedger:
+    """Simple ledger tracking user consents by scope."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = db_path or settings.UME_CONSENT_LEDGER_PATH
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(self.db_path)
+        self._create_table()
+
+    def _create_table(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS consent (
+                    user_id TEXT NOT NULL,
+                    scope TEXT NOT NULL,
+                    timestamp INTEGER NOT NULL,
+                    PRIMARY KEY (user_id, scope)
+                )
+                """
+            )
+
+    def give_consent(
+        self, user_id: str, scope: str, *, timestamp: Optional[int] = None
+    ) -> None:
+        ts = timestamp or int(time.time())
+        with self.conn:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO consent(user_id, scope, timestamp) VALUES(?,?,?)",
+                (user_id, scope, ts),
+            )
+
+    def revoke_consent(self, user_id: str, scope: str) -> None:
+        with self.conn:
+            self.conn.execute(
+                "DELETE FROM consent WHERE user_id=? AND scope=?",
+                (user_id, scope),
+            )
+
+    def has_consent(self, user_id: str, scope: str) -> bool:
+        cur = self.conn.execute(
+            "SELECT 1 FROM consent WHERE user_id=? AND scope=?",
+            (user_id, scope),
+        )
+        return cur.fetchone() is not None
+
+    def close(self) -> None:
+        self.conn.close()
+
+
+# Global ledger instance used by the privacy agent
+consent_ledger = ConsentLedger()

--- a/src/ume/plugins/alignment/policies/allow.rego
+++ b/src/ume/plugins/alignment/policies/allow.rego
@@ -1,10 +1,11 @@
 package ume
 
-# Allow an event only when no deny rules match
+# Allow an event only when no deny rules match and user consent is present
 
 default allow = false
 
 allow {
+    input.consent
     not forbidden_node
     not admin_role_update
     not admin_edge

--- a/src/ume/plugins/alignment/policies/deny_missing_consent.rego
+++ b/src/ume/plugins/alignment/policies/deny_missing_consent.rego
@@ -1,0 +1,6 @@
+package ume
+
+# Deny events when user consent is not present
+no_consent {
+    not input.consent
+}

--- a/tests/test_privacy_agent_rego.py
+++ b/tests/test_privacy_agent_rego.py
@@ -7,47 +7,47 @@ from ume.pipeline import privacy_agent
 pytest.importorskip("regopy")
 
 class FakeAnalyzer:
-    def analyze(self, text: str, language: str = "en"):
+    def analyze(self, text: str, language: str = "en") -> list[object]:
         return []
 
 class FakeAnonymizer:
-    def anonymize(self, text: str, analyzer_results):
+    def anonymize(self, text: str, analyzer_results: object) -> SimpleNamespace:
         return SimpleNamespace(text=text)
 
 class FakeMessage:
-    def __init__(self, value):
+    def __init__(self, value: bytes) -> None:
         self._value = value
 
-    def value(self):
+    def value(self) -> bytes:
         return self._value
 
-    def error(self):
+    def error(self) -> None:
         return None
 
 class FakeConsumer:
-    def __init__(self, messages):
+    def __init__(self, messages: list[FakeMessage]) -> None:
         self._messages = messages
 
-    def poll(self, timeout=1.0):
+    def poll(self, timeout: float = 1.0) -> FakeMessage:
         if self._messages:
             return self._messages.pop(0)
         raise KeyboardInterrupt
 
-    def subscribe(self, topics):
+    def subscribe(self, topics: list[str]) -> None:
         pass
 
-    def close(self):
+    def close(self) -> None:
         pass
 
 class FakeProducer:
-    def __init__(self):
-        self.produced = []
+    def __init__(self) -> None:
+        self.produced: list[tuple[str, bytes]] = []
         self.flush_calls = 0
 
-    def produce(self, topic, value, *args, **kwargs):
+    def produce(self, topic: str, value: bytes, *args: object, **kwargs: object) -> None:
         self.produced.append((topic, value))
 
-    def flush(self):
+    def flush(self) -> None:
         self.flush_calls += 1
 
 
@@ -67,10 +67,69 @@ def test_rego_policy_denies_event(monkeypatch):
     monkeypatch.setattr(privacy_agent, "Producer", lambda conf: producer)
     monkeypatch.setattr(privacy_agent, "_ANALYZER", FakeAnalyzer())
     monkeypatch.setattr(privacy_agent, "_ANONYMIZER", FakeAnonymizer())
-    monkeypatch.setattr(privacy_agent.settings, "KAFKA_PRODUCER_BATCH_SIZE", 1)
+    monkeypatch.setattr(privacy_agent.settings, "KAFKA_PRODUCER_BATCH_SIZE", 1)  # type: ignore[attr-defined]
     monkeypatch.setattr(privacy_agent, "BATCH_SIZE", 1)
 
     privacy_agent.run_privacy_agent()
 
     assert not any(topic == privacy_agent.CLEAN_TOPIC for topic, _ in producer.produced)
     assert producer.flush_calls == 1
+
+
+class FakeLedger:
+    def __init__(self, allowed: bool) -> None:
+        self.allowed = allowed
+
+    def has_consent(self, user_id: str, scope: str) -> bool:  # noqa: D401
+        return self.allowed
+
+
+def _setup_agent(monkeypatch: pytest.MonkeyPatch, consumer: FakeConsumer, producer: FakeProducer, ledger: FakeLedger) -> None:
+    monkeypatch.setattr(privacy_agent, "Consumer", lambda conf: consumer)
+    monkeypatch.setattr(privacy_agent, "Producer", lambda conf: producer)
+    monkeypatch.setattr(privacy_agent, "_ANALYZER", FakeAnalyzer())
+    monkeypatch.setattr(privacy_agent, "_ANONYMIZER", FakeAnonymizer())
+    monkeypatch.setattr(privacy_agent, "consent_ledger", ledger)
+    monkeypatch.setattr(privacy_agent.settings, "KAFKA_PRODUCER_BATCH_SIZE", 1)  # type: ignore[attr-defined]
+    monkeypatch.setattr(privacy_agent, "BATCH_SIZE", 1)
+
+
+def test_event_without_consent_goes_to_quarantine(monkeypatch: pytest.MonkeyPatch) -> None:
+    event = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n1",
+        "payload": {"node_id": "n1", "user_id": "u1", "scope": "profile", "attributes": {}},
+    }
+    msg = FakeMessage(json.dumps(event).encode("utf-8"))
+
+    consumer = FakeConsumer([msg])
+    producer = FakeProducer()
+    ledger = FakeLedger(False)
+
+    _setup_agent(monkeypatch, consumer, producer, ledger)
+
+    privacy_agent.run_privacy_agent()
+
+    assert not any(topic == privacy_agent.CLEAN_TOPIC for topic, _ in producer.produced)
+    assert any(topic == privacy_agent.QUARANTINE_TOPIC for topic, _ in producer.produced)
+
+
+def test_event_with_consent_published(monkeypatch: pytest.MonkeyPatch) -> None:
+    event = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n2",
+        "payload": {"node_id": "n2", "user_id": "u1", "scope": "profile", "attributes": {}},
+    }
+    msg = FakeMessage(json.dumps(event).encode("utf-8"))
+
+    consumer = FakeConsumer([msg])
+    producer = FakeProducer()
+    ledger = FakeLedger(True)
+
+    _setup_agent(monkeypatch, consumer, producer, ledger)
+
+    privacy_agent.run_privacy_agent()
+
+    assert any(topic == privacy_agent.CLEAN_TOPIC for topic, _ in producer.produced)


### PR DESCRIPTION
## Summary
- track user consent with a new `ConsentLedger`
- gate sanitized events on consent in `privacy_agent`
- update Rego policies to require consent
- document consent handling in `ACCESS_CONTROL.md`
- test consent logic in the privacy agent
- add missing stub config for ledger path

## Testing
- `pre-commit run --files src/ume/__init__.py src/ume/consent_ledger.py src/ume/pipeline/privacy_agent.py src/ume/config.py src/ume/plugins/alignment/policies/allow.rego src/ume/plugins/alignment/policies/deny_missing_consent.rego tests/test_privacy_agent_rego.py docs/ACCESS_CONTROL.md`
- `pytest tests/test_privacy_agent_rego.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2f2a064883269f4a34e831999478