### PR TITLE
Fix ValueOverseer import

### DIFF
--- a/src/ume/agent_orchestrator.py
+++ b/src/ume/agent_orchestrator.py
@@ -10,6 +10,10 @@ from .config import settings
 
 from .persistent_graph import PersistentGraph
 from .message_bus import MessageEnvelope
+try:  # pragma: no cover - value_overseer may have optional deps
+    from .value_overseer import ValueOverseer
+except Exception:  # pragma: no cover - fallback when optional deps missing
+    ValueOverseer = None  # type: ignore[assignment]
 
 
 @dataclass
@@ -56,10 +60,6 @@ class Critic:
 class Overseer:
     """Monitor worker outputs for hallucinations."""
 
-    def is_allowed(self, task: AgentTask) -> bool:  # pragma: no cover - default passthrough
-        """Return ``True`` if the task is permitted."""
-        return True
-
     def hallucination_check(
         self,
         message: MessageEnvelope,
@@ -73,6 +73,11 @@ class Overseer:
         """Return ``True`` for all tasks by default."""
 
         return True
+
+
+if ValueOverseer is None:  # pragma: no cover - fallback when optional deps missing
+    class ValueOverseer(Overseer):
+        pass
 
 
 class ReflectionAgent:


### PR DESCRIPTION
## Summary
- add optional import for `ValueOverseer` with fallback implementation
- remove duplicate `is_allowed` method in `Overseer`

## Testing
- `ruff check src/ume/agent_orchestrator.py`
- `mypy --config-file mypy.ini src/ume/agent_orchestrator.py`
- `pytest -q tests/test_agent_orchestrator.py::test_execution_cycle -q`
- `pytest -q tests/test_value_overseer.py::test_allowed_task_runs -q`


------
https://chatgpt.com/codex/tasks/task_e_6862866f8ea88326a76e61750f922218