### PR TITLE
Add Postgres and Redis graph backends

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 120
+        "line_number": 145
       }
     ],
     "tests/test_anonymizer.py": [
@@ -146,5 +146,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-02T01:22:42Z"
+  "generated_at": "2025-07-02T02:04:23Z"
 }

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -59,6 +59,7 @@ below lists all available variables and their default values.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `UME_DB_PATH` | `ume_graph.db` | SQLite database used by `PersistentGraph`. |
+| `UME_GRAPH_BACKEND` | `sqlite` | Backend for graph storage (`sqlite`, `postgres`, or `redis`). |
 | `UME_SNAPSHOT_PATH` | `ume_snapshot.json` | Path to graph snapshot file. |
 | `UME_AUDIT_LOG_PATH` | `audit.log` | Location of the audit log. |
 | `UME_AUDIT_SIGNING_KEY` | `default-key` | Key used to sign audit entries. Must be changed from the default or startup will fail. |

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -84,6 +84,8 @@ except Exception:  # pragma: no cover - allow import without environment setup
 from .event import Event, EventType, parse_event, EventError
 from .graph import MockGraph
 from .persistent_graph import PersistentGraph
+from .postgres_graph import PostgresGraph
+from .redis_graph_adapter import RedisGraphAdapter
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
@@ -200,6 +202,8 @@ __all__ = [
     "EventError",
     "MockGraph",
     "PersistentGraph",
+    "PostgresGraph",
+    "RedisGraphAdapter",
     "Neo4jGraph",
     "IGraphAdapter",
     "RoleBasedGraphAdapter",

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
 
     # UME Core
     UME_DB_PATH: str = "ume_graph.db"
+    UME_GRAPH_BACKEND: str = "sqlite"  # sqlite, postgres, or redis
     UME_SNAPSHOT_PATH: str = "ume_snapshot.json"
     UME_COLD_DB_PATH: str = "ume_cold.db"
     UME_COLD_SNAPSHOT_PATH: str = "ume_cold_snapshot.json"

--- a/src/ume/postgres_graph.py
+++ b/src/ume/postgres_graph.py
@@ -1,0 +1,236 @@
+"""PostgreSQL-backed graph adapter."""
+from __future__ import annotations
+
+import importlib
+import json
+import time
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+from .graph_adapter import IGraphAdapter
+from .processing import ProcessingError
+from .graph_algorithms import GraphAlgorithmsMixin
+from .audit import log_audit_entry
+from .config import settings
+
+_spec = importlib.util.find_spec("psycopg")
+psycopg = importlib.import_module("psycopg") if _spec is not None else None
+
+
+class PostgresGraph(GraphAlgorithmsMixin, IGraphAdapter):
+    """Graph adapter using PostgreSQL via psycopg."""
+
+    def __init__(self, dsn: str | None = None) -> None:
+        if psycopg is None:
+            raise ImportError("psycopg is required for PostgresGraph")
+        self._dsn = dsn or settings.UME_DB_PATH
+        self._conn = psycopg.connect(self._dsn, autocommit=True)
+        self._create_tables()
+
+    def _create_tables(self) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS nodes (
+                    id TEXT PRIMARY KEY,
+                    attributes JSONB,
+                    redacted BOOLEAN DEFAULT FALSE,
+                    created_at BIGINT DEFAULT EXTRACT(EPOCH FROM NOW())
+                )
+                """
+            )
+            cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS edges (
+                    source TEXT,
+                    target TEXT,
+                    label TEXT,
+                    redacted BOOLEAN DEFAULT FALSE,
+                    created_at BIGINT DEFAULT EXTRACT(EPOCH FROM NOW()),
+                    PRIMARY KEY (source, target, label)
+                )
+                """
+            )
+            cur.execute("CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source)")
+            cur.execute("CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target)")
+
+    # ---- Resource management -------------------------------------------------
+    def close(self) -> None:
+        self._conn.close()
+
+    # ---- Node methods -------------------------------------------------------
+    def add_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM nodes WHERE id=%s AND redacted=false",
+                (node_id,),
+            )
+            if cur.fetchone() is not None:
+                raise ProcessingError(f"Node '{node_id}' already exists.")
+            cur.execute(
+                "INSERT INTO nodes(id, attributes, created_at) VALUES(%s, %s, %s)",
+                (node_id, json.dumps(attributes), int(time.time())),
+            )
+
+    def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT attributes FROM nodes WHERE id=%s AND redacted=false",
+                (node_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise ProcessingError(f"Node '{node_id}' not found for update.")
+            data = json.loads(row[0])
+            data.update(attributes)
+            cur.execute(
+                "UPDATE nodes SET attributes=%s WHERE id=%s",
+                (json.dumps(data), node_id),
+            )
+
+    def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT attributes FROM nodes WHERE id=%s AND redacted=false",
+                (node_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return None
+            return cast(Dict[str, Any], json.loads(row[0]))
+
+    def node_exists(self, node_id: str) -> bool:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM nodes WHERE id=%s AND redacted=false",
+                (node_id,),
+            )
+            return cur.fetchone() is not None
+
+    def get_all_node_ids(self) -> List[str]:
+        with self._conn.cursor() as cur:
+            cur.execute("SELECT id FROM nodes WHERE redacted=false")
+            return [row[0] for row in cur.fetchall()]
+
+    def dump(self) -> Dict[str, Any]:
+        nodes: Dict[str, Any] = {}
+        with self._conn.cursor() as cur:
+            cur.execute("SELECT id, attributes FROM nodes WHERE redacted=false")
+            for nid, attrs in cur.fetchall():
+                nodes[nid] = json.loads(attrs)
+        edges = self.get_all_edges()
+        return {"nodes": nodes, "edges": edges}
+
+    def clear(self) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute("TRUNCATE edges")
+            cur.execute("TRUNCATE nodes")
+
+    # ---- Edge methods -------------------------------------------------------
+    def add_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        if not self.node_exists(source_node_id) or not self.node_exists(target_node_id):
+            raise ProcessingError(
+                f"Both source node '{source_node_id}' and target node '{target_node_id}' must exist to add an edge."
+            )
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM edges WHERE source=%s AND target=%s AND label=%s",
+                (source_node_id, target_node_id, label),
+            )
+            if cur.fetchone() is not None:
+                raise ProcessingError(
+                    f"Edge ({source_node_id}, {target_node_id}, {label}) already exists."
+                )
+            cur.execute(
+                "INSERT INTO edges(source, target, label, created_at) VALUES(%s, %s, %s, %s)",
+                (source_node_id, target_node_id, label, int(time.time())),
+            )
+
+    def get_all_edges(self) -> List[Tuple[str, str, str]]:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT e.source, e.target, e.label
+                FROM edges e
+                JOIN nodes s ON e.source = s.id
+                JOIN nodes t ON e.target = t.id
+                WHERE e.redacted=false AND s.redacted=false AND t.redacted=false
+                """
+            )
+            return [(row[0], row[1], row[2]) for row in cur.fetchall()]
+
+    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "DELETE FROM edges WHERE source=%s AND target=%s AND label=%s",
+                (source_node_id, target_node_id, label),
+            )
+            if cur.rowcount == 0:
+                edge_tuple = (source_node_id, target_node_id, label)
+                raise ProcessingError(
+                    f"Edge {edge_tuple} does not exist and cannot be deleted."
+                )
+
+    def find_connected_nodes(self, node_id: str, edge_label: Optional[str] = None) -> List[str]:
+        if not self.node_exists(node_id):
+            raise ProcessingError(f"Node '{node_id}' not found.")
+        with self._conn.cursor() as cur:
+            if edge_label:
+                cur.execute(
+                    """
+                    SELECT e.target FROM edges e
+                    JOIN nodes s ON e.source = s.id
+                    JOIN nodes t ON e.target = t.id
+                    WHERE e.source=%s AND e.label=%s
+                      AND e.redacted=false AND s.redacted=false AND t.redacted=false
+                    """,
+                    (node_id, edge_label),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT e.target FROM edges e
+                    JOIN nodes s ON e.source = s.id
+                    JOIN nodes t ON e.target = t.id
+                    WHERE e.source=%s AND e.redacted=false AND s.redacted=false AND t.redacted=false
+                    """,
+                    (node_id,),
+                )
+            return [row[0] for row in cur.fetchall()]
+
+    # ---- Redaction ----------------------------------------------------------
+    def redact_node(self, node_id: str) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE nodes SET redacted=true WHERE id=%s",
+                (node_id,),
+            )
+            if cur.rowcount == 0:
+                raise ProcessingError(f"Node '{node_id}' not found to redact.")
+        log_audit_entry(settings.UME_AGENT_ID, f"redact_node {node_id}")
+
+    def redact_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE edges SET redacted=true WHERE source=%s AND target=%s AND label=%s",
+                (source_node_id, target_node_id, label),
+            )
+            if cur.rowcount == 0:
+                edge_tuple = (source_node_id, target_node_id, label)
+                raise ProcessingError(
+                    f"Edge {edge_tuple} does not exist and cannot be redacted."
+                )
+        log_audit_entry(settings.UME_AGENT_ID, f"redact_edge {source_node_id} {target_node_id} {label}")
+
+    # ---- Misc utilities -----------------------------------------------------
+    def purge_old_records(self, max_age_seconds: int) -> None:
+        cutoff = int(time.time()) - max_age_seconds - 1
+        with self._conn.cursor() as cur:
+            cur.execute("DELETE FROM edges WHERE created_at < %s", (cutoff,))
+            cur.execute(
+                "DELETE FROM edges WHERE source IN (SELECT id FROM nodes WHERE created_at < %s)"
+                " OR target IN (SELECT id FROM nodes WHERE created_at < %s)",
+                (cutoff, cutoff),
+            )
+            cur.execute("DELETE FROM nodes WHERE created_at < %s", (cutoff,))
+
+

