### PR TITLE
Add vector age scheduler

### DIFF
--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -139,6 +139,8 @@ removed from the vector index to keep retrieval‑augmented generation fresh.
 Call :func:`ume.start_memory_aging_scheduler` with paired episodic and
 semantic memory objects to enable the process. Pass ``vector_age_seconds=None``
 to disable vector pruning.
+Use :func:`ume.start_vector_age_scheduler` to audit existing vectors and
+record the ``ume_stale_vector_count`` metric.
 
 ## Schema Upgrades
 

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -61,6 +61,7 @@ Here are a few Prometheus queries you can use when building graphs:
 | `ume_request_latency_seconds` | Average request latency | `rate(ume_request_latency_seconds_sum[5m]) / rate(ume_request_latency_seconds_count[5m])` |
 | `ume_vector_query_latency_seconds` | Latency of vector similarity search | `rate(ume_vector_query_latency_seconds_sum[5m]) / rate(ume_vector_query_latency_seconds_count[5m])` |
 | `ume_vector_index_size` | Number of vectors stored | `ume_vector_index_size` |
+| `ume_stale_vector_count` | Vectors older than the freshness limit | `ume_stale_vector_count` |
 
 You can combine these metrics in Grafana to visualize API performance and index
 growth over time.

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -102,7 +102,12 @@ from .auto_snapshot import (
     enable_snapshot_autosave_and_restore,
 )
 from .retention import start_retention_scheduler, stop_retention_scheduler
-from .memory_aging import start_memory_aging_scheduler, stop_memory_aging_scheduler
+from .memory_aging import (
+    start_memory_aging_scheduler,
+    stop_memory_aging_scheduler,
+    start_vector_age_scheduler,
+    stop_vector_age_scheduler,
+)
 from .graph_adapter import IGraphAdapter
 from .rbac_adapter import RoleBasedGraphAdapter, AccessDeniedError
 from .plugins.alignment import PolicyViolationError
@@ -207,6 +212,8 @@ __all__ = [
     "stop_retention_scheduler",
     "start_memory_aging_scheduler",
     "stop_memory_aging_scheduler",
+    "start_vector_age_scheduler",
+    "stop_vector_age_scheduler",
     "validate_event_dict",
     "GraphSchema",
     "load_default_schema",

--- a/src/ume/metrics.py
+++ b/src/ume/metrics.py
@@ -25,6 +25,10 @@ STALE_VECTOR_WARNINGS = Counter(
     "ume_stale_vector_warning_total",
     "Number of times stale vectors exceeded threshold",
 )
+STALE_VECTOR_COUNT = Gauge(
+    "ume_stale_vector_count",
+    "Current number of vectors exceeding the freshness limit",
+)
 
 # Reliability metrics
 RESPONSE_CONFIDENCE = Histogram(

--- a/tests/test_vector_age_scheduler.py
+++ b/tests/test_vector_age_scheduler.py
@@ -1,0 +1,28 @@
+import time
+import types
+import pytest
+
+from ume.memory_aging import (
+    start_vector_age_scheduler,
+    stop_vector_age_scheduler,
+)
+from ume.config import settings
+from ume.metrics import STALE_VECTOR_WARNINGS, STALE_VECTOR_COUNT
+
+
+def test_vector_age_scheduler_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = int(time.time())
+    store = types.SimpleNamespace(get_vector_timestamps=lambda: {"old": now - 100})
+
+    monkeypatch.setattr(settings, "UME_VECTOR_MAX_AGE_DAYS", 0)
+    STALE_VECTOR_WARNINGS._value.set(0)  # type: ignore[attr-defined]
+    STALE_VECTOR_COUNT.set(0)
+
+    thread, stop = start_vector_age_scheduler(store, interval_seconds=0.01, log=True)
+    time.sleep(0.02)
+    stop()
+    stop_vector_age_scheduler()
+
+    assert STALE_VECTOR_WARNINGS._value.get() == 1  # type: ignore[attr-defined]
+    assert STALE_VECTOR_COUNT._value.get() == 1
+


### PR DESCRIPTION
## Summary
- add new metrics `ume_stale_vector_count`
- implement vector age scheduler in `memory_aging`
- export scheduler from `ume` package
- document stale vector metric and scheduler
- test stale vector detection

## Testing
- `pre-commit run --files src/ume/memory_aging.py src/ume/metrics.py src/ume/__init__.py`
- `pre-commit run --files tests/test_vector_age_scheduler.py`
- `pytest tests/test_memory_aging.py tests/test_vector_age_scheduler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68628687522c83268e653a533877ab34