### PR TITLE
Add API Dockerfile and clean up tests

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+# Python 3.12 is needed for FastAPI's Pydantic 2 stack
+WORKDIR /app
+RUN pip install poetry
+COPY pyproject.toml poetry.lock ./
+RUN poetry install --no-root --no-dev
+RUN poetry run python -m spacy download en_core_web_lg
+COPY src/ /app/src
+ENV PYTHONPATH=/app
+CMD ["poetry", "run", "uvicorn", "ume.api:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,7 +60,7 @@ services:
   ume-api:
     build:
       context: ..
-      dockerfile: Dockerfile.privacy-agent
+      dockerfile: docker/Dockerfile.api
     command: uvicorn ume.api:app --host 0.0.0.0 --port 8000
     depends_on:
       redpanda:

--- a/src/ume/ledger_routes.py
+++ b/src/ume/ledger_routes.py
@@ -12,12 +12,12 @@ from . import api_deps as deps
 router = APIRouter()
 
 
-class LedgerEvent(BaseModel):  # type: ignore[misc]
+class LedgerEvent(BaseModel):
     offset: int
     event: Dict[str, Any]
 
 
-@router.get("/ledger/events", response_model=List[LedgerEvent])  # type: ignore[misc]
+@router.get("/ledger/events", response_model=List[LedgerEvent])
 def list_events(
     start: int = Query(0, ge=0),
     end: int | None = Query(None, ge=0),
@@ -28,7 +28,7 @@ def list_events(
     return [LedgerEvent(offset=o, event=e) for o, e in entries]
 
 
-@router.get("/ledger/replay")  # type: ignore[misc]
+@router.get("/ledger/replay")
 def replay_ledger(
     end_offset: int | None = Query(None, ge=0),
     end_timestamp: int | None = Query(None, ge=0),


### PR DESCRIPTION
## Summary
- add Dockerfile.api for running the FastAPI service
- have compose use the new Dockerfile
- clean up unused mypy ignores in ledger_routes

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini --strict`
- `pytest tests/test_api.py::test_exception_logging_on_query -q`
- `pytest tests/test_vector_store_unit.py::test_create_default_store_selects_backend -q`


------
https://chatgpt.com/codex/tasks/task_e_6869e84542fc8326abd63c5819223669