### PR TITLE
Improve scheduler docs and annotations

### DIFF
--- a/docs/AGING_SCHEDULERS.md
+++ b/docs/AGING_SCHEDULERS.md
@@ -1,0 +1,15 @@
+# Aging Schedulers
+
+UME exposes several helpers that maintain memory freshness. They can run
+side by side and each focuses on a specific layer of storage.
+
+- `start_retention_scheduler` removes graph entries older than the configured
+  retention window.
+- `start_memory_aging_scheduler` migrates events from episodic to semantic
+  memory and optionally archives very old items in cold storage while pruning
+  outdated vectors.
+- `start_vector_age_scheduler` audits existing vectors and records warnings
+  when embeddings exceed the `UME_VECTOR_MAX_AGE_DAYS` threshold.
+
+Applications can start these schedulers independently. Each function returns the
+background thread and a stop callback so lifecycles can be coordinated.

--- a/src/ume/retention.py
+++ b/src/ume/retention.py
@@ -17,12 +17,18 @@ _vector_stop: threading.Event | None = None
 
 
 class _SupportsPurge(Protocol):
+    """Graph-like object able to purge old records."""
+
     def purge_old_records(self, max_age_seconds: int) -> None:
+        """Remove items older than ``max_age_seconds`` from the graph."""
         ...
 
 
 class _SupportsVectorAge(Protocol):
+    """Vector store with introspection of embedding timestamps."""
+
     def get_vector_timestamps(self) -> dict[str, int]:
+        """Return mapping of vector IDs to their creation timestamps."""
         ...
 
 
@@ -97,6 +103,8 @@ def start_vector_age_scheduler(
     warn_threshold: int = 0,
     log: bool = False,
 ) -> tuple[threading.Thread, Callable[[], None]]:
+    """Run ``_check_stale_vectors`` periodically in a background thread."""
+
     global _vector_thread, _vector_stop
 
     if _vector_thread and _vector_thread.is_alive():
@@ -125,6 +133,8 @@ def start_vector_age_scheduler(
 
 
 def stop_vector_age_scheduler() -> None:
+    """Terminate the vector age scheduler if it is running."""
+
     global _vector_thread, _vector_stop
     if _vector_stop is not None:
         _vector_stop.set()


### PR DESCRIPTION
## Summary
- document scheduler protocol interfaces
- describe vector age scheduler lifecycle
- add aging scheduler overview doc

## Testing
- `mypy --config-file mypy.ini src/ume/memory_aging.py src/ume/retention.py`

------
https://chatgpt.com/codex/tasks/task_e_68645398102c8326ade12de94fd095ff