### PR TITLE
Add up alias for quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ PYTHONPATH=src pytest
 Create a `.env` file in the project root before starting any services. Copy the
 template from [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) and set a
 non-default `UME_AUDIT_SIGNING_KEY` or UME will refuse to start. The
-`quickstart` command described below automatically creates this file if it is
+`ume up` command described below automatically creates this file if it is
 missing and inserts a random signing key:
 
 ```bash
@@ -351,7 +351,7 @@ The `ume` CLI can spin up all services for local development. From the repositor
 
 
 ```bash
-poetry run python ume_cli.py quickstart
+poetry run python ume_cli.py up
 ```
 
 The command generates TLS certificates if needed and waits until the services

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -117,7 +117,7 @@ stack:
 1. Install Docker and Docker Compose.
 2. From the project root run:
    ```bash
-   poetry run python ume_cli.py quickstart
+   poetry run python ume_cli.py up
    ```
 3. Wait until `redpanda`, `neo4j`, and `ume-api` report `healthy` with `docker compose ps`.
 4. Inspect logs with `docker compose logs -f ume-api`.

--- a/tests/test_cli_internal.py
+++ b/tests/test_cli_internal.py
@@ -68,3 +68,27 @@ def test_compose_ps(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixtu
     out = capsys.readouterr().out
     assert "api: healthy" in out
     assert "agent: unhealthy" in out
+
+
+def test_up_alias(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+    import sys
+    import ume_cli as cli
+
+    importlib.reload(cli)
+
+    calls: list[str] = []
+
+    def fake_compose_up(*_: object, **__: object) -> None:
+        calls.append("up")
+
+    monkeypatch.setattr(cli, "_compose_up", fake_compose_up)
+    monkeypatch.setattr(cli, "_ensure_env_file", lambda: None)
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **k: None)
+
+    sys.argv = ["ume_cli.py", "up"]
+    cli.main()
+    sys.argv = ["ume_cli.py", "quickstart"]
+    cli.main()
+
+    assert calls == ["up", "up"]

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -678,21 +678,22 @@ def main() -> None:
     )
 
     sub = parser.add_subparsers(dest="command")
-    sub.add_parser("up", help="Start Docker Compose stack")
+    # ``up`` is kept as a short alias for ``quickstart`` for convenience
+    sub.add_parser("up", help="Create .env, generate certs and start the stack")
     sub.add_parser("down", help="Stop Docker Compose stack")
-    sub.add_parser("quickstart", help="Create .env, generate certs and start the stack")
+    sub.add_parser(
+        "quickstart",
+        help="Create .env, generate certs and start the stack (same as 'up')",
+    )
     sub.add_parser("ps", help="Show status and health of Docker Compose services")
 
     args = parser.parse_args()
 
-    if args.command == "up":
-        _compose_up()
+    if args.command in {"up", "quickstart"}:
+        _quickstart()
         return
     if args.command == "down":
         _compose_down()
-        return
-    if args.command == "quickstart":
-        _quickstart()
         return
     if args.command == "ps":
         _compose_ps()


### PR DESCRIPTION
## Summary
- allow `ume up` to run the quickstart setup
- update docs to use `ume up` command
- test that both `up` and `quickstart` start the stack

## Testing
- `pre-commit run --files ume_cli.py tests/test_cli_internal.py README.md docs/CONFIG_TEMPLATES.md`
- `pytest tests/test_cli_internal.py::test_up_alias -q`
- `pytest tests/test_cli_internal.py::test_compose_ps -q`


------
https://chatgpt.com/codex/tasks/task_e_686db5a5bf188326a7443732ef446ca9