### PR TITLE
Add average metrics to vector benchmark

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 120
       }
     ],
     "tests/test_anonymizer.py": [
@@ -146,5 +146,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-01T19:34:49Z"
+  "generated_at": "2025-07-02T01:22:42Z"
 }

--- a/docs/VECTOR_BENCHMARKS.md
+++ b/docs/VECTOR_BENCHMARKS.md
@@ -1,13 +1,14 @@
 # Vector Store Benchmark
 
-The `benchmark_vector_store` utility measures how quickly the FAISS index can be built and queried.
+The `benchmark_vector_store` utility measures how quickly the FAISS index can be built and queried.  
+It now supports running the benchmark multiple times and reports the average build time and query latency.
 
 On an RTX 4080 with 100k random vectors (dimension 1536) and 100 search queries the GPU backed store built the index in about **2.1s** and averaged **0.7ms** per query. The CPU version required roughly **9.5s** to build and **3.6ms** per query.
 
 Run the benchmark from the CLI:
 
 ```bash
-ume> benchmark_vectors --gpu --num-vectors 100000 --num-queries 100
+ume> benchmark_vectors --gpu --num-vectors 100000 --num-queries 100 --runs 3
 ```
 
 or via the HTTP API:
@@ -15,5 +16,14 @@ or via the HTTP API:
 ```bash
 TOKEN=$(curl -s -X POST -d "username=ume&password=password" http://localhost:8000/token | jq -r .access_token)
 curl -H "Authorization: Bearer $TOKEN" \
-  'http://localhost:8000/vectors/benchmark?use_gpu=true&num_vectors=100000&num_queries=100'
+  'http://localhost:8000/vectors/benchmark?use_gpu=true&num_vectors=100000&num_queries=100&runs=3'
+
+Example response:
+
+```json
+{
+  "avg_build_time": 2.1,
+  "avg_query_latency": 0.0007
+}
+```
 ```

--- a/scripts/benchmark_vector_store.py
+++ b/scripts/benchmark_vector_store.py
@@ -20,6 +20,7 @@ def main() -> None:
     parser.add_argument("--dim", type=int, default=DEF_DIM, help="Vector dimension")
     parser.add_argument("--num-vectors", type=int, default=DEF_NUM_VECTORS, help="Number of vectors")
     parser.add_argument("--num-queries", type=int, default=DEF_QUERIES, help="Number of queries")
+    parser.add_argument("--runs", type=int, default=1, help="Number of runs")
     args = parser.parse_args()
 
     if args.use_gpu and not hasattr(faiss, "StandardGpuResources"):
@@ -30,10 +31,11 @@ def main() -> None:
         dim=args.dim,
         num_vectors=args.num_vectors,
         num_queries=args.num_queries,
+        runs=args.runs,
     )
     mode = "GPU" if args.use_gpu else "CPU"
     print(
-        f"Build time: {result['build_time']:.3f}s\n"
+        f"Average build time: {result['avg_build_time']:.3f}s\n"
         f"Average latency ({mode}): {result['avg_query_latency']:.6f}s per query"
     )
 

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -34,7 +34,7 @@ from pydantic import BaseModel
 from .audit import get_audit_entries
 from .rbac_adapter import AccessDeniedError
 from .graph_adapter import IGraphAdapter
