### PR TITLE
Add consent ledger dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,8 @@ cython_debug/
 
 # Ruff stuff:
 .ruff_cache/
+frontend/node_modules/
+frontend/package-lock.json
 
 # PyPI configuration file
 .pypirc

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -13,6 +14,10 @@
   },
   "devDependencies": {
     "vite": "^5.2.0",
-    "@vitejs/plugin-react": "^4.1.0"
+    "@vitejs/plugin-react": "^4.1.0",
+    "vitest": "^1.4.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.3.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import PiiStatus from './PiiStatus';
 import PolicyEditor from './PolicyEditor';
 import Recommendations from './Recommendations';
+import ConsentLedger from './ConsentLedger';
 
 const POLICY_CONTENT = {
   'allow.rego': `package ume
@@ -149,6 +150,7 @@ function App() {
       )}
       <PiiStatus token={token} />
       <Recommendations token={token} />
+      <ConsentLedger token={token} />
       <h3>Policies</h3>
       <ul>
         {policies.map((p) => (

--- a/frontend/src/ConsentLedger.jsx
+++ b/frontend/src/ConsentLedger.jsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+export default function ConsentLedger({ token }) {
+  const [entries, setEntries] = useState([]);
+  const [userId, setUserId] = useState('');
+  const [scope, setScope] = useState('');
+
+  const headers = { Authorization: 'Bearer ' + token };
+
+  const load = async () => {
+    const res = await fetch('/consent', { headers });
+    if (res.ok) setEntries(await res.json());
+  };
+
+  useEffect(() => {
+    if (token) load();
+  }, [token]);
+
+  const add = async () => {
+    await fetch('/consent', {
+      method: 'POST',
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: userId, scope }),
+    });
+    setUserId('');
+    setScope('');
+    load();
+  };
+
+  const remove = async (uid, sc) => {
+    await fetch(`/consent?user_id=${encodeURIComponent(uid)}&scope=${encodeURIComponent(sc)}`, {
+      method: 'DELETE',
+      headers,
+    });
+    load();
+  };
+
+  return (
+    <div style={{ marginTop: '8px' }}>
+      <h3>Consent Ledger</h3>
+      <ul>
+        {entries.map((e) => (
+          <li key={e.user_id + e.scope}>
+            {e.user_id} - {e.scope}
+            <button onClick={() => remove(e.user_id, e.scope)} style={{ marginLeft: '4px' }}>
+              Revoke
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div>
+        <input placeholder="User ID" value={userId} onChange={(e) => setUserId(e.target.value)} />
+        <input
+          placeholder="Scope"
+          value={scope}
+          onChange={(e) => setScope(e.target.value)}
+          style={{ marginLeft: '4px' }}
+        />
+        <button onClick={add} style={{ marginLeft: '4px' }}>
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/ConsentLedger.test.jsx
+++ b/frontend/src/ConsentLedger.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import ConsentLedger from './ConsentLedger';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+function mockFetch(responses) {
+  global.fetch = vi.fn((url, opts = {}) => {
+    const method = (opts.method || 'GET').toUpperCase();
+    const key = method + ' ' + url;
+    const response = responses[key] || responses[url] || {};
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(response),
+      text: () => Promise.resolve(JSON.stringify(response)),
+    });
+  });
+}
+
+describe('ConsentLedger', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+  it('loads and displays entries', async () => {
+    mockFetch({ '/consent': [{ user_id: 'u1', scope: 's1', timestamp: 1 }] });
+    render(<ConsentLedger token="t" />);
+    await waitFor(() => screen.getByText('u1 - s1'));
+    expect(screen.getByText('u1 - s1')).toBeInTheDocument();
+  });
+
+  it('adds a new entry', async () => {
+    const responses = {
+      '/consent': [],
+      'POST /consent': {},
+    };
+    mockFetch(responses);
+    render(<ConsentLedger token="t" />);
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+    fireEvent.change(screen.getByPlaceholderText('User ID'), { target: { value: 'u2' } });
+    fireEvent.change(screen.getByPlaceholderText('Scope'), { target: { value: 's2' } });
+    fireEvent.click(screen.getByText('Add'));
+    expect(fetch).toHaveBeenCalledWith('/consent', expect.objectContaining({ method: 'POST' }));
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.js',
+  },
+});

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/src/ume/consent_ledger.py
+++ b/src/ume/consent_ledger.py
@@ -14,7 +14,7 @@ class ConsentLedger:
     def __init__(self, db_path: str | None = None) -> None:
         self.db_path = db_path or settings.UME_CONSENT_LEDGER_PATH
         Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
-        self.conn = sqlite3.connect(self.db_path)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         self._create_table()
 
     def _create_table(self) -> None:
@@ -53,6 +53,12 @@ class ConsentLedger:
             (user_id, scope),
         )
         return cur.fetchone() is not None
+
+    def list_consents(self) -> list[tuple[str, str, int]]:
+        """Return all stored consent entries."""
+        cur = self.conn.execute("SELECT user_id, scope, timestamp FROM consent")
+        rows = cur.fetchall()
+        return [(str(u), str(s), int(t)) for u, s, t in rows]
 
     def close(self) -> None:
         self.conn.close()

--- a/tests/test_api_consent.py
+++ b/tests/test_api_consent.py
@@ -1,0 +1,39 @@
+from fastapi.testclient import TestClient
+from ume.api import app
+from ume.config import settings
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return res.json()["access_token"]
+
+
+def test_consent_flow(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "UME_CONSENT_LEDGER_PATH", str(tmp_path / "ledger.db"))
+    from ume.consent_ledger import ConsentLedger
+    ledger = ConsentLedger(str(tmp_path / "ledger.db"))
+    monkeypatch.setattr("ume.api.consent_ledger", ledger)
+
+    client = TestClient(app)
+    token = _token(client)
+    auth = {"Authorization": f"Bearer {token}"}
+
+    res = client.get("/consent", headers=auth)
+    assert res.status_code == 200
+    assert res.json() == []
+
+    res = client.post("/consent", json={"user_id": "u1", "scope": "s1"}, headers=auth)
+    assert res.status_code == 200
+
+    res = client.get("/consent", headers=auth)
+    data = res.json()
+    assert len(data) == 1
+    assert data[0]["user_id"] == "u1"
+    assert data[0]["scope"] == "s1"
+
+    res = client.delete("/consent", params={"user_id": "u1", "scope": "s1"}, headers=auth)
+    assert res.status_code == 200
+    assert client.get("/consent", headers=auth).json() == []


### PR DESCRIPTION
## Summary
- expose new `/consent` endpoints on the API
- list, add, and revoke consents in a new ConsentLedger React component
- wire ConsentLedger into the dashboard
- add frontend unit tests and Vitest config
- test the new API operations

## Testing
- `pre-commit run --files src/ume/consent_ledger.py src/ume/api.py`
- `npx vitest run`
- `pytest tests/test_api_consent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68628689a5b88326b348ef831d20ab2a