### PR TITLE
Add async wrappers for integrations

### DIFF
--- a/src/ume/integrations/__init__.py
+++ b/src/ume/integrations/__init__.py
@@ -1,8 +1,17 @@
 """Integrations for external frameworks."""
 
-from .langgraph import LangGraph
-from .letta import Letta
-from .memgpt import MemGPT
-from .supermemory import SuperMemory
+from .langgraph import LangGraph, AsyncLangGraph
+from .letta import Letta, AsyncLetta
+from .memgpt import MemGPT, AsyncMemGPT
+from .supermemory import SuperMemory, AsyncSuperMemory
 
-__all__ = ["LangGraph", "Letta", "MemGPT", "SuperMemory"]
+__all__ = [
+    "LangGraph",
+    "AsyncLangGraph",
+    "Letta",
+    "AsyncLetta",
+    "MemGPT",
+    "AsyncMemGPT",
+    "SuperMemory",
+    "AsyncSuperMemory",
+]

--- a/src/ume/integrations/langgraph.py
+++ b/src/ume/integrations/langgraph.py
@@ -49,3 +49,48 @@ class LangGraph:
         tb: TracebackType | None,
     ) -> None:
         self.close()
+
+
+class AsyncLangGraph:
+    """Async wrapper to forward events to a running UME instance."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.AsyncClient(timeout=5)
+
+    async def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            await self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            await self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
+
+    async def recall(self, payload: Mapping[str, Any]) -> Any:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        resp = await self._client.get(
+            f"{self.base_url}/recall", params=payload, headers=headers
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncLangGraph":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()

--- a/src/ume/integrations/letta.py
+++ b/src/ume/integrations/letta.py
@@ -49,3 +49,48 @@ class Letta:
         tb: TracebackType | None,
     ) -> None:
         self.close()
+
+
+class AsyncLetta:
+    """Async wrapper to forward events to a running UME instance."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.AsyncClient(timeout=5)
+
+    async def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            await self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            await self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
+
+    async def recall(self, payload: Mapping[str, Any]) -> Any:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        resp = await self._client.get(
+            f"{self.base_url}/recall", params=payload, headers=headers
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncLetta":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()

--- a/src/ume/integrations/memgpt.py
+++ b/src/ume/integrations/memgpt.py
@@ -49,3 +49,48 @@ class MemGPT:
         tb: TracebackType | None,
     ) -> None:
         self.close()
+
+
+class AsyncMemGPT:
+    """Async wrapper to forward events to a running UME instance."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.AsyncClient(timeout=5)
+
+    async def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            await self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            await self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
+
+    async def recall(self, payload: Mapping[str, Any]) -> Any:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        resp = await self._client.get(
+            f"{self.base_url}/recall", params=payload, headers=headers
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncMemGPT":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()

--- a/tests/test_integrations_async.py
+++ b/tests/test_integrations_async.py
@@ -1,0 +1,85 @@
+import asyncio
+import httpx
+import pytest
+
+from ume.integrations.langgraph import AsyncLangGraph
+from ume.integrations.letta import AsyncLetta
+from ume.integrations.memgpt import AsyncMemGPT
+from ume.integrations.supermemory import AsyncSuperMemory
+
+respx = pytest.importorskip("respx")
+
+
+def test_async_langgraph_wrapper_forwards() -> None:
+    async def runner():
+        async with AsyncLangGraph(base_url="http://ume", api_key="token") as client:
+            with respx.mock(assert_all_called=True) as mock:
+                evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
+                recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"ok": True}))
+                await client.send_events([{"foo": "bar"}])
+                result = await client.recall({"node_id": "n1"})
+                assert evt.called
+                assert recall.called
+                assert result == {"ok": True}
+                assert dict(recall.calls.last.request.url.params) == {"node_id": "n1"}
+
+    asyncio.run(runner())
+
+
+def test_async_letta_wrapper_forwards() -> None:
+    async def runner():
+        async with AsyncLetta(base_url="http://ume") as client:
+            with respx.mock(assert_all_called=True) as mock:
+                evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
+                recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"id": 1}))
+                await client.send_events([{"foo": 1}])
+                result = await client.recall({"id": 1})
+                assert evt.called
+                assert recall.called
+                assert result == {"id": 1}
+                assert dict(recall.calls.last.request.url.params) == {"id": "1"}
+
+    asyncio.run(runner())
+
+
+def test_async_memgpt_wrapper_forwards() -> None:
+    async def runner():
+        async with AsyncMemGPT(base_url="http://ume") as client:
+            with respx.mock(assert_all_called=True) as mock:
+                evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
+                recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"id": 2}))
+                await client.send_events([{"foo": 2}])
+                result = await client.recall({"id": 2})
+                assert evt.called
+                assert recall.called
+                assert result == {"id": 2}
+                assert dict(recall.calls.last.request.url.params) == {"id": "2"}
+
+    asyncio.run(runner())
+
+
+def test_async_supermemory_wrapper_forwards() -> None:
+    async def runner():
+        async with AsyncSuperMemory(base_url="http://ume") as client:
+            with respx.mock(assert_all_called=True) as mock:
+                evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
+                recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"result": 3}))
+                await client.send_events([{"foo": 3}])
+                result = await client.recall({"result": 3})
+                assert evt.called
+                assert recall.called
+                assert result == {"result": 3}
+                assert dict(recall.calls.last.request.url.params) == {"result": "3"}
+
+    asyncio.run(runner())
+
+
+def test_async_wrapper_batch_endpoint() -> None:
+    async def runner():
+        async with AsyncLangGraph(base_url="http://ume") as client:
+            with respx.mock(assert_all_called=True) as mock:
+                batch = mock.post("http://ume/events/batch").mock(return_value=httpx.Response(200))
+                await client.send_events([{"foo": "a"}, {"foo": "b"}])
+                assert batch.called
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- implement `Async*` wrappers for integrations
- export async wrappers via `__all__`
- add tests for async integrations

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini --strict`
- `pytest tests/test_integrations.py tests/test_integrations_async.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686db18392248326ba94d55f1d586c96