### PR TITLE
Improve watcher shutdown

### DIFF
--- a/src/ume/watchers/dev_log_watcher.py
+++ b/src/ume/watchers/dev_log_watcher.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
+import signal
 import time
+from types import FrameType
 from pathlib import Path
 from typing import Iterable
 
@@ -52,8 +54,17 @@ class DevLogHandler(FileSystemEventHandler):  # type: ignore[misc]
             logger.error("Failed to produce dev log event: %s", exc)
 
 
-def run_watcher(paths: Iterable[str]) -> None:
-    """Start watching given paths until process exit."""
+def run_watcher(paths: Iterable[str], runtime: float | None = None) -> None:
+    """Start watching given paths until process exit.
+
+    Parameters
+    ----------
+    paths:
+        Iterable of filesystem paths to watch.
+    runtime:
+        Optional duration in seconds to run before stopping. ``None`` (default)
+        runs indefinitely until interrupted.
+    """
 
     producer = Producer({"bootstrap.servers": settings.KAFKA_BOOTSTRAP_SERVERS})
     observer = Observer()
@@ -62,8 +73,26 @@ def run_watcher(paths: Iterable[str]) -> None:
         observer.schedule(handler, str(Path(p)), recursive=True)
     observer.start()
     logger.info("Watching %s", list(paths))
+
+    should_stop = False
+
+    def handle_signal(signum: int, _frame: FrameType | None) -> None:
+        nonlocal should_stop
+        logger.info("Stopping watcher due to signal %s", signum)
+        should_stop = True
+        observer.stop()
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
     try:
-        observer.join()
+        end_time = None if runtime is None else time.time() + runtime
+        while not should_stop:
+            if end_time is not None and time.time() >= end_time:
+                break
+            time.sleep(1)
+    except KeyboardInterrupt:  # pragma: no cover - manual interrupt
+        logger.info("Stopping watcher due to keyboard interrupt")
     finally:
         observer.stop()
         producer.flush()

--- a/tests/test_dev_log_watcher.py
+++ b/tests/test_dev_log_watcher.py
@@ -71,7 +71,7 @@ def test_run_watcher_produces_event(tmp_path: Path, monkeypatch: MonkeyPatch) ->
     monkeypatch.setattr(dev_log_watcher, "Producer", lambda *_, **__: Producer())
     monkeypatch.setattr(dev_log_watcher, "Observer", lambda: observer)
 
-    dev_log_watcher.run_watcher([str(tmp_path)])
+    dev_log_watcher.run_watcher([str(tmp_path)], runtime=0)
 
     assert observer.scheduled == [str(tmp_path)]
     assert messages


### PR DESCRIPTION
## Summary
- handle signals and keyboard interrupt in `dev_log_watcher.run_watcher`

## Testing
- `pre-commit run --files src/ume/watchers/dev_log_watcher.py tests/test_dev_log_watcher.py`
- `pytest -q tests/test_dev_log_watcher.py`


------
https://chatgpt.com/codex/tasks/task_e_6863e679528883269445f571a6f1fe26