### PR TITLE
Add watcher and CLI tests

### DIFF
--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -1,0 +1,37 @@
+import logging
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tests.test_dev_log_watcher import load_dev_log_watcher
+
+
+def test_on_modified_ignores_directory(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    dev_log_watcher = load_dev_log_watcher(monkeypatch)
+    messages: list[bytes] = []
+
+    class Producer:
+        def produce(self, topic: str, data: bytes) -> None:
+            messages.append(data)
+
+    handler = dev_log_watcher.DevLogHandler(Producer())
+    event = SimpleNamespace(src_path=str(tmp_path), is_directory=True)
+    handler.on_modified(event)
+
+    assert messages == []
+
+
+def test_on_modified_logs_error(tmp_path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    dev_log_watcher = load_dev_log_watcher(monkeypatch)
+
+    class Producer:
+        def produce(self, *_: Any, **__: Any) -> None:
+            raise dev_log_watcher.KafkaException("boom")
+
+    handler = dev_log_watcher.DevLogHandler(Producer())
+    caplog.set_level(logging.ERROR)
+    event = SimpleNamespace(src_path=str(tmp_path / "file.txt"), is_directory=False)
+    handler.on_modified(event)
+
+    assert any("Failed to produce dev log event" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- test DevLogHandler processing errors and directory events
- extend CLI smoke tests for invalid JSON and sync
- support env overrides for CLI smoke helper

## Testing
- `pre-commit run --files tests/test_cli_smoke.py tests/test_watchers.py`
- `pytest tests/test_watchers.py tests/test_cli_smoke.py::test_cli_new_node_invalid_json tests/test_cli_smoke.py::test_cli_sync_without_peer tests/test_cli_smoke.py::test_cli_set_peer_and_sync_calls_replicator --maxfail=1 --cov=ume_cli --cov=src`

------
https://chatgpt.com/codex/tasks/task_e_6864923ea42c8326af0d08f30e8d134b