### PR TITLE
Add graph restore endpoint

### DIFF
--- a/src/ume/snapshot_routes.py
+++ b/src/ume/snapshot_routes.py
@@ -6,6 +6,9 @@ from pydantic import BaseModel
 from .api_deps import get_graph, get_current_role
 from .graph_adapter import IGraphAdapter
 from .snapshot import snapshot_graph_to_file, load_graph_into_existing
+from .event_ledger import event_ledger
+from .persistent_graph import build_graph_from_ledger
+from .api_deps import configure_graph
 
 router = APIRouter(prefix="/snapshot")
 
@@ -35,4 +38,20 @@ def load_snapshot(
     if role != "AnalyticsAgent":
         raise HTTPException(status_code=403, detail="Forbidden")
     load_graph_into_existing(graph, Path(req.path))
+    return {"status": "ok"}
+
+
+@router.post("/restore")
+def restore_graph(
+    req: SnapshotPath,
+    graph: IGraphAdapter = Depends(get_graph),
+    role: str = Depends(get_current_role),
+) -> dict[str, str]:
+    """Rebuild the graph database from the event ledger."""
+    if role != "AnalyticsAgent":
+        raise HTTPException(status_code=403, detail="Forbidden")
+    if hasattr(graph, "close"):
+        graph.close()
+    new_graph = build_graph_from_ledger(event_ledger, db_path=req.path)
+    configure_graph(new_graph)
     return {"status": "ok"}


### PR DESCRIPTION
## Summary
- add `/snapshot/restore` API to rebuild the graph from the ledger
- close the existing graph before configuring the rebuilt instance
- test restoring from ledger on all supported backends

## Testing
- `ruff check src/ume/snapshot_routes.py tests/test_snapshot_routes.py`
- `poetry run pytest tests/test_snapshot_routes.py::test_restore_route_builds_graph -q`


------
https://chatgpt.com/codex/tasks/task_e_686a003a20848326a30e7b71292da114