-from . import VectorStore, create_default_store
+from . import VectorStore, create_vector_store
 from .api_deps import (
     POLICY_DIR,  # noqa: F401 re-exported for tests
     TOKENS,

--- a/src/ume/vector_routes.py
+++ b/src/ume/vector_routes.py
@@ -48,6 +48,7 @@ def api_benchmark_vectors(
     use_gpu: bool = Query(False),
     num_vectors: int = 1000,
     num_queries: int = 100,
+    runs: int = 1,
     _: str = Depends(deps.get_current_role),
     store: VectorStore = Depends(deps.get_vector_store),
 ) -> Dict[str, Any]:
@@ -59,5 +60,6 @@ def api_benchmark_vectors(
         dim=store.dim,
         num_vectors=num_vectors,
         num_queries=num_queries,
+        runs=runs,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 # Stub optional dependencies so importing ume modules doesn't fail when they
 # aren't installed. Tests that rely on these packages will provide their own
 # implementations.
-sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+try:  # use real httpx if available for API tests
+    import httpx as _real_httpx  # noqa: F401
+except Exception:  # pragma: no cover - httpx optional in many tests
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
 yaml_stub = types.ModuleType("yaml")
 yaml_stub.safe_load = lambda _: {}
 sys.modules.setdefault("yaml", yaml_stub)
@@ -44,8 +47,15 @@ class _DummyMetric:  # pragma: no cover - simple stub
 prom_stub.Counter = _DummyMetric  # type: ignore[attr-defined]
 prom_stub.Histogram = _DummyMetric  # type: ignore[attr-defined]
 prom_stub.Gauge = _DummyMetric  # type: ignore[attr-defined]
-sys.modules.setdefault("prometheus_client", prom_stub)
-sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+try:  # use real prometheus_client if available
+    import prometheus_client as _real_prom  # noqa: F401
+    sys.modules.setdefault("prometheus_client", _real_prom)
+except Exception:  # pragma: no cover - optional for most tests
+    sys.modules.setdefault("prometheus_client", prom_stub)
+try:  # use real numpy if available for vector benchmark tests
+    import numpy as _real_numpy  # noqa: F401
+except Exception:  # pragma: no cover - numpy optional for most tests
+    sys.modules.setdefault("numpy", types.ModuleType("numpy"))
 jsonschema_stub = types.ModuleType("jsonschema")
 class _ValidationError(Exception):
     pass

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -21,8 +21,8 @@ def test_benchmark_vector_store_structure():
     res = benchmarks.benchmark_vector_store(
         use_gpu=False, dim=2, num_vectors=10, num_queries=5
     )
-    assert set(res.keys()) == {"build_time", "avg_query_latency"}
-    assert isinstance(res["build_time"], float)
+    assert set(res.keys()) == {"avg_build_time", "avg_query_latency"}
+    assert isinstance(res["avg_build_time"], float)
     assert isinstance(res["avg_query_latency"], float)
 
 
@@ -39,5 +39,5 @@ def test_run_benchmarks_csv(tmp_path):
     assert len(results) == 2
     with csv_path.open() as f:
         header = next(csv.reader(f))
-        assert header == ["run", "build_time", "avg_query_latency"]
+        assert header == ["run", "avg_build_time", "avg_query_latency"]
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -245,5 +245,5 @@ def test_cli_benchmark_vectors():
     if not hasattr(faiss, "IndexFlatL2"):
         pytest.skip("faiss is missing required functionality")
     stdout, stderr, rc = run_cli_commands(["benchmark_vectors --num-vectors 10 --num-queries 2", "exit"])
-    assert "Index build time" in stdout
+    assert "Avg build time" in stdout
     assert rc == 0

--- a/tests/test_vector_api.py
+++ b/tests/test_vector_api.py
@@ -103,7 +103,7 @@ def test_benchmark_endpoint():
     )
     assert res.status_code == 200
     data = res.json()
-    assert "build_time" in data and "avg_query_latency" in data
+    assert "avg_build_time" in data and "avg_query_latency" in data
 
 
 def test_benchmark_requires_authentication() -> None:

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -367,6 +367,7 @@ class UMEPrompt(Cmd):
         parser.add_argument("--gpu", action="store_true")
         parser.add_argument("--num-vectors", type=int, default=1000)
         parser.add_argument("--num-queries", type=int, default=100)
+        parser.add_argument("--runs", type=int, default=1)
         try:
             opts = parser.parse_args(shlex.split(arg))
         except SystemExit:
@@ -376,9 +377,10 @@ class UMEPrompt(Cmd):
             dim=settings.UME_VECTOR_DIM,
             num_vectors=opts.num_vectors,
             num_queries=opts.num_queries,
+            runs=opts.runs,
         )
         print(
-            f"Index build time: {result['build_time']:.2f}s, "
+            f"Avg build time: {result['avg_build_time']:.2f}s, "
             f"Avg query latency: {result['avg_query_latency']*1000:.3f}ms"
         )
 


### PR DESCRIPTION
## Summary
- report avg build time and query latency in `benchmark_vector_store`
- add runs option to benchmark CLI and script
- expose avg metrics via `/vectors/benchmark`
- document vector benchmark usage
- use real dependencies in tests when installed

## Testing
- `pre-commit run --files tests/conftest.py scripts/benchmark_vector_store.py src/ume/benchmarks.py src/ume/vector_routes.py ume_cli.py tests/test_benchmarks.py tests/test_cli_smoke.py tests/test_vector_api.py src/ume/api.py`
- `pytest tests/test_benchmarks.py tests/test_vector_api.py tests/test_cli_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6864538f74108326afea4e2131f4559f