### PR TITLE
Check S3 paths before writing audit logs

### DIFF
--- a/src/ume/audit.py
+++ b/src/ume/audit.py
@@ -79,6 +79,10 @@ def _write_lines(path: str, lines: List[str]) -> None:
                 "boto3 is required to write to S3 paths but is not installed"
             )
         bucket, key = _parse_s3(path)
+        if not bucket or not key:
+            raise ValueError(
+                f"Invalid S3 path: '{path}'. Expected format 's3://bucket/key'."
+            )
         s3 = boto3.client("s3")
         try:
             s3.put_object(Bucket=bucket, Key=key, Body=data.encode())


### PR DESCRIPTION
## Summary
- validate bucket and key from `_parse_s3` in `_write_lines`
- test invalid S3 paths for `_write_lines`

## Testing
- `ruff check src/ume/audit.py tests/test_audit_logging.py`
- `pytest -q tests/test_audit_logging.py::test_parse_s3_invalid tests/test_audit_logging.py::test_write_lines_invalid_s3_path -q`


------
https://chatgpt.com/codex/tasks/task_e_6860530dfa8c8326b456b80e0785a2d2