### PR TITLE
Add graph snapshot routes

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -47,6 +47,14 @@ Create an edge.
 ### DELETE `/edges/{source}/{target}/{label}`
 Delete an edge.
 
+### POST `/snapshot/save`
+Write the entire graph state to a JSON file.
+- **Body**: `{"path": "file.json"}`
+
+### POST `/snapshot/load`
+Replace the current graph with the contents of a snapshot file.
+- **Body**: `{"path": "file.json"}`
+
 ### GET `/policies`
 List available Rego policy files.
 

--- a/tests/test_api_snapshot.py
+++ b/tests/test_api_snapshot.py
@@ -1,0 +1,70 @@
+import os
+from pathlib import Path
+from fastapi.testclient import TestClient
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return str(res.json()["access_token"])
+
+
+def setup_module(_: object) -> None:
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+
+
+def test_snapshot_roundtrip(tmp_path: Path) -> None:
+    g = MockGraph()
+    g.add_node("a", {"x": 1})
+    g.add_node("b", {"y": 2})
+    g.add_edge("a", "b", "L")
+    configure_graph(g)
+
+    client = TestClient(app)
+    token = _token(client)
+    snap = tmp_path / "snap.json"
+
+    res_save = client.post(
+        "/snapshot/save",
+        json={"path": str(snap)},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res_save.status_code == 200
+    assert snap.is_file()
+
+    g.clear()
+    assert g.get_all_node_ids() == []
+
+    res_load = client.post(
+        "/snapshot/load",
+        json={"path": str(snap)},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res_load.status_code == 200
+    assert set(g.get_all_node_ids()) == {"a", "b"}
+    assert ("a", "b", "L") in g.get_all_edges()
+
+
+def test_snapshot_requires_analytics_role(tmp_path: Path) -> None:
+    g = MockGraph()
+    configure_graph(g)
+
+    client = TestClient(app)
+    orig_role = settings.UME_OAUTH_ROLE
+    os.environ["UME_OAUTH_ROLE"] = "AutoDev"
+    settings.UME_OAUTH_ROLE = "AutoDev"
+    token = _token(client)
+    os.environ["UME_OAUTH_ROLE"] = orig_role or ""
+    settings.UME_OAUTH_ROLE = orig_role
+
+    res = client.post(
+        "/snapshot/save",
+        json={"path": str(tmp_path / "s.json")},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- add `/snapshot/save` and `/snapshot/load` routes
- wire routes to snapshot helpers
- protect snapshot operations with an AnalyticsAgent role check
- document snapshot endpoints
- test snapshot API end-to-end

## Testing
- `ruff check src/ume/graph_routes.py tests/test_api_snapshot.py --fix`
- `pytest tests/test_api_snapshot.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6864923d8c188326ab08218b7bfdced8