### PR TITLE
Modify fallback embedding generation

### DIFF
--- a/src/ume/embedding.py
+++ b/src/ume/embedding.py
@@ -16,7 +16,8 @@ else:
                 self.model_name = model_name
 
             def encode(self, text: str) -> list[float]:
-                return [1.0, 0.0] if "apple" in text else [0.9, 0.1]
+                """Return a dummy embedding of the configured dimension."""
+                return [0.0] * settings.UME_VECTOR_DIM
 
 
 SentenceTransformer: type[SentenceTransformerImpl] = SentenceTransformerImpl

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -19,3 +19,13 @@ def test_generate_embedding(monkeypatch):
     importlib.reload(emb)
     vec = emb.generate_embedding("hello")
     assert vec == [0.0] * 5
+
+
+def test_generate_embedding_default_length(monkeypatch):
+    """Ensure fallback implementation returns correct vector length."""
+    sys.modules.pop("sentence_transformers", None)
+    sys.modules.pop("ume.embedding", None)
+    import ume.embedding as emb
+    importlib.reload(emb)
+    vec = emb.generate_embedding("hello")
+    assert len(vec) == emb.settings.UME_VECTOR_DIM


### PR DESCRIPTION
## Summary
- return zero vectors from fallback SentenceTransformer implementation
- test that fallback vectors match configured dimension
- fix monkeypatch usage in embedding tests
- ensure exception logging test patches dependency correctly

## Testing
- `pre-commit run --files src/ume/embedding.py tests/test_embedding.py tests/test_api.py`
- `pytest tests/test_embedding.py tests/test_api.py::test_exception_logging_on_query -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d9ff4c0108326bc4d4db5f729bcaa