### PR TITLE
Update docs for new memory API service

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,12 +345,18 @@ See [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) for the full list of available
 settings.
 
 ### 2. Start the Docker Stack
-The `docker/docker-compose.yml` file starts Redpanda along with the privacy agent
-and FastAPI server. From the repository root run:
+The `docker/docker-compose.yml` file now starts Redpanda, the privacy agent,
+and the `ume-api` service. From the repository root run:
 
 ```bash
 cd docker && docker compose up -d
 ```
+First-time users can launch the stack with a single command:
+```bash
+cd docker && docker compose up
+```
+Once `ume-api` reports `healthy`, memory endpoints are live on
+`http://localhost:8000` (try `/query` or `/events`).
 If you want to enable TLS for the broker and API, generate certificates first:
 ```bash
 bash docker/generate-certs.sh

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -121,9 +121,14 @@ repurposed for a Neo4j container if needed. To start the stack:
    bash generate-certs.sh
    docker compose up
    ```
+   *First-time users can launch everything in one step with:*
+   ```bash
+   cd docker && docker compose up
+   ```
 3. Wait until `redpanda` and `ume-api` report `healthy` with `docker compose ps`.
-4. Inspect logs with `docker compose logs -f ume-api`.
-5. Confirm all services report `healthy` with `docker compose ps`.
+4. Once healthy, the `ume-api` service exposes ready-to-use memory endpoints on `http://localhost:8000` (e.g. `/query`, `/events`, `/recall`).
+5. Inspect logs with `docker compose logs -f ume-api`.
+6. Confirm all services report `healthy` with `docker compose ps`.
 
-6. Stop all containers with `docker compose down` when finished.
+7. Stop all containers with `docker compose down` when finished.
 


### PR DESCRIPTION
## Summary
- clarify that docker compose starts `ume-api`
- mention available memory endpoints on localhost:8000
- show one-liner compose startup

## Testing
- `python scripts/ci_should_run.py`

------
https://chatgpt.com/codex/tasks/task_e_6865d9e459b4832695cdd3304402d688