### PR TITLE
Update compose docs for API service

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,15 @@ UME_AUDIT_SIGNING_KEY=my-ume-key
 See [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) for the full list of available
 settings.
 
-### 2. Start Redpanda (Kafka) via Docker
-The `docker/docker-compose.yml` file spins up the broker. You can launch the
-stack directly using the CLI:
+### 2. Start the Docker Stack
+The `docker/docker-compose.yml` file now starts Redpanda, the privacy agent **and the API service**.
+Running the stack exposes ready-to-use memory endpoints on `http://localhost:8000`.
+First-time users can spin up the demo stack in one command:
+```bash
+git clone https://github.com/d0tTino/universal-memory-engine.git \
+  && cd universal-memory-engine/docker && docker compose up
+```
+You can also launch everything with the CLI:
 ```bash
 ume-cli up
 ```

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -107,8 +107,9 @@ A single-node Dell PowerEdge R7625 with an EPYC 9254P CPU, 256 GB RAM and four N
 
 ## Docker Compose Quickstart
 
-The repository ships with a `docker-compose.yml` for spinning up Redpanda
-alongside the privacy agent. To start the stack:
+The repository ships with a `docker-compose.yml` for spinning up Redpanda,
+the privacy agent **and the UME API**.  Bringing up the stack exposes the
+memory endpoints under `http://localhost:8000`. To start everything:
 
 1. Install Docker and Docker Compose.
 2. From the project root run:
@@ -118,8 +119,10 @@ alongside the privacy agent. To start the stack:
    bash generate-certs.sh
    docker compose up
    ```
-3. Wait until `redpanda` reports `healthy` with `docker compose ps`.
-4. Inspect logs with `docker compose logs -f privacy-agent`.
-5. Confirm both services report `healthy` with `docker compose ps`.
+3. Wait until all services report `healthy` with `docker compose ps`.
+4. Visit `http://localhost:8000/docs` to explore the API. The `/recall` endpoint
+   is immediately available for querying memory.
+5. Inspect logs with `docker compose logs -f privacy-agent` or
+   `docker compose logs -f api`.
 6. Stop all containers with `docker compose down` when finished.
 


### PR DESCRIPTION
## Summary
- document new API container in Docker Compose quickstart
- clarify that the compose stack exposes memory endpoints
- add a single-line quickstart command for newcomers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686555f1e5d88326ba5de6a4c58fad15