### PR TITLE
Add batch events endpoint and wrapper updates

### DIFF
--- a/src/integrations/langgraph.py
+++ b/src/integrations/langgraph.py
@@ -16,8 +16,17 @@ class LangGraph:
 
     def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
         headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
-        for evt in events:
-            self._client.post(f"{self.base_url}/events", json=evt, headers=headers)
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
 
     def recall(self, payload: Mapping[str, Any]) -> Any:
         headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}

--- a/src/integrations/letta.py
+++ b/src/integrations/letta.py
@@ -16,8 +16,17 @@ class Letta:
 
     def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
         headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
-        for evt in events:
-            self._client.post(f"{self.base_url}/events", json=evt, headers=headers)
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
 
     def recall(self, payload: Mapping[str, Any]) -> Any:
         headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -88,3 +88,17 @@ def test_post_events_batch(client_and_graph) -> None:
     assert res.status_code == 200
     assert g.get_node("n1") == {"text": "a"}
     assert g.get_node("n2") == {"text": "b"}
+
+
+def test_post_events_batch_invalid(client_and_graph) -> None:
+    client, _ = client_and_graph
+    token = _token(client)
+    events = [
+        {"event_type": "CREATE_NODE", "timestamp": "bad"}
+    ]
+    res = client.post(
+        "/events/batch",
+        json=events,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -31,3 +31,11 @@ def test_letta_wrapper_forwards() -> None:
         assert recall.called
         assert result == {"id": 1}
         assert dict(recall.calls.last.request.url.params) == {"id": "1"}
+
+
+def test_wrapper_batch_endpoint() -> None:
+    client = LangGraph(base_url="http://ume")
+    with respx.mock(assert_all_called=True) as mock:
+        batch = mock.post("http://ume/events/batch").mock(return_value=httpx.Response(200))
+        client.send_events([{"foo": "a"}, {"foo": "b"}])
+        assert batch.called


### PR DESCRIPTION
## Summary
- support batch event ingestion in integration wrappers
- expose failure test for `/events/batch`
- add tests for integration wrapper batch logic

## Testing
- `ruff check . --fix`
- `pytest tests/test_api_events.py tests/test_integrations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686555f13ab8832690697f4e2fed9554