### PR TITLE
Add Overseer with hallucination check

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -137,9 +137,9 @@ from .agent_orchestrator import (
     Supervisor,
     Critic,
     AgentTask,
-    MessageEnvelope,
     ReflectionAgent,
 )
+from .message_bus import MessageEnvelope
 from .dag_service import DAGService
 from .resource_scheduler import ResourceScheduler, ScheduledTask
 
@@ -220,6 +220,7 @@ __all__ = [
     "AgentOrchestrator",
     "Supervisor",
     "Critic",
+    "Overseer",
     "MessageEnvelope",
     "ReflectionAgent",
     "Task",

--- a/src/ume/message_bus.py
+++ b/src/ume/message_bus.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class MessageEnvelope:
+    """JSON-RPC envelope implementing the OVON schema."""
+
+    content: str
+    id: str | int | None = None
+    jsonrpc: str = "2.0"
+    ovon: str = "0.1"
+    meta: Dict[str, Any] | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return this envelope as a JSON serializable dictionary."""
+        return {
+            "jsonrpc": self.jsonrpc,
+            "ovon": self.ovon,
+            "id": self.id,
+            "content": self.content,
+            "meta": self.meta or {},
+        }


### PR DESCRIPTION
## Summary
- add MessageEnvelope implementing OVON JSON-RPC envelope
- introduce Overseer class and integrate into AgentOrchestrator
- route worker results through Overseer
- export new classes
- test Overseer behavior and envelope wrapping
- avoid full package import in tests to remove optional dependency requirement

## Testing
- `ruff check src/ume/agent_orchestrator.py src/ume/message_bus.py tests/test_agent_orchestrator.py`
- `mypy src/ume/agent_orchestrator.py src/ume/message_bus.py tests/test_agent_orchestrator.py`
- `pytest tests/test_agent_orchestrator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2f1ea4148326b528732d5728cfc5