### PR TITLE
Add dynamic reload for policy plugins

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -44,6 +44,7 @@ from .graph_adapter import IGraphAdapter
 from .query import Neo4jQueryEngine
 from .consent_ledger import consent_ledger
 from . import VectorStore, create_default_store
+from .plugins import alignment
 
 logger = logging.getLogger(__name__)
 
@@ -689,6 +690,16 @@ def list_policies(_: str = Depends(get_current_role)) -> Dict[str, List[str]]:
     return {"policies": sorted(files)}
 
 
+@app.post("/policies/reload")
+def reload_policies(_: str = Depends(get_current_role)) -> Dict[str, str]:
+    """Reload alignment policy plugins."""
+    import importlib
+
+    importlib.reload(alignment)
+    alignment.reload_plugins()
+    return {"status": "ok"}
+
+
 @app.post("/policies/{name:path}")
 async def add_policy(
     name: str,
@@ -750,6 +761,8 @@ def validate_policy(req: PolicySource, _: str = Depends(get_current_role)) -> Di
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {"status": "ok"}
+
+
 
 
 @app.get("/consent", response_model=list[ConsentEntry])

--- a/src/ume/plugins/alignment/__init__.py
+++ b/src/ume/plugins/alignment/__init__.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import List, Callable, cast
 import importlib
+import importlib.util
 import pkgutil
+import sys
 
 from ...event import Event
 from ...audit import log_audit_entry
@@ -60,8 +62,22 @@ def get_plugins() -> List[AlignmentPlugin]:
 def load_plugins() -> None:
     """Import all modules in this package so they can register plugins."""
     package = __name__
+    importlib.invalidate_caches()
     for _, modname, _ in pkgutil.iter_modules(__path__):
         importlib.import_module(f"{package}.{modname}")
+
+
+def reload_plugins() -> None:
+    """Clear and reload all plugin modules."""
+    _plugins.clear()
+    package = __name__
+    importlib.invalidate_caches()
+    for _, modname, _ in pkgutil.iter_modules(__path__):
+        fullname = f"{package}.{modname}"
+        if fullname in sys.modules:
+            importlib.reload(sys.modules[fullname])
+        else:
+            importlib.import_module(fullname)
 
 
 # Load plugins on import

--- a/tests/test_policy_reload.py
+++ b/tests/test_policy_reload.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from ume.api import app, configure_graph
+from ume.graph import MockGraph
+from ume.config import settings
+from ume.plugins import alignment
+
+
+def setup_module(_: object) -> None:
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: [{"q": q}]})()
+    g = MockGraph()
+    configure_graph(g)
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return str(res.json()["access_token"])
+
+
+def test_reload_policies(monkeypatch):
+    alignment._plugins.clear()
+    client = TestClient(app)
+    token = _token(client)
+    res = client.post("/policies/reload", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    assert len(alignment.get_plugins()) > 0

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -481,6 +481,16 @@ class UMEPrompt(Cmd):
         else:
             print("MirrorMaker not running.")
 
+    def do_reload_policies(self, arg):
+        """reload_policies
+        Reload alignment policy plugins."""
+        import importlib
+        from ume.plugins import alignment
+
+        importlib.reload(alignment)
+        alignment.reload_plugins()
+        print("Policies reloaded.")
+
 
     def do_watch(self, arg):
         """watch [path1,path2,...]


### PR DESCRIPTION
## Summary
- add `reload_plugins` function to Alignment plugin package
- expose `/policies/reload` API endpoint
- implement `reload_policies` command in `ume-cli`
- test plugin reload endpoint

## Testing
- `pre-commit run --files src/ume/plugins/alignment/__init__.py src/ume/api.py ume_cli.py tests/test_policy_reload.py`
- `pytest tests/test_policy_reload.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e69c34bc8326be04bbe3777fa995