### PR TITLE
Enable mypy for integrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     rev: v1.16.1
     hooks:
       - id: mypy
-        args: ["--config-file", "mypy.ini", "--strict"]
+        args: ["--config-file", "pyproject.toml", "--strict"]
         additional_dependencies: ["types-PyYAML"]
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,12 @@ compile-protos = "scripts.compile_protos:main"
 line-length = 88
 exclude = ["src/ume/proto/*", "src/ume_client/ume_pb2*.py"]
 
+[tool.mypy]
+files = ["src/integrations"]
+python_version = "3.10"
+strict = true
+ignore_missing_imports = true
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/src/integrations/langgraph.py
+++ b/src/integrations/langgraph.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterable, Mapping, Any
+from typing_extensions import Self
 from types import TracebackType
 
 import httpx
@@ -39,7 +40,7 @@ class LangGraph:
     def close(self) -> None:
         self._client.close()
 
-    def __enter__(self) -> "LangGraph":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(

--- a/src/integrations/letta.py
+++ b/src/integrations/letta.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterable, Mapping, Any
+from typing_extensions import Self
 from types import TracebackType
 
 import httpx
@@ -39,7 +40,7 @@ class Letta:
     def close(self) -> None:
         self._client.close()
 
-    def __enter__(self) -> "Letta":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(

--- a/src/integrations/memgpt.py
+++ b/src/integrations/memgpt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterable, Mapping, Any
+from typing_extensions import Self
 from types import TracebackType
 
 import httpx
@@ -39,7 +40,7 @@ class MemGPT:
     def close(self) -> None:
         self._client.close()
 
-    def __enter__(self) -> "MemGPT":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(

--- a/src/integrations/supermemory.py
+++ b/src/integrations/supermemory.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Iterable, Mapping, Any
+from typing_extensions import Self
 from types import TracebackType
 
 import httpx
@@ -39,7 +40,7 @@ class SuperMemory:
     def close(self) -> None:
         self._client.close()
 
-    def __enter__(self) -> "SuperMemory":
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(


### PR DESCRIPTION
## Summary
- add `Self` based `__enter__` return types
- mark the `integrations` package as typed and configure mypy
- use pyproject for mypy in pre-commit

## Testing
- `pre-commit run --files src/integrations/langgraph.py src/integrations/letta.py src/integrations/memgpt.py src/integrations/supermemory.py pyproject.toml .pre-commit-config.yaml`
- `pytest -k integrations -q`

------
https://chatgpt.com/codex/tasks/task_e_686a004bc1208326a14f595b95d30e82