### PR TITLE
Add docker compose commands to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,16 @@ See [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) for the full list of available
 settings.
 
 ### 2. Start Redpanda (Kafka) via Docker
-The `docker/docker-compose.yml` file spins up the broker. From the repository
-root you can start it with:
+The `docker/docker-compose.yml` file spins up the broker. You can launch the
+stack directly using the CLI:
+```bash
+ume-cli up
+```
+To stop all containers run:
+```bash
+ume-cli down
+```
+If you prefer to call Docker Compose manually:
 ```bash
 cd docker && docker compose up -d
 ```


### PR DESCRIPTION
## Summary
- launch the UME stack with `ume-cli up`
- wait for healthchecks and print useful URLs
- stop the stack with `ume-cli down`
- test new subcommand behavior
- document compose commands in README
- fix test mocking for docker compose output

## Testing
- `pre-commit run --files tests/test_cli_smoke.py ume_cli.py README.md`
- `pytest tests/test_cli_smoke.py::test_cli_up_and_down -q`

------
https://chatgpt.com/codex/tasks/task_e_68654e276f8c8326be5fccd076f14128