### PR TITLE
Implement token cleanup scheduler

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 161
+        "line_number": 172
       }
     ],
     "tests/test_anonymizer.py": [
@@ -146,5 +146,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-09T00:30:43Z"
+  "generated_at": "2025-07-09T13:34:16Z"
 }

--- a/src/ume/api_deps.py
+++ b/src/ume/api_deps.py
@@ -53,6 +53,14 @@ def configure_vector_store(store: VectorStore) -> None:
     app.state.vector_store = store
 
 
+def remove_expired_tokens() -> None:
+    """Delete tokens from ``TOKENS`` that have expired."""
+    now = time.time()
+    expired = [tok for tok, (_, exp) in TOKENS.items() if exp < now]
+    for tok in expired:
+        TOKENS.pop(tok, None)
+
+
 def get_current_role(token: str = Depends(oauth2_scheme)) -> str:
     if token == settings.UME_API_TOKEN:
         return settings.UME_API_ROLE or ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,10 @@ import pytest
 # Ensure the src directory is importable when UME isn't installed
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+# Force the vector backend to chroma to avoid faiss dependency during tests
+from ume.config import settings as _settings
+object.__setattr__(_settings, "UME_VECTOR_BACKEND", "chroma")
+
 # Stub optional dependencies so importing ume modules doesn't fail when they
 # aren't installed. Tests that rely on these packages will provide their own
 # implementations.
@@ -92,6 +96,7 @@ _OPTIONAL_PACKAGES = [
     "confluent_kafka",
     "structlog",
     "neo4j",
+    "faiss",
 ]
 
 for _package in _OPTIONAL_PACKAGES:
@@ -106,6 +111,12 @@ for _package in _OPTIONAL_PACKAGES:
             module.KafkaError = _Dummy
             module.KafkaException = Exception
             module.Message = _Dummy
+        if _package == "faiss":
+            # minimal stub just to satisfy import checks in tests
+            module.IndexFlatL2 = object
+        if _package == "neo4j":
+            module.GraphDatabase = object
+            module.Driver = object
         sys.modules.setdefault(_package, module)
 
 try:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -287,3 +287,17 @@ def test_exception_logging_on_query(
         "Unhandled exception while processing request" in rec.getMessage()
         for rec in caplog.records
     )
+
+
+def test_token_cleanup_task(monkeypatch: MonkeyPatch) -> None:
+    from ume import api as api_mod
+
+    monkeypatch.setattr(api_mod, "TOKEN_CLEANUP_INTERVAL", 0.01)
+    monkeypatch.setattr(settings, "UME_OAUTH_TTL", 0.02)
+
+    with TestClient(app) as client:
+        token = _token(client)
+        assert token in deps.TOKENS
+        time.sleep(0.05)
+        assert token not in deps.TOKENS
+


### PR DESCRIPTION
## Summary
- clean out expired tokens automatically
- make helper for removing expired tokens
- test background cleanup
- stub optional dependencies for test runs

## Testing
- `pre-commit run --files src/ume/api.py src/ume/api_deps.py tests/conftest.py tests/test_api.py`
- `pytest tests/test_api.py -k test_token_cleanup_task -q`


------
https://chatgpt.com/codex/tasks/task_e_686e6a3cca5883268d94b74b6a51faf1