### PR TITLE
Ensure ledger rejects duplicate offsets

### DIFF
--- a/src/ume/event_ledger.py
+++ b/src/ume/event_ledger.py
@@ -31,10 +31,13 @@ class EventLedger:
 
     def append(self, offset: int, event: Dict[str, Any]) -> None:
         with self.conn:
-            self.conn.execute(
-                "INSERT OR REPLACE INTO events(offset, data) VALUES (?, ?)",
-                (offset, json.dumps(event)),
-            )
+            try:
+                self.conn.execute(
+                    "INSERT INTO events(offset, data) VALUES (?, ?)",
+                    (offset, json.dumps(event)),
+                )
+            except sqlite3.IntegrityError as exc:
+                raise ValueError(f"Offset {offset} already exists") from exc
 
     def range(
         self,

--- a/tests/test_event_ledger.py
+++ b/tests/test_event_ledger.py
@@ -1,5 +1,6 @@
 from ume.event_ledger import EventLedger
 from ume.persistent_graph import PersistentGraph
+import pytest
 
 
 def test_replay_from_offset(tmp_path):
@@ -14,4 +15,32 @@ def test_replay_from_offset(tmp_path):
     assert g.get_node("n1") is not None
     assert g.get_node("n2") is not None
     assert last == 1
+
+
+def test_append_duplicate_offset_error(tmp_path):
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    event1 = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n1",
+        "payload": {"node_id": "n1"},
+    }
+    ledger.append(0, event1)
+
+    with pytest.raises(ValueError):
+        ledger.append(
+            0,
+            {
+                "event_type": "CREATE_NODE",
+                "timestamp": 2,
+                "node_id": "n2",
+                "payload": {"node_id": "n2"},
+            },
+        )
+
+    # Existing event should remain unchanged
+    events = ledger.range()
+    assert len(events) == 1
+    assert events[0][0] == 0
+    assert events[0][1] == event1
 


### PR DESCRIPTION
## Summary
- avoid replacing existing ledger entries
- raise `ValueError` when inserting duplicate offsets
- test duplicate offset behavior

## Testing
- `ruff check .`
- `pytest tests/test_event_ledger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68685f04c5488326a3d311e073faa351