### PR TITLE
Add env.example and update env file handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ PYTHONPATH=src pytest
 ```
 
 Create a `.env` file in the project root before starting any services. Copy the
-template from [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) and set a
+template from [`env.example`](env.example) and set a
 non-default `UME_AUDIT_SIGNING_KEY` or UME will refuse to start. The
 `ume up` command described below automatically creates this file if it is
 missing and inserts a random signing key:
@@ -344,7 +344,7 @@ missing and inserts a random signing key:
 UME_AUDIT_SIGNING_KEY=<randomly-generated-key>
 ```
 
-See [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) for the full list of available
+See [`env.example`](env.example) for the full list of available
 settings.
 
 ### 2. Start the Docker Stack
@@ -493,7 +493,7 @@ Authorization: Bearer <token>
 Tokens expire after `UME_OAUTH_TTL` seconds (default 3600).
 
 The only unauthenticated route is `/metrics`, which exposes Prometheus metrics.
-See [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) for a sample `.env` file.
+See [`env.example`](env.example) for a sample `.env` file.
 
 ### Posting Events
 
@@ -543,7 +543,7 @@ UME options. When imported it first loads a `.env` file from the project root if
 present and then applies any matching environment variables, allowing you to
 override the defaults without modifying the code.
 
-See [`docs/ENV_EXAMPLE.md`](docs/ENV_EXAMPLE.md) for a minimal `.env` template.
+See [`env.example`](env.example) for a minimal `.env` template.
 
 ## Federated Deployments
 

--- a/env.example
+++ b/env.example
@@ -1,10 +1,3 @@
-# Example .env
-
-The `.env` file allows you to override default settings defined in `src/ume/config.py`. Values in this file are loaded before reading your shell environment.
-
-An `env.example` file with the following contents is included at the project root.
-
-```bash
 # Path where the CLI stores its SQLite database
 UME_CLI_DB=./ume.db
 
@@ -31,8 +24,3 @@ LLM_FERRY_API_KEY=
 
 # Number of hours of events to include in Angel Bridge summaries
 ANGEL_BRIDGE_LOOKBACK_HOURS=24
-```
-
-UME requires **Python 3.10** or newer. If your system Python is older than 3.10,
-consider using [pyenv](https://github.com/pyenv/pyenv) or running in a
-container image that provides a compatible Python version to ensure compatibility.

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -621,38 +621,25 @@ def _compose_ps(compose_file: Path = COMPOSE_FILE) -> None:
 
 
 def _ensure_env_file(env_file: Path = Path(".env")) -> None:
-    """Create ``.env`` from ``docs/ENV_EXAMPLE.md`` if missing.
+    """Create ``.env`` from ``env.example`` if missing.
 
     A random ``UME_AUDIT_SIGNING_KEY`` is inserted so the default key
     from ``src/ume/config.py`` is never used.
     """
     if env_file.exists():
         return
-    example = Path(__file__).resolve().parent / "docs" / "ENV_EXAMPLE.md"
+    example = Path(__file__).resolve().parent / "env.example"
     try:
-        lines = example.read_text().splitlines()
+        env_lines = example.read_text().splitlines()
     except FileNotFoundError:
         return
-    start = None
-    for idx, line in enumerate(lines):
-        if line.strip().startswith("```bash"):
-            start = idx + 1
-            break
-    if start is None:
-        return
-    end = start
-    for idx in range(start, len(lines)):
-        if lines[idx].strip().startswith("```"):
-            end = idx
-            break
-    env_lines = lines[start:end]
     for i, line in enumerate(env_lines):
         if line.startswith("UME_AUDIT_SIGNING_KEY="):
             env_lines[i] = f"UME_AUDIT_SIGNING_KEY={secrets.token_hex(32)}"
             break
     env_content = "\n".join(env_lines) + "\n"
     env_file.write_text(env_content)
-    print("Created .env from docs/ENV_EXAMPLE.md with random UME_AUDIT_SIGNING_KEY")
+    print("Created .env from env.example with random UME_AUDIT_SIGNING_KEY")
 
 
 def _quickstart() -> None:


### PR DESCRIPTION
## Summary
- add env.example as a template environment file
- copy env.example when creating .env and inject random signing key
- reference env.example in docs
- document the template location

## Testing
- `pre-commit run --files README.md docs/ENV_EXAMPLE.md ume_cli.py env.example`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e6a3df3dc832688e96f2273531fac