### PR TITLE
fix: stub optional deps for tests

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -266,8 +266,6 @@ __all__ = [
     "ResourceScheduler",
     "ScheduledTask",
     "TweetBot",
-    "ResourceScheduler",
-    "ScheduledTask",
 
     # Submodules
     "audit",

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -34,7 +34,7 @@ from pydantic import BaseModel
 from .audit import get_audit_entries
 from .rbac_adapter import AccessDeniedError
 from .graph_adapter import IGraphAdapter
-from . import VectorStore, create_default_store
+from . import VectorStore, create_vector_store
 from .api_deps import (
     POLICY_DIR,  # noqa: F401 re-exported for tests
     TOKENS,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 import types
+import importlib
 from pathlib import Path
 import os
 
@@ -23,10 +24,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 # Stub optional dependencies so importing ume modules doesn't fail when they
 # aren't installed. Tests that rely on these packages will provide their own
 # implementations.
-sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+if importlib.util.find_spec("httpx") is None:
+    sys.modules.setdefault("httpx", types.ModuleType("httpx"))
+
 yaml_stub = types.ModuleType("yaml")
 yaml_stub.safe_load = lambda _: {}
-sys.modules.setdefault("yaml", yaml_stub)
+if importlib.util.find_spec("yaml") is None:
+    sys.modules.setdefault("yaml", yaml_stub)
+
 prom_stub = types.ModuleType("prometheus_client")
 class _DummyMetric:  # pragma: no cover - simple stub
     def __init__(self, *_: object, **__: object) -> None:
@@ -44,8 +49,12 @@ class _DummyMetric:  # pragma: no cover - simple stub
 prom_stub.Counter = _DummyMetric  # type: ignore[attr-defined]
 prom_stub.Histogram = _DummyMetric  # type: ignore[attr-defined]
 prom_stub.Gauge = _DummyMetric  # type: ignore[attr-defined]
-sys.modules.setdefault("prometheus_client", prom_stub)
-sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+if importlib.util.find_spec("prometheus_client") is None:
+    sys.modules.setdefault("prometheus_client", prom_stub)
+
+if importlib.util.find_spec("numpy") is None:
+    sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+
 jsonschema_stub = types.ModuleType("jsonschema")
 class _ValidationError(Exception):
     pass
@@ -55,7 +64,31 @@ def _validate(*_: object, **__: object) -> None:
 
 jsonschema_stub.validate = _validate  # type: ignore[attr-defined]
 jsonschema_stub.ValidationError = _ValidationError  # type: ignore[attr-defined]
-sys.modules.setdefault("jsonschema", jsonschema_stub)
+if importlib.util.find_spec("jsonschema") is None:
+    sys.modules.setdefault("jsonschema", jsonschema_stub)
+
+# Additional optional packages used in some modules. These are large or
+# platform-specific dependencies that aren't needed for most unit tests, so we
+# provide lightweight stubs when they aren't installed.
+_OPTIONAL_PACKAGES = [
+    "confluent_kafka",
+    "structlog",
+    "neo4j",
+]
+
+for _package in _OPTIONAL_PACKAGES:
+    if importlib.util.find_spec(_package) is None:
+        module = types.ModuleType(_package)
+        if _package == "confluent_kafka":
+            class _Dummy:
+                pass
+
+            module.Consumer = _Dummy
+            module.Producer = _Dummy
+            module.KafkaError = _Dummy
+            module.KafkaException = Exception
+            module.Message = _Dummy
+        sys.modules.setdefault(_package, module)
 
 try:
     from ume.pipeline import privacy_agent as privacy_agent_module

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -62,6 +62,7 @@ def dummy_create() -> DummyVS:
     return DummyVS()
 
 package.VectorStore = DummyVS  # type: ignore[attr-defined]
+package.create_vector_store = dummy_create  # type: ignore[attr-defined]
 package.create_default_store = dummy_create  # type: ignore[attr-defined]
 spec_api = importlib.util.spec_from_file_location("ume.api", root / "src" / "ume" / "api.py")
 assert spec_api and spec_api.loader


### PR DESCRIPTION
## Summary
- stub optional dependencies in `tests/conftest.py`
- provide dummy classes for `confluent_kafka` when not installed

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini`
- `pytest tests/test_metrics.py::test_http_metrics_recorded -q`


------
https://chatgpt.com/codex/tasks/task_e_6864515b6e248326b2c2c3a6d40c9940