### PR TITLE
Fix thread cleanup for memory aging scheduler

### DIFF
--- a/src/ume/memory_aging.py
+++ b/src/ume/memory_aging.py
@@ -213,7 +213,7 @@ def stop_vector_age_scheduler() -> None:
     global _vector_thread, _vector_stop, _vector_params
     if _vector_stop is not None:
         _vector_stop.set()
-    if _vector_thread is not None:
+    if _vector_thread is not None and _vector_thread.is_alive():
         _vector_thread.join()
     _vector_thread = None
     _vector_stop = None
@@ -224,9 +224,12 @@ def stop_memory_aging_scheduler() -> None:
     """Stop the memory aging scheduler if running."""
     global _thread, _stop_event, _thread_params
 
+    # Ensure any auxiliary schedulers are also terminated
+    stop_vector_age_scheduler()
+
     if _stop_event is not None:
         _stop_event.set()
-    if _thread is not None:
+    if _thread is not None and _thread.is_alive():
         _thread.join()
     _thread = None
     _stop_event = None

--- a/tests/test_memory_aging.py
+++ b/tests/test_memory_aging.py
@@ -197,3 +197,44 @@ def test_scheduler_restarts_with_new_options() -> None:
 
     stop_memory_aging_scheduler()
     assert not thread2.is_alive()
+
+
+def test_start_stop_twice_no_active_threads() -> None:
+    """Starting and stopping twice leaves no active threads."""
+    episodic = EpisodicMemory(db_path=":memory:")
+    semantic = SemanticMemory(db_path=":memory:")
+
+    thread1, _ = start_memory_aging_scheduler(
+        episodic,
+        semantic,
+        cold=None,
+        event_age_seconds=0,
+        cold_age_seconds=None,
+        interval_seconds=0.01,
+        vector_check_interval=0.01,
+    )
+
+    stop_memory_aging_scheduler()
+    assert not thread1.is_alive()
+
+    thread2, _ = start_memory_aging_scheduler(
+        episodic,
+        semantic,
+        cold=None,
+        event_age_seconds=0,
+        cold_age_seconds=None,
+        interval_seconds=0.01,
+        vector_check_interval=0.01,
+    )
+
+    stop_memory_aging_scheduler()
+    assert not thread2.is_alive()
+
+    import ume.memory_aging as aging
+
+    assert aging._thread is None
+    assert aging._stop_event is None
+    assert aging._thread_params is None
+    assert aging._vector_thread is None
+    assert aging._vector_stop is None
+    assert aging._vector_params is None


### PR DESCRIPTION
## Summary
- ensure `stop_memory_aging_scheduler` cleans up the vector age scheduler
- add regression test for repeated start/stop behavior
- wait for threads to fully exit before clearing state

## Testing
- `pre-commit run --files src/ume/memory_aging.py tests/test_memory_aging.py`
- `pytest tests/test_memory_aging.py::test_start_stop_twice_no_active_threads -q`


------
https://chatgpt.com/codex/tasks/task_e_6869e84385b88326bb0fe99e95283b1c