### PR TITLE
Add overseer retry logic with JSON-RPC worker interface

### DIFF
--- a/src/ume/agent_orchestrator.py
+++ b/src/ume/agent_orchestrator.py
@@ -10,6 +10,7 @@ from .config import settings
 
 from .persistent_graph import PersistentGraph
 from .message_bus import MessageEnvelope
+from .value_overseer import ValueOverseer
 
 
 @dataclass
@@ -69,11 +70,6 @@ class Overseer:
     ) -> MessageEnvelope:  # pragma: no cover - default passthrough
         return message
 
-    def is_allowed(self, task: AgentTask) -> bool:  # pragma: no cover - passthrough
-        """Return ``True`` for all tasks by default."""
-
-        return True
-
 
 class ReflectionAgent:
     """Optional agent that can post-process worker output."""
@@ -91,17 +87,19 @@ class AgentOrchestrator:
         critic: Critic | None = None,
         reflection: ReflectionAgent | None = None,
         overseer: ValueOverseer | None = None,
+        max_retries: int | None = None,
 
     ) -> None:
         self.supervisor = supervisor or Supervisor()
         self.critic = critic or Critic()
         self.reflection = reflection or ReflectionAgent()
         self.overseer = overseer or ValueOverseer()
+        self.max_retries = max_retries or 0
 
-        self._workers: Dict[str, Callable[[AgentTask], Awaitable[Any]]] = {}
+        self._workers: Dict[str, Callable[[Dict[str, Any]], Awaitable[Any]]] = {}
 
     def register_worker(
-        self, agent_id: str, handler: Callable[[AgentTask], Awaitable[Any]]
+        self, agent_id: str, handler: Callable[[Dict[str, Any]], Awaitable[Any]]
     ) -> None:
         """Register a worker that can execute tasks."""
         self._workers[agent_id] = handler
@@ -119,20 +117,31 @@ class AgentOrchestrator:
         tasks = allowed_tasks
 
         async def _run(
-            worker: Callable[[AgentTask], Awaitable[Any]],
+            worker: Callable[[Dict[str, Any]], Awaitable[Any]],
             agent_id: str,
             task: AgentTask,
         ) -> tuple[str, float]:
-            result = await worker(task)
-            if not isinstance(result, MessageEnvelope):
-                result = MessageEnvelope(content=str(result))
-            checked = self.overseer.hallucination_check(
-                result, task=task, agent_id=agent_id
-            )
-            reviewed = self.reflection.review(checked)
-            return agent_id, self.critic.score(
-                reviewed.content, task=task, agent_id=agent_id
-            )
+            envelope = MessageEnvelope(content=task.payload, id=task.id)
+            attempts = 0
+            while True:
+                result = await worker(envelope.to_dict())
+                if isinstance(result, MessageEnvelope):
+                    resp = result
+                elif isinstance(result, dict):
+                    resp = MessageEnvelope.from_dict(result)
+                else:
+                    resp = MessageEnvelope(content=str(result))
+                checked = self.overseer.hallucination_check(
+                    resp, task=task, agent_id=agent_id
+                )
+                if checked.meta and checked.meta.get("hallucination"):
+                    attempts += 1
+                    if attempts <= self.max_retries:
+                        continue
+                reviewed = self.reflection.review(checked)
+                return agent_id, self.critic.score(
+                    reviewed.content, task=task, agent_id=agent_id
+                )
 
         coros = [
             _run(worker, agent_id, task)

--- a/src/ume/message_bus.py
+++ b/src/ume/message_bus.py
@@ -23,3 +23,14 @@ class MessageEnvelope:
             "content": self.content,
             "meta": self.meta or {},
         }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "MessageEnvelope":
+        """Create a :class:`MessageEnvelope` instance from ``data``."""
+        return cls(
+            content=str(data.get("content", "")),
+            id=data.get("id"),
+            jsonrpc=str(data.get("jsonrpc", "2.0")),
+            ovon=str(data.get("ovon", "0.1")),
+            meta=data.get("meta"),
+        )


### PR DESCRIPTION
## Summary
- extend `MessageEnvelope` with `from_dict` helper
- revise `AgentOrchestrator` to send JSON-RPC envelopes to workers and retry tasks flagged as hallucinations
- update existing tests for new interface
- add tests covering overseer retry behaviour

## Testing
- `pre-commit run --files src/ume/message_bus.py src/ume/agent_orchestrator.py tests/test_agent_orchestrator.py tests/test_value_overseer.py`
- `pytest tests/test_agent_orchestrator.py tests/test_value_overseer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6862867e639483269268180dc5ae3cd6