### PR TITLE
Add vitest tests for dashboard components

### DIFF
--- a/frontend/src/PiiStatus.test.jsx
+++ b/frontend/src/PiiStatus.test.jsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import PiiStatus from './PiiStatus';
+
+function mockFetch(data) {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(data),
+    }),
+  );
+}
+
+describe('PiiStatus', () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('polls and displays redaction count', async () => {
+    const intervals = [];
+    vi.spyOn(global, 'setInterval').mockImplementation((fn) => {
+      intervals.push(fn);
+      return 1;
+    });
+    mockFetch({ redacted: 3 });
+    render(<PiiStatus token="t" />);
+    await intervals[0]();
+    await waitFor(() => screen.getByText('Redacted events: 3'));
+    expect(fetch).toHaveBeenCalledWith('/pii/redactions', expect.any(Object));
+  });
+
+  it('does not poll without a token', () => {
+    mockFetch({ redacted: 1 });
+    render(<PiiStatus />);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/PolicyEditor.test.jsx
+++ b/frontend/src/PolicyEditor.test.jsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import PolicyEditor from './PolicyEditor';
+
+function mockFetch(responses) {
+  global.fetch = vi.fn((url, opts = {}) => {
+    const method = (opts.method || 'GET').toUpperCase();
+    const key = method + ' ' + url;
+    const res = responses[key] ?? responses[url] ?? { ok: true, body: {} };
+    const ok = res.ok !== undefined ? res.ok : true;
+    const body = res.body !== undefined ? res.body : res;
+    if (typeof body === 'string') {
+      return Promise.resolve({ ok, text: () => Promise.resolve(body) });
+    }
+    return Promise.resolve({ ok, json: () => Promise.resolve(body), text: () => Promise.resolve(JSON.stringify(body)) });
+  });
+}
+
+describe('PolicyEditor', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('loads and displays policy content', async () => {
+    mockFetch({ '/policies/p.txt': 'hello' });
+    render(<PolicyEditor token="t" policy="p.txt" />);
+    await waitFor(() => screen.getByDisplayValue('hello'));
+    expect(screen.getByRole('textbox').value).toBe('hello');
+  });
+
+  it('saves edited policy', async () => {
+    const responses = {
+      '/policies/p.txt': 'start',
+      'PUT /policies/p.txt': {},
+    };
+    const onSaved = vi.fn();
+    mockFetch(responses);
+    render(<PolicyEditor token="t" policy="p.txt" onSaved={onSaved} />);
+    await waitFor(() => screen.getByDisplayValue('start'));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'new' } });
+    fireEvent.click(screen.getByText('Save'));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        '/policies/p.txt',
+        expect.objectContaining({ method: 'PUT' }),
+      ),
+    );
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('validates policy content', async () => {
+    const responses = {
+      '/policies/p.txt': 'start',
+      'POST /policies/validate': { ok: true, body: {} },
+    };
+    mockFetch(responses);
+    global.alert = vi.fn();
+    render(<PolicyEditor token="t" policy="p.txt" />);
+    await waitFor(() => screen.getByDisplayValue('start'));
+    fireEvent.click(screen.getByText('Validate'));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        '/policies/validate',
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+    expect(global.alert).toHaveBeenCalledWith('Policy is valid');
+  });
+});

--- a/frontend/src/Recommendations.test.jsx
+++ b/frontend/src/Recommendations.test.jsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import Recommendations from './Recommendations';
+
+function mockFetch(responses) {
+  global.fetch = vi.fn((url, opts = {}) => {
+    const method = (opts.method || 'GET').toUpperCase();
+    const key = method + ' ' + url;
+    const res = responses[key] ?? responses[url] ?? { ok: true, body: {} };
+    const ok = res.ok !== undefined ? res.ok : true;
+    const body = res.body !== undefined ? res.body : res;
+    if (typeof body === 'string') {
+      return Promise.resolve({ ok, text: () => Promise.resolve(body) });
+    }
+    return Promise.resolve({ ok, json: () => Promise.resolve(body) });
+  });
+}
+
+describe('Recommendations', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('loads and displays recommendations', async () => {
+    mockFetch({ '/recommendations': [{ id: 1, action: 'Act' }] });
+    render(<Recommendations token="t" />);
+    await waitFor(() => screen.getByText('Act'));
+    expect(screen.getByText('Act')).toBeInTheDocument();
+  });
+
+  it('sends feedback on actions', async () => {
+    const responses = {
+      '/recommendations': [{ id: 1, action: 'Act' }],
+      'POST /feedback/accept': {},
+      'POST /feedback/reject': {},
+    };
+    mockFetch(responses);
+    render(<Recommendations token="t" />);
+    await waitFor(() => screen.getByText('Act'));
+    fireEvent.click(screen.getByText('Accept'));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        '/feedback/accept',
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+    fireEvent.click(screen.getByText('Reject'));
+    await waitFor(() =>
+      expect(fetch).toHaveBeenCalledWith(
+        '/feedback/reject',
+        expect.objectContaining({ method: 'POST' }),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for PiiStatus, PolicyEditor and Recommendations components
- validate key interaction flows via Vitest

## Testing
- `pre-commit run --files frontend/src/PiiStatus.test.jsx frontend/src/PolicyEditor.test.jsx frontend/src/Recommendations.test.jsx`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68686c5b81288326a5e2cc66de94625a