### PR TITLE
Implement batching for UMEClient

### DIFF
--- a/tests/test_client_module.py
+++ b/tests/test_client_module.py
@@ -10,12 +10,14 @@ class DummyProducer:
     def __init__(self):
         self.produced = []
         self.flushed = False
+        self.flush_count = 0
 
     def produce(self, topic, value):
         self.produced.append((topic, value))
 
     def flush(self):
         self.flushed = True
+        self.flush_count += 1
 
 class DummyConsumer:
     def __init__(self, messages):
@@ -51,6 +53,7 @@ class DummySettings:
     KAFKA_CLEAN_EVENTS_TOPIC = "clean"
     KAFKA_BOOTSTRAP_SERVERS = "server"
     KAFKA_GROUP_ID = "group"
+    KAFKA_PRODUCER_BATCH_SIZE = 10
 
 @pytest.fixture(autouse=True)
 def embed_module(monkeypatch):
@@ -60,12 +63,14 @@ def embed_module(monkeypatch):
     yield
     sys.modules.pop('ume.embedding')
 
-def make_client(monkeypatch, msgs=None):
+def make_client(monkeypatch, msgs=None, batch_size=10):
     producer = DummyProducer()
     consumer = DummyConsumer(msgs or [])
     monkeypatch.setattr(client, 'Producer', lambda conf: producer)
     monkeypatch.setattr(client, 'Consumer', lambda conf: consumer)
-    return client.UMEClient(DummySettings()), producer, consumer  # type: ignore[arg-type]
+    settings = DummySettings()
+    settings.KAFKA_PRODUCER_BATCH_SIZE = batch_size
+    return client.UMEClient(settings), producer, consumer  # type: ignore[arg-type]
 
 def test_produce_event(monkeypatch):
     c, prod, _ = make_client(monkeypatch)
@@ -79,12 +84,52 @@ def test_produce_event(monkeypatch):
         label="",
     )
     c.produce_event(event)
-    assert prod.flushed
+    assert prod.flush_count == 0
     topic, value = prod.produced[0]
     assert topic == "raw"
     data = json.loads(value.decode("utf-8"))
     assert data["schema_version"] == client.DEFAULT_VERSION
     assert data["event"]["node_id"] == "n"
+
+
+def test_flush_after_batch(monkeypatch):
+    c, prod, _ = make_client(monkeypatch, batch_size=2)
+    event = Event(
+        event_type="CREATE_NODE",
+        timestamp=1,
+        payload={},
+        node_id="n",
+        source="test",
+        target_node_id="unused",
+        label="",
+    )
+    c.produce_event(event)
+    assert prod.flush_count == 0
+    c.produce_event(event)
+    assert prod.flush_count == 1
+
+
+def test_flush_on_close(monkeypatch):
+    c, prod, _ = make_client(monkeypatch, batch_size=5)
+    event = Event(
+        event_type="CREATE_NODE",
+        timestamp=1,
+        payload={},
+        node_id="n",
+        source="test",
+        target_node_id="unused",
+        label="",
+    )
+    c.produce_event(event)
+    assert prod.flush_count == 0
+    c.close()
+    assert prod.flush_count == 1
+
+
+def test_no_flush_without_pending(monkeypatch):
+    c, prod, _ = make_client(monkeypatch)
+    c.close()
+    assert prod.flush_count == 0
 
 def test_produce_event_invalid(monkeypatch):
     c, prod, _ = make_client(monkeypatch)


### PR DESCRIPTION
## Summary
- add batching support to `UMEClient` producer
- flush only when batch size reached or on close
- avoid flushing when there is nothing pending
- test that messages batch and flush correctly

## Testing
- `pre-commit run --files src/ume/client.py tests/test_client_module.py`
- `pytest tests/test_client_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686d9ff4086883268050796dff1d3c55