### PR TITLE
Fix overseer duplicate method and import

### DIFF
--- a/src/ume/agent_orchestrator.py
+++ b/src/ume/agent_orchestrator.py
@@ -10,6 +10,7 @@ from .config import settings
 
 from .persistent_graph import PersistentGraph
 from .message_bus import MessageEnvelope
+from .value_overseer import ValueOverseer
 
 
 @dataclass
@@ -68,11 +69,6 @@ class Overseer:
         agent_id: str | None = None,
     ) -> MessageEnvelope:  # pragma: no cover - default passthrough
         return message
-
-    def is_allowed(self, task: AgentTask) -> bool:  # pragma: no cover - passthrough
-        """Return ``True`` for all tasks by default."""
-
-        return True
 
 
 class ReflectionAgent:


### PR DESCRIPTION
## Summary
- remove redundant `is_allowed` method definition
- import `ValueOverseer` for default Overseer initialization

## Testing
- `ruff check src/ume/agent_orchestrator.py`
- `pytest tests/test_agent_orchestrator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6862866a522c83269d4ab9597e383432