### PR TITLE
Add value overseer

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -37,6 +37,7 @@ except Exception:  # pragma: no cover - allow import without environment setup
         UME_RELIABILITY_THRESHOLD=0.5,
         WATCH_PATHS=["."],
         DAG_RESOURCES={"cpu": 1, "io": 1},
+        UME_VALUE_STORE_PATH=None,
         UME_VECTOR_DIM=0,
         UME_VECTOR_INDEX="vectors.faiss",
         UME_VECTOR_USE_GPU=False,
@@ -140,6 +141,7 @@ from .agent_orchestrator import (
     MessageEnvelope,
     ReflectionAgent,
 )
+from .value_overseer import ValueOverseer
 from .dag_service import DAGService
 from .resource_scheduler import ResourceScheduler, ScheduledTask
 
@@ -222,6 +224,7 @@ __all__ = [
     "Critic",
     "MessageEnvelope",
     "ReflectionAgent",
+    "ValueOverseer",
     "Task",
     "DAGExecutor",
     "DAGService",

--- a/src/ume/agent_orchestrator.py
+++ b/src/ume/agent_orchestrator.py
@@ -5,6 +5,10 @@ import asyncio
 from collections import defaultdict
 from typing import Callable, Any, Dict, List, Awaitable
 
+from .audit import log_audit_entry
+from .config import settings
+from .value_overseer import ValueOverseer
+
 from .persistent_graph import PersistentGraph
 
 
@@ -72,10 +76,12 @@ class AgentOrchestrator:
         supervisor: Supervisor | None = None,
         critic: Critic | None = None,
         reflection: ReflectionAgent | None = None,
+        overseer: ValueOverseer | None = None,
     ) -> None:
         self.supervisor = supervisor or Supervisor()
         self.critic = critic or Critic()
         self.reflection = reflection or ReflectionAgent()
+        self.overseer = overseer or ValueOverseer()
         self._workers: Dict[str, Callable[[AgentTask], Awaitable[Any]]] = {}
 
     def register_worker(
@@ -87,6 +93,14 @@ class AgentOrchestrator:
     async def execute_objective(self, objective: str) -> Dict[str, float]:
         """Plan tasks for the objective and execute them across workers."""
         tasks = self.supervisor.plan(objective)
+        allowed_tasks: list[AgentTask] = []
+        for task in tasks:
+            if self.overseer.is_allowed(task):
+                allowed_tasks.append(task)
+            else:
+                user_id = settings.UME_AGENT_ID
+                log_audit_entry(user_id, f"blocked_task {task.payload}")
+        tasks = allowed_tasks
 
         async def _run(
             worker: Callable[[AgentTask], Awaitable[Any]],

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_RELIABILITY_THRESHOLD: float = 0.5
     WATCH_PATHS: list[str] = ["."]
     DAG_RESOURCES: dict[str, int] = {"cpu": 1, "io": 1}
+    UME_VALUE_STORE_PATH: str | None = None
 
     # Vector store
     UME_VECTOR_DIM: int = 1536

--- a/src/ume/value_overseer.py
+++ b/src/ume/value_overseer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from .config import settings
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .agent_orchestrator import AgentTask
+
+
+class ValueOverseer:
+    """Check tasks against a stored list of disallowed actions."""
+
+    def __init__(self, store_path: str | None = None) -> None:
+        self.store_path = store_path or settings.UME_VALUE_STORE_PATH
+        self._blocked = self._load_blocked()
+
+    def _load_blocked(self) -> list[str]:
+        if not self.store_path:
+            return []
+        try:
+            with open(self.store_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            return []
+        if isinstance(data, dict):
+            data = data.get("blocked", [])
+        if not isinstance(data, list):
+            return []
+        return [str(item) for item in data]
+
+    def reload(self) -> None:
+        """Reload the block list from disk."""
+        self._blocked = self._load_blocked()
+
+    def is_allowed(self, task: AgentTask) -> bool:
+        """Return ``True`` if the task is permitted."""
+        for forbidden in self._blocked:
+            if forbidden in task.payload:
+                return False
+        return True

--- a/tests/test_value_overseer.py
+++ b/tests/test_value_overseer.py
@@ -1,0 +1,84 @@
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def load_modules():
+    base = Path(__file__).resolve().parents[1] / "src" / "ume"
+    modules = {}
+    for name in ["config", "audit", "value_overseer", "agent_orchestrator"]:
+        full = f"ume.{name}"
+        sys.modules.pop(full, None)
+        spec = importlib.util.spec_from_file_location(full, base / f"{name}.py")
+        assert spec and spec.loader
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[full] = mod
+        spec.loader.exec_module(mod)
+        modules[name] = mod
+    return modules
+
+
+class DummySupervisor:
+    def __init__(self, base):
+        self._base = base
+
+    def plan(self, objective: str):
+        AgentTask = self._base["agent_orchestrator"].AgentTask
+        return [AgentTask(id="t1", payload=objective)]
+
+
+def setup_env(tmp_path, blocked):
+    store = tmp_path / "values.json"
+    store.write_text(json.dumps({"blocked": blocked}))
+    log = tmp_path / "audit.log"
+    os.environ["UME_VALUE_STORE_PATH"] = str(store)
+    os.environ["UME_AUDIT_LOG_PATH"] = str(log)
+    os.environ["UME_AUDIT_SIGNING_KEY"] = "test-key"
+    os.environ["UME_AGENT_ID"] = "tester"
+    open(log, "w").close()
+    return load_modules()
+
+
+def test_disallowed_task_blocks_execution(tmp_path):
+    mods = setup_env(tmp_path, ["bad"])
+    AgentOrchestrator = mods["agent_orchestrator"].AgentOrchestrator
+    AgentTask = mods["agent_orchestrator"].AgentTask
+    get_audit_entries = mods["audit"].get_audit_entries
+
+    orchestrator = AgentOrchestrator(DummySupervisor(mods))
+    executed = []
+
+    async def worker(task: AgentTask) -> str:
+        executed.append(task.payload)
+        return "ok"
+
+    orchestrator.register_worker("w", worker)
+    asyncio.run(orchestrator.execute_objective("bad"))
+
+    assert executed == []
+    entries = get_audit_entries()
+    assert len(entries) == 1
+    assert "bad" in str(entries[0]["reason"])
+
+
+def test_allowed_task_runs(tmp_path):
+    mods = setup_env(tmp_path, ["bad"])
+    AgentOrchestrator = mods["agent_orchestrator"].AgentOrchestrator
+    AgentTask = mods["agent_orchestrator"].AgentTask
+    get_audit_entries = mods["audit"].get_audit_entries
+
+    orchestrator = AgentOrchestrator(DummySupervisor(mods))
+    executed = []
+
+    async def worker(task: AgentTask) -> str:
+        executed.append(task.payload)
+        return "ok"
+
+    orchestrator.register_worker("w", worker)
+    asyncio.run(orchestrator.execute_objective("good"))
+
+    assert executed == ["good"]
+    assert get_audit_entries() == []


### PR DESCRIPTION
## Summary
- add value overseer module for blocking tasks by value store
- connect ValueOverseer to AgentOrchestrator and log blocked tasks
- expose value store path in settings
- export ValueOverseer from package
- test overseer behaviour

## Testing
- `ruff check src/ume/value_overseer.py src/ume/agent_orchestrator.py src/ume/config.py tests/test_value_overseer.py src/ume/__init__.py`
- `pytest tests/test_value_overseer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685f2f2be9508326bd71ce4f18839fef