### PR TITLE
Implement batch vector addition

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -520,7 +520,7 @@ def api_add_vector(
     """Store an embedding vector for later similarity search."""
     if len(req.vector) != store.dim:
         raise HTTPException(status_code=400, detail="Invalid vector dimension")
-    store.add(req.id, req.vector)
+    store.add_many({req.id: req.vector})
     return {"status": "ok"}
 
 

--- a/src/ume/benchmarks.py
+++ b/src/ume/benchmarks.py
@@ -28,8 +28,7 @@ def benchmark_vector_store(
     vectors = np.random.random((num_vectors, dim)).astype("float32")
 
     start = time.perf_counter()
-    for i, vec in enumerate(vectors):
-        store.add(f"v{i}", vec.tolist())
+    store.add_many({f"v{i}": vec.tolist() for i, vec in enumerate(vectors)})
     build_time = time.perf_counter() - start
 
     queries = np.random.random((num_queries, dim)).astype("float32")

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -305,3 +305,15 @@ def test_context_manager_stops_flush_thread(tmp_path: Path) -> None:
         assert thread is not None and thread.is_alive()
     assert thread is not None and not thread.is_alive()
 
+
+def test_add_many() -> None:
+    store = VectorStore(dim=2, use_gpu=False)
+    store.add_many({"a": [1.0, 0.0], "b": [0.0, 1.0]})
+    assert set(store.query([1.0, 0.0], k=2)) == {"a", "b"}
+
+
+def test_add_many_dimension_mismatch() -> None:
+    store = VectorStore(dim=2, use_gpu=False)
+    with pytest.raises(ValueError):
+        store.add_many({"a": [1.0]})
+


### PR DESCRIPTION
## Summary
- support adding vectors in bulk with `add_many`
- leverage new `add_many` in benchmarks and API
- test `add_many` behavior

## Testing
- `ruff check --config pyproject.toml` on changed files
- `mypy --config-file mypy.ini --strict` on changed files
- `pytest tests/test_vector_store.py::test_add_many tests/test_vector_store.py::test_add_many_dimension_mismatch tests/test_vector_api.py::test_add_vector_authorized -q`

------
https://chatgpt.com/codex/tasks/task_e_6863e6981b6c83268cee94610742dae3