### PR TITLE
Enforce audit key on import

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ evaluates them using the built-in `RegoPolicyEngine`. Policies should define
 - Python **3.10** or newer
 - Poetry (https://python-poetry.org)
 - Docker & Docker Compose
+- A non-default `UME_AUDIT_SIGNING_KEY` environment variable
 - See [docs/WINDOWS_QUICKSTART.md](docs/WINDOWS_QUICKSTART.md) for Windows-specific instructions
 
 ### 1. Install Python Dependencies

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -3,7 +3,6 @@
 # ruff: noqa: E402
 
 import importlib  # noqa: E402
-import os  # noqa: E402
 import sys  # noqa: E402
 import types  # noqa: E402
 from types import SimpleNamespace
@@ -12,12 +11,11 @@ def _make_stub(name: str) -> types.ModuleType:
     stub = types.ModuleType(name)
     return stub
 
-os.environ.setdefault("UME_AUDIT_SIGNING_KEY", "stub")
 try:  # Expose config for tests as early as possible
     config = importlib.import_module(".config", __name__)
     Settings = config.Settings
     setattr(sys.modules[__name__], "config", config)
-except Exception:  # pragma: no cover - allow import without environment setup
+except ImportError:  # pragma: no cover - allow import without environment setup
     stub = _make_stub("ume.config")
     sys.modules["ume.config"] = stub
     stub.settings = SimpleNamespace(  # type: ignore[attr-defined]

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -3,6 +3,9 @@ from pydantic import Extra
 from typing import Any
 
 
+DEFAULT_AUDIT_SIGNING_KEY = "default-key"
+
+
 class Settings(BaseSettings):  # type: ignore[misc]
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", extra=Extra.ignore
@@ -15,7 +18,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_COLD_SNAPSHOT_PATH: str = "ume_cold_snapshot.json"
     UME_COLD_EVENT_AGE_DAYS: int = 180
     UME_AUDIT_LOG_PATH: str = "audit.log"
-    UME_AUDIT_SIGNING_KEY: str = "default-key"
+    UME_AUDIT_SIGNING_KEY: str = DEFAULT_AUDIT_SIGNING_KEY
     UME_CONSENT_LEDGER_PATH: str = "consent_ledger.db"
     UME_FEEDBACK_DB_PATH: str = "feedback.db"
     UME_AGENT_ID: str = "SYSTEM"
@@ -86,7 +89,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
 
     def model_post_init(self, __context: Any) -> None:  # noqa: D401
         """Validate settings after initialization."""
-        if self.UME_AUDIT_SIGNING_KEY == "default-key":
+        if self.UME_AUDIT_SIGNING_KEY == DEFAULT_AUDIT_SIGNING_KEY:
             raise ValueError("UME_AUDIT_SIGNING_KEY must be set to a non-default value")
 
 

--- a/tests/test_import_no_key.py
+++ b/tests/test_import_no_key.py
@@ -1,0 +1,15 @@
+import importlib
+import sys
+import pytest
+
+
+def test_import_without_key(monkeypatch):
+    monkeypatch.delenv("UME_AUDIT_SIGNING_KEY", raising=False)
+    sys.modules.pop("ume", None)
+    sys.modules.pop("ume.config", None)
+    with pytest.raises(ValueError):
+        importlib.import_module("ume")
+    # Restore for other tests
+    monkeypatch.setenv("UME_AUDIT_SIGNING_KEY", "test-key")
+    sys.modules.pop("ume", None)
+    importlib.import_module("ume")


### PR DESCRIPTION
## Summary
- remove default `UME_AUDIT_SIGNING_KEY` fallback and only stub config on ImportError
- add constant for the default audit key in `Settings`
- document required environment variable in README quickstart
- test that importing UME without the key raises `ValueError`

## Testing
- `pre-commit run --files src/ume/__init__.py src/ume/config.py README.md tests/test_import_no_key.py`
- `pytest tests/test_import_no_key.py tests/test_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6864922b655883268a6773bc3a9b80f9