--- a/src/ume/redis_graph_adapter.py
+++ b/src/ume/redis_graph_adapter.py
@@ -1,0 +1,154 @@
+"""Redis-backed implementation of :class:`IGraphAdapter`."""
+from __future__ import annotations
+
+import importlib
+import json
+from typing import Any, Dict, List, Optional, Tuple, cast
+
+from .graph_adapter import IGraphAdapter
+from .processing import ProcessingError
+from .graph_algorithms import GraphAlgorithmsMixin
+from .audit import log_audit_entry
+from .config import settings
+
+_spec = importlib.util.find_spec("redis")
+redis = importlib.import_module("redis") if _spec is not None else None
+
+
+class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
+    """Simple graph adapter using Redis hashes and sets."""
+
+    def __init__(self, url: str | None = None) -> None:
+        if redis is None:
+            raise ImportError("redis is required for RedisGraphAdapter")
+        self._url = url or settings.UME_DB_PATH
+        self._client = redis.from_url(self._url)
+
+    # ---- Utility ------------------------------------------------------------
+    def close(self) -> None:
+        try:
+            self._client.close()
+        except Exception:  # pragma: no cover - connection closing best-effort
+            pass
+
+    def clear(self) -> None:
+        self._client.flushdb()
+
+    # ---- Node methods -------------------------------------------------------
+    def _node_key(self, node_id: str) -> str:
+        return f"node:{node_id}"
+
+    def add_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        if self.node_exists(node_id):
+            raise ProcessingError(f"Node '{node_id}' already exists.")
+        self._client.set(self._node_key(node_id), json.dumps(attributes))
+
+    def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        data = self.get_node(node_id)
+        if data is None:
+            raise ProcessingError(f"Node '{node_id}' not found for update.")
+        data.update(attributes)
+        self._client.set(self._node_key(node_id), json.dumps(data))
+
+    def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        if self._client.sismember("redacted_nodes", node_id):
+            return None
+        raw = self._client.get(self._node_key(node_id))
+        if raw is None:
+            return None
+        return cast(Dict[str, Any], json.loads(raw))
+
+    def node_exists(self, node_id: str) -> bool:
+        return self._client.exists(self._node_key(node_id)) == 1 and not self._client.sismember(
+            "redacted_nodes", node_id
+        )
+
+    def get_all_node_ids(self) -> List[str]:
+        keys = self._client.keys("node:*")
+        return [k.decode().split(":", 1)[1] for k in keys if not self._client.sismember("redacted_nodes", k.decode().split(":", 1)[1])]
+
+    def dump(self) -> Dict[str, Any]:
+        nodes: Dict[str, Any] = {}
+        for k in self._client.keys("node:*"):
+            node_id = k.decode().split(":", 1)[1]
+            if self._client.sismember("redacted_nodes", node_id):
+                continue
+            raw = self._client.get(k)
+            if raw is not None:
+                nodes[node_id] = json.loads(raw)
+        edges = self.get_all_edges()
+        return {"nodes": nodes, "edges": edges}
+
+    # ---- Edge methods -------------------------------------------------------
+    def _edge_member(self, source: str, target: str, label: str) -> str:
+        return f"{source}|{target}|{label}"
+
+    def add_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        if not self.node_exists(source_node_id) or not self.node_exists(target_node_id):
+            raise ProcessingError(
+                f"Both source node '{source_node_id}' and target node '{target_node_id}' must exist to add an edge."
+            )
+        member = self._edge_member(source_node_id, target_node_id, label)
+        if self._client.sismember("edges", member):
+            raise ProcessingError(
+                f"Edge ({source_node_id}, {target_node_id}, {label}) already exists."
+            )
+        self._client.sadd("edges", member)
+
+    def get_all_edges(self) -> List[Tuple[str, str, str]]:
+        result = []
+        for b in self._client.smembers("edges"):
+            member = b.decode()
+            if self._client.sismember("redacted_edges", member):
+                continue
+            src, tgt, lbl = member.split("|", 2)
+            if self._client.sismember("redacted_nodes", src) or self._client.sismember("redacted_nodes", tgt):
+                continue
+            result.append((src, tgt, lbl))
+        return result
+
+    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        member = self._edge_member(source_node_id, target_node_id, label)
+        if self._client.srem("edges", member) == 0:
+            raise ProcessingError(
+                f"Edge {(source_node_id, target_node_id, label)} does not exist and cannot be deleted."
+            )
+        self._client.srem("redacted_edges", member)
+
+    def find_connected_nodes(self, node_id: str, edge_label: Optional[str] = None) -> List[str]:
+        if not self.node_exists(node_id):
+            raise ProcessingError(f"Node '{node_id}' not found.")
+        connected: List[str] = []
+        for b in self._client.smembers("edges"):
+            member = b.decode()
+            src, tgt, lbl = member.split("|", 2)
+            if src != node_id:
+                continue
+            if edge_label is not None and lbl != edge_label:
+                continue
+            if self._client.sismember("redacted_edges", member):
+                continue
+            if self._client.sismember("redacted_nodes", tgt):
+                continue
+            connected.append(tgt)
+        return connected
+
+    # ---- Redaction ----------------------------------------------------------
+    def redact_node(self, node_id: str) -> None:
+        if not self.node_exists(node_id):
+            raise ProcessingError(f"Node '{node_id}' not found to redact.")
+        self._client.sadd("redacted_nodes", node_id)
+        log_audit_entry(settings.UME_AGENT_ID, f"redact_node {node_id}")
+
+    def redact_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        member = self._edge_member(source_node_id, target_node_id, label)
+        if not self._client.sismember("edges", member):
+            raise ProcessingError(
+                f"Edge {(source_node_id, target_node_id, label)} does not exist and cannot be redacted."
+            )
+        self._client.sadd("redacted_edges", member)
+        log_audit_entry(
+            settings.UME_AGENT_ID,
+            f"redact_edge {source_node_id} {target_node_id} {label}",
+        )
+

--- a/tests/test_graph_adapters_integration.py
+++ b/tests/test_graph_adapters_integration.py
@@ -1,0 +1,39 @@
+import os
+import pytest
+
+from ume.postgres_graph import PostgresGraph
+from ume.redis_graph_adapter import RedisGraphAdapter
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("UME_DOCKER_TESTS"), reason="Docker tests disabled")
+def test_postgres_graph_crud(postgres_service):
+    graph = PostgresGraph(postgres_service["dsn"])
+    graph.add_node("n1", {"v": 1})
+    assert graph.get_node("n1") == {"v": 1}
+    graph.update_node("n1", {"v": 2})
+    assert graph.get_node("n1") == {"v": 2}
+    graph.add_node("n2", {})
+    graph.add_edge("n1", "n2", "R")
+    assert ("n1", "n2", "R") in graph.get_all_edges()
+    graph.delete_edge("n1", "n2", "R")
+    assert graph.get_all_edges() == []
+    graph.clear()
+    graph.close()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("UME_DOCKER_TESTS"), reason="Docker tests disabled")
+def test_redis_graph_crud(redis_service):
+    graph = RedisGraphAdapter(redis_service["url"])
+    graph.add_node("n1", {"v": 1})
+    assert graph.get_node("n1") == {"v": 1}
+    graph.update_node("n1", {"v": 2})
+    assert graph.get_node("n1") == {"v": 2}
+    graph.add_node("n2", {})
+    graph.add_edge("n1", "n2", "R")
+    assert ("n1", "n2", "R") in graph.get_all_edges()
+    graph.delete_edge("n1", "n2", "R")
+    assert graph.get_all_edges() == []
+    graph.clear()
+    graph.close()


### PR DESCRIPTION
## Summary
- implement `PostgresGraph` and `RedisGraphAdapter`
- allow `create_graph_adapter` to select backend from settings
- document `UME_GRAPH_BACKEND`
- support containers for Postgres and Redis in tests
- add CRUD tests for new adapters

## Testing
- `pre-commit run --files docs/CONFIG_TEMPLATES.md src/ume/config.py src/ume/factories.py src/ume/__init__.py src/ume/postgres_graph.py src/ume/redis_graph_adapter.py tests/conftest.py tests/test_graph_adapters_integration.py`
- `pytest tests/test_graph_adapters_integration.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6864922e227883269d9afb8571a6f85d