### PR TITLE
Add AsyncUMEClient error handling tests

### DIFF
--- a/tests/test_grpc_streaming.py
+++ b/tests/test_grpc_streaming.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 from pathlib import Path
 import grpc
+import pytest
 
 base = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(base / "src" / "ume_client"))
@@ -141,4 +142,121 @@ def test_get_audit_entries_async():
             pass
 
     asyncio.run(runner())
+
+
+class ErrorServicer(TestServicer):
+    async def StreamCypher(self, request, context):
+        if not request.cypher:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "empty query")
+        for rec in DummyQE().execute_cypher(request.cypher):
+            struct = ume_pb2.google_dot_protobuf_dot_struct__pb2.Struct()
+            struct.update(rec)
+            yield ume_pb2.CypherRecord(record=struct)
+
+    async def SearchVectors(self, request, context):
+        if not request.vector:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, "empty vector")
+        ids = store.query(list(request.vector), k=request.k or 5)
+        return ume_pb2.VectorSearchResponse(ids=ids)
+
+
+async def _run_error_server(port_holder: list[int]):
+    server = grpc.aio.server()
+    svc = ErrorServicer()
+    ume_pb2_grpc.add_UMEServicer_to_server(svc, server)
+    port = server.add_insecure_port("localhost:0")
+    port_holder.append(port)
+    await server.start()
+    await server.wait_for_termination()
+
+
+async def _run_error_test(port: int):
+    async with AsyncUMEClient(f"localhost:{port}") as client:
+        with pytest.raises(grpc.aio.AioRpcError) as exc:
+            async for _ in client.stream_cypher(""):
+                pass
+        assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+async def _run_malformed_search_test(port: int):
+    async with AsyncUMEClient(f"localhost:{port}") as client:
+        with pytest.raises(grpc.aio.AioRpcError) as exc:
+            await client.search_vectors([])
+        assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+
+def test_server_error_and_malformed_request():
+    port_holder: list[int] = []
+
+    async def runner():
+        server_task = asyncio.create_task(_run_error_server(port_holder))
+        while not port_holder:
+            await asyncio.sleep(0.01)
+        await _run_error_test(port_holder[0])
+        await _run_malformed_search_test(port_holder[0])
+        server_task.cancel()
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(runner())
+
+
+class CancelServicer(TestServicer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.cancelled = False
+
+    async def StreamCypher(self, request, context):
+        context.add_done_callback(lambda *_: setattr(self, "cancelled", True))
+        for rec in DummyQE().execute_cypher(request.cypher):
+            struct = ume_pb2.google_dot_protobuf_dot_struct__pb2.Struct()
+            struct.update(rec)
+            yield ume_pb2.CypherRecord(record=struct)
+            await asyncio.sleep(0.01)
+            if not context.is_active():
+                self.cancelled = True
+                return
+
+
+async def _run_cancel_server(port_holder: list[int], svc_holder: list[CancelServicer]):
+    server = grpc.aio.server()
+    svc = CancelServicer()
+    svc_holder.append(svc)
+    ume_pb2_grpc.add_UMEServicer_to_server(svc, server)
+    port = server.add_insecure_port("localhost:0")
+    port_holder.append(port)
+    await server.start()
+    await server.wait_for_termination()
+
+
+async def _run_cancel_test(port: int):
+    async with AsyncUMEClient(f"localhost:{port}") as client:
+        gen = client.stream_cypher("return 1")
+        results = []
+        async for rec in gen:
+            results.append(rec)
+            break
+        await gen.aclose()
+        assert results == [{"n": 1}]
+
+
+def test_stream_cypher_client_cancel():
+    port_holder: list[int] = []
+    svc_holder: list[CancelServicer] = []
+
+    async def runner():
+        server_task = asyncio.create_task(_run_cancel_server(port_holder, svc_holder))
+        while not port_holder:
+            await asyncio.sleep(0.01)
+        await _run_cancel_test(port_holder[0])
+        server_task.cancel()
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(runner())
+    assert svc_holder[0].cancelled
 


### PR DESCRIPTION
## Summary
- add tests covering error handling and cancellation for AsyncUMEClient

## Testing
- `ruff check`
- `pytest tests/test_grpc_streaming.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68686c58622c8326b82ef65584b15b49