### PR TITLE
Add embedding dimension validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,7 +910,10 @@ index via `VectorStoreListener`.
 Set the following environment variables to configure the store:
 
 - `UME_VECTOR_BACKEND` – `faiss` (default) or `chroma`.
-- `UME_VECTOR_DIM` – dimension of the embedding vectors (default `1536`).
+- `UME_VECTOR_DIM` – dimension of the embedding vectors (default `1536`). This
+  must match the output dimension of the configured embedding model. If set to
+  `0`, the dimension will be detected automatically when the vector store is
+  created.
 - `UME_VECTOR_INDEX` – path of the index file.
 - `UME_VECTOR_USE_GPU` – set to `true` to build the index on a GPU (requires
   FAISS compiled with GPU support).


### PR DESCRIPTION
## Summary
- detect embedding model vector length when creating a VectorStore
- auto-adjust or raise when `UME_VECTOR_DIM` mismatches
- cover dimension checks in new unit tests
- document embedding dimension requirement

## Testing
- `ruff check src/ume/vector_store.py tests/test_vector_store.py`
- `mypy src/ume/vector_store.py tests/test_vector_store.py`
- `pytest tests/test_vector_store.py::test_create_default_store_dimension_mismatch tests/test_vector_store.py::test_create_default_store_dimension_autoset tests/test_vector_store_unit.py::test_create_default_store_selects_backend -q`

------
https://chatgpt.com/codex/tasks/task_e_686e784117f08326bffa27025aa335c6