### PR TITLE
Add quickstart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,9 @@ PYTHONPATH=src pytest
 
 Create a `.env` file in the project root before starting any services. Copy the
 template from [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) and set a
-non-default `UME_AUDIT_SIGNING_KEY` or UME will refuse to start:
+non-default `UME_AUDIT_SIGNING_KEY` or UME will refuse to start. The
+`quickstart` command described below automatically creates this file if it is
+missing:
 
 ```bash
 # .env
@@ -349,20 +351,16 @@ The `ume` CLI can spin up all services for local development. From the repositor
 
 
 ```bash
-poetry run python ume_cli.py up
+poetry run python ume_cli.py quickstart
 ```
 
-The command waits for the services to become healthy and then prints the main URLs:
+The command generates TLS certificates if needed and waits until the services
+become healthy before printing the main URLs:
 
 ```
 http://localhost:8000/docs
 http://localhost:8000/recall
 
-```
-
-If you want to enable TLS for the broker and API, generate certificates first:
-```bash
-bash docker/generate-certs.sh
 ```
 Stop the services with:
 ```bash

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -117,15 +117,10 @@ stack:
 1. Install Docker and Docker Compose.
 2. From the project root run:
    ```bash
-   cd docker
-   # Optional: generate TLS certificates
-   bash generate-certs.sh
-   docker compose up
+   poetry run python ume_cli.py quickstart
    ```
 3. Wait until `redpanda`, `neo4j`, and `ume-api` report `healthy` with `docker compose ps`.
 4. Inspect logs with `docker compose logs -f ume-api`.
 5. Confirm all services report `healthy` with `docker compose ps`.
-
-
-7. Stop all containers with `docker compose down` when finished.
+6. Stop all containers with `docker compose down` when finished.
 


### PR DESCRIPTION
## Summary
- add a `quickstart` subcommand to `ume_cli.py`
- document the new workflow in README
- update config templates with the quickstart command

## Testing
- `poetry run pre-commit run --files ume_cli.py`
- `poetry run pytest tests/test_api.py::test_exception_logging_on_query -q`

------
https://chatgpt.com/codex/tasks/task_e_68686c564e98832691ccaa4f9ca8a1b1