### PR TITLE
Add MemGPT and SuperMemory integrations

### DIFF
--- a/examples/memgpt_integration.ipynb
+++ b/examples/memgpt_integration.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MemGPT Integration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from integrations.memgpt import MemGPT\n",
+    "client = MemGPT()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.send_events([{\"event_type\": \"CREATE_NODE\", \"timestamp\": 0, \"payload\": {\"node_id\": \"n1\", \"attributes\": {}}}])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.recall({\"node_id\": \"n1\"})"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/supermemory_integration.ipynb
+++ b/examples/supermemory_integration.ipynb
@@ -1,0 +1,46 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SuperMemory Integration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from integrations.supermemory import SuperMemory\n",
+    "client = SuperMemory()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.send_events([{\"event_type\": \"CREATE_NODE\", \"timestamp\": 0, \"payload\": {\"node_id\": \"n1\", \"attributes\": {}}}])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "client.recall({\"node_id\": \"n1\"})"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/integrations/__init__.py
+++ b/src/integrations/__init__.py
@@ -2,5 +2,7 @@
 
 from .langgraph import LangGraph
 from .letta import Letta
+from .memgpt import MemGPT
+from .supermemory import SuperMemory
 
-__all__ = ["LangGraph", "Letta"]
+__all__ = ["LangGraph", "Letta", "MemGPT", "SuperMemory"]

--- a/src/integrations/memgpt.py
+++ b/src/integrations/memgpt.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Any
+from types import TracebackType
+
+import httpx
+
+
+class MemGPT:
+    """Thin wrapper to forward events to a running UME instance."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.Client(timeout=5)
+
+    def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
+
+    def recall(self, payload: Mapping[str, Any]) -> Any:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        resp = self._client.get(
+            f"{self.base_url}/recall", params=payload, headers=headers
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "MemGPT":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/src/integrations/supermemory.py
+++ b/src/integrations/supermemory.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Any
+from types import TracebackType
+
+import httpx
+
+
+class SuperMemory:
+    """Thin wrapper to forward events to a running UME instance."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.Client(timeout=5)
+
+    def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
+
+    def recall(self, payload: Mapping[str, Any]) -> Any:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        resp = self._client.get(
+            f"{self.base_url}/recall", params=payload, headers=headers
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "SuperMemory":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -3,6 +3,8 @@ import pytest
 
 from integrations.langgraph import LangGraph
 from integrations.letta import Letta
+from integrations.memgpt import MemGPT
+from integrations.supermemory import SuperMemory
 
 respx = pytest.importorskip("respx")
 
@@ -31,6 +33,32 @@ def test_letta_wrapper_forwards() -> None:
         assert recall.called
         assert result == {"id": 1}
         assert dict(recall.calls.last.request.url.params) == {"id": "1"}
+
+
+def test_memgpt_wrapper_forwards() -> None:
+    client = MemGPT(base_url="http://ume")
+    with respx.mock(assert_all_called=True) as mock:
+        evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
+        recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"id": 2}))
+        client.send_events([{"foo": 2}])
+        result = client.recall({"id": 2})
+        assert evt.called
+        assert recall.called
+        assert result == {"id": 2}
+        assert dict(recall.calls.last.request.url.params) == {"id": "2"}
+
+
+def test_supermemory_wrapper_forwards() -> None:
+    client = SuperMemory(base_url="http://ume")
+    with respx.mock(assert_all_called=True) as mock:
+        evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
+        recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"result": 3}))
+        client.send_events([{"foo": 3}])
+        result = client.recall({"result": 3})
+        assert evt.called
+        assert recall.called
+        assert result == {"result": 3}
+        assert dict(recall.calls.last.request.url.params) == {"result": "3"}
 
 
 def test_wrapper_batch_endpoint() -> None:


### PR DESCRIPTION
## Summary
- add simple wrappers for MemGPT and SuperMemory integrations
- demonstrate usage of the new integrations in example notebooks
- cover integrations with unit tests

## Testing
- `pre-commit run --files src/integrations/memgpt.py src/integrations/supermemory.py src/integrations/__init__.py tests/test_integrations.py examples/memgpt_integration.ipynb examples/supermemory_integration.ipynb`
- `pytest tests/test_integrations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68686c57c140832687b0442faf64e34e