### PR TITLE
Add event ledger with replay endpoints

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -92,6 +92,13 @@ Incoming events are streamed through Redpanda topics. The Privacy Agent applies
 rules defined in the Policy DSL before forwarding sanitized events to the graph
 adapter layer.
 
+## Event Ledger
+
+Sanitized events are appended to a lightweight ledger along with their
+Redpanda offsets. The ledger can be queried via the `/ledger/events` API and
+used with `PersistentGraph.replay_from_ledger()` to rebuild state from any
+offset.
+
 ## Policy DSL Flow
 
 ```mermaid

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -27,6 +27,7 @@ except ImportError:  # pragma: no cover - allow import without environment setup
         UME_AUDIT_LOG_PATH="/tmp/audit.log",
         UME_AUDIT_SIGNING_KEY="stub",
         UME_CONSENT_LEDGER_PATH="consent_ledger.db",
+        UME_EVENT_LEDGER_PATH="event_ledger.db",
         UME_FEEDBACK_DB_PATH="feedback.db",
         UME_AGENT_ID="SYSTEM",
         UME_EMBED_MODEL="all-MiniLM-L6-v2",

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -41,6 +41,7 @@ from .pii_routes import router as pii_router
 from .recommendations_routes import router as recommendations_router
 from .feedback_routes import router as feedback_router
 from .snapshot_routes import router as snapshot_router
+from .ledger_routes import router as ledger_router
 from .consent_ledger import consent_ledger  # noqa: F401
 
 from . import api_deps
@@ -77,6 +78,7 @@ app.include_router(pii_router)
 app.include_router(recommendations_router)
 app.include_router(feedback_router)
 app.include_router(snapshot_router)
+app.include_router(ledger_router)
 
 
 

--- a/src/ume/config.py
+++ b/src/ume/config.py
@@ -21,6 +21,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_AUDIT_LOG_PATH: str = "audit.log"
     UME_AUDIT_SIGNING_KEY: str = DEFAULT_AUDIT_SIGNING_KEY
     UME_CONSENT_LEDGER_PATH: str = "consent_ledger.db"
+    UME_EVENT_LEDGER_PATH: str = "event_ledger.db"
     UME_FEEDBACK_DB_PATH: str = "feedback.db"
     UME_AGENT_ID: str = "SYSTEM"
     UME_EMBED_MODEL: str = "all-MiniLM-L6-v2"

--- a/src/ume/event_ledger.py
+++ b/src/ume/event_ledger.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Tuple, Optional
+
+from .config import settings
+
+
+class EventLedger:
+    """Persist sanitized events with their Redpanda offsets."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        self.db_path = db_path or settings.UME_EVENT_LEDGER_PATH
+        Path(self.db_path).parent.mkdir(parents=True, exist_ok=True)
+        self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+        self.conn.row_factory = sqlite3.Row
+        self._create_table()
+
+    def _create_table(self) -> None:
+        with self.conn:
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS events (
+                    offset INTEGER PRIMARY KEY,
+                    data TEXT NOT NULL
+                )
+                """
+            )
+
+    def append(self, offset: int, event: Dict[str, Any]) -> None:
+        with self.conn:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO events(offset, data) VALUES (?, ?)",
+                (offset, json.dumps(event)),
+            )
+
+    def range(
+        self,
+        start: int = 0,
+        end: Optional[int] = None,
+        limit: Optional[int] = None,
+    ) -> List[Tuple[int, Dict[str, Any]]]:
+        query = "SELECT offset, data FROM events WHERE offset >= ?"
+        params: List[Any] = [start]
+        if end is not None:
+            query += " AND offset <= ?"
+            params.append(end)
+        query += " ORDER BY offset"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
+        cur = self.conn.execute(query, params)
+        return [
+            (int(row["offset"]), json.loads(row["data"])) for row in cur.fetchall()
+        ]
+
+    def max_offset(self) -> int:
+        cur = self.conn.execute("SELECT MAX(offset) FROM events")
+        row = cur.fetchone()
+        if row and row[0] is not None:
+            return int(row[0])
+        return -1
+
+    def close(self) -> None:
+        self.conn.close()
+
+
+# Global ledger instance used by graph consumers
+event_ledger = EventLedger()

--- a/tests/test_api_ledger.py
+++ b/tests/test_api_ledger.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+from ume.api import app
+from ume.config import settings
+from ume.event_ledger import EventLedger
+
+
+def _token(client):
+    res = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return res.json()["access_token"]
+
+
+def test_list_ledger_events(tmp_path, monkeypatch):
+    path = str(tmp_path / "ledger.db")
+    ledger = EventLedger(path)
+    ledger.append(0, {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {"node_id": "n1"}})
+    ledger.append(1, {"event_type": "CREATE_NODE", "timestamp": 2, "node_id": "n2", "payload": {"node_id": "n2"}})
+    monkeypatch.setattr("ume.ledger_routes.event_ledger", ledger)
+
+    client = TestClient(app)
+    token = _token(client)
+    res = client.get("/ledger/events", headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 2
+    assert data[0]["offset"] == 0
+    assert data[1]["offset"] == 1
+

--- a/tests/test_event_ledger.py
+++ b/tests/test_event_ledger.py
@@ -1,0 +1,17 @@
+from ume.event_ledger import EventLedger
+from ume.persistent_graph import PersistentGraph
+
+
+def test_replay_from_offset(tmp_path):
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    event1 = {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {"node_id": "n1"}}
+    event2 = {"event_type": "CREATE_NODE", "timestamp": 2, "node_id": "n2", "payload": {"node_id": "n2"}}
+    ledger.append(0, event1)
+    ledger.append(1, event2)
+
+    g = PersistentGraph(":memory:")
+    last = g.replay_from_ledger(ledger, 0)
+    assert g.get_node("n1") is not None
+    assert g.get_node("n2") is not None
+    assert last == 1
+


### PR DESCRIPTION
## Summary
- persist events using `ume.event_ledger`
- expose `/ledger/events` route
- add `PersistentGraph.replay_from_ledger`
- document event ledger usage
- test replay behaviour and route

## Testing
- `ruff check .`
- `mypy`
- `pytest tests/test_event_ledger.py tests/test_api_ledger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a17351cc8326b05749b03998f140