### PR TITLE
Add automatic audit signing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,11 +336,11 @@ Create a `.env` file in the project root before starting any services. Copy the
 template from [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) and set a
 non-default `UME_AUDIT_SIGNING_KEY` or UME will refuse to start. The
 `quickstart` command described below automatically creates this file if it is
-missing:
+missing and inserts a random signing key:
 
 ```bash
 # .env
-UME_AUDIT_SIGNING_KEY=my-ume-key
+UME_AUDIT_SIGNING_KEY=<randomly-generated-key>
 ```
 
 See [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) for the full list of available


### PR DESCRIPTION
## Summary
- generate a random signing key in `.env` when `ume_cli` creates the file
- note auto-generated key in the quickstart docs
- restart vector age scheduler when parameters change

## Testing
- `ruff check ume_cli.py`
- `mypy --config-file mypy.ini ume_cli.py`
- `ruff check src/ume/retention.py`
- `mypy --config-file mypy.ini src/ume/retention.py`
- `pytest tests/test_api.py::test_exception_logging_on_query tests/test_vector_store_unit.py::test_create_default_store_selects_backend tests/test_retention.py::test_vector_age_scheduler_continues_after_error -q`


------
https://chatgpt.com/codex/tasks/task_e_6869e841fa8483268b8b4c488573873f