### PR TITLE
Implement document cleanup and retrieval

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -39,7 +39,6 @@ except Exception:  # pragma: no cover - allow import without environment setup
         UME_LOG_JSON=False,
         UME_GRAPH_RETENTION_DAYS=30,
         UME_RELIABILITY_THRESHOLD=0.5,
-        UME_COLD_EVENT_AGE_DAYS=180,
         WATCH_PATHS=["."],
         DAG_RESOURCES={"cpu": 1, "io": 1},
         UME_VALUE_STORE_PATH=None,

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -83,7 +83,19 @@ except Exception:  # pragma: no cover - allow import without environment setup
 from .event import Event, EventType, parse_event, EventError
 from .graph import MockGraph
 from .persistent_graph import PersistentGraph
-from .neo4j_graph import Neo4jGraph
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from .neo4j_graph import Neo4jGraph
+else:  # pragma: no cover - optional dependency
+    try:
+        from .neo4j_graph import Neo4jGraph
+    except Exception:
+        class Neo4jGraph:
+            """Placeholder when neo4j dependencies are missing."""
+
+            def __init__(self, *_: object, **__: object) -> None:
+                raise ImportError("neo4j is required for Neo4jGraph")
 from .auto_snapshot import (
     enable_periodic_snapshot,
     disable_periodic_snapshot,

--- a/src/ume/document_guru.py
+++ b/src/ume/document_guru.py
@@ -1,0 +1,9 @@
+"""Utility functions for the Document Guru workflow."""
+from __future__ import annotations
+
+
+def reformat_document(content: str) -> str:
+    """Return a lightly cleaned version of ``content``."""
+    lines = [line.strip() for line in content.splitlines()]
+    cleaned_lines: list[str] = [line for line in lines if line]
+    return "\n".join(cleaned_lines)

--- a/tests/test_document_guru.py
+++ b/tests/test_document_guru.py
@@ -1,9 +1,22 @@
 import pytest
 from fastapi.testclient import TestClient
 
-from ume.api import app, configure_graph
-from ume import MockGraph
+import importlib.util
+import sys
+import types
+from ume.graph import MockGraph
 from ume.config import settings
+
+spec = importlib.util.spec_from_file_location("ume.api", "src/ume/api.py")
+api = importlib.util.module_from_spec(spec)
+sys.modules["ume.api"] = api
+if "neo4j" not in sys.modules:
+    neo4j_stub = types.SimpleNamespace(GraphDatabase=object, Driver=object)
+    sys.modules["neo4j"] = neo4j_stub
+spec.loader.exec_module(api)
+
+app = api.app
+configure_graph = api.configure_graph
 
 
 @pytest.fixture

--- a/tests/test_document_guru.py
+++ b/tests/test_document_guru.py
@@ -39,9 +39,15 @@ def test_upload_document(client_and_graph):
     token = _token(client)
     res = client.post(
         "/documents",
-        json={"content": "doc"},
+        json={"content": "  line1  \n\n line2 "},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
     doc_id = res.json()["id"]
-    assert g.get_node(doc_id)["content"] == "doc"
+    assert g.get_node(doc_id)["content"] == "line1\nline2"
+
+    res = client.get(
+        f"/documents/{doc_id}", headers={"Authorization": f"Bearer {token}"}
+    )
+    assert res.status_code == 200
+    assert res.json()["content"] == "line1\nline2"


### PR DESCRIPTION
## Summary
- add a new `document_guru` helper with `reformat_document`
- clean uploaded document content and add `/documents/{id}` endpoint
- extend Document Guru test to cover cleanup and retrieval
- fix duplicate setting in `__init__.py`
- strip leading spaces during cleanup

## Testing
- `poetry run ruff check src/ume/document_guru.py src/ume/api.py tests/test_document_guru.py src/ume/__init__.py`
- `poetry run mypy src/ume/document_guru.py src/ume/api.py tests/test_document_guru.py`
- `poetry run pytest tests/test_document_guru.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f52514d483269df970e04df10964