### PR TITLE
Update docs for snapshot scheduler and ledger replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ The `ume` CLI can spin up all services for local development. From the repositor
 
 
 ```bash
-poetry run python ume_cli.py up
+poetry run ume-cli up
 ```
 
 The command generates TLS certificates if needed and waits until the services
@@ -365,7 +365,7 @@ http://localhost:8000/recall
 ```
 Stop the services with:
 ```bash
-poetry run python ume_cli.py down
+poetry run ume-cli down
 ```
 See [docs/SSL_SETUP.md](docs/SSL_SETUP.md) for details.
 

--- a/docs/AGING_SCHEDULERS.md
+++ b/docs/AGING_SCHEDULERS.md
@@ -10,6 +10,9 @@ side by side and each focuses on a specific layer of storage.
   outdated vectors.
 - `start_vector_age_scheduler` audits existing vectors and records warnings
   when embeddings exceed the `UME_VECTOR_MAX_AGE_DAYS` threshold.
+- `enable_periodic_snapshot` periodically writes the graph to
+  `UME_SNAPSHOT_PATH`. Use `enable_snapshot_autosave_and_restore` to restore
+  the previous snapshot at startup and schedule future saves.
 
 Applications can start these schedulers independently. Each function returns the
 background thread and a stop callback so lifecycles can be coordinated.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -55,6 +55,14 @@ Write the entire graph state to a JSON file.
 Replace the current graph with the contents of a snapshot file.
 - **Body**: `{"path": "file.json"}`
 
+### GET `/ledger/events`
+List entries in the event ledger.
+- **Query parameters**: `start` (default `0`), optional `end`, optional `limit`.
+
+### GET `/ledger/replay`
+Return a snapshot of the graph reconstructed from ledger events.
+- **Query parameters**: optional `end_offset`, optional `end_timestamp`.
+
 ### GET `/policies`
 List available Rego policy files.
 

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -118,7 +118,7 @@ stack:
 1. Install Docker and Docker Compose.
 2. From the project root run:
    ```bash
-   poetry run python ume_cli.py up
+   poetry run ume-cli up
    ```
 3. Wait until `redpanda`, `neo4j`, and `ume-api` report `healthy` with `docker compose ps`.
 4. Inspect logs with `docker compose logs -f ume-api`.

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -150,6 +150,14 @@ snapshot = build_graph_from_ledger(ledger, end_timestamp=1_725_000_000)
 The `/ledger/replay` API wraps this helper and returns a JSON snapshot of the
 graph state.
 
+## Snapshot scheduler
+
+Call :func:`ume.enable_periodic_snapshot` to write the graph to
+``UME_SNAPSHOT_PATH`` at a fixed interval (default 3600 seconds). The function
+returns the background thread and a stop callback. Use
+:func:`ume.enable_snapshot_autosave_and_restore` to restore an existing snapshot
+before scheduling future saves.
+
 ## Memory aging
 
 The :class:`ume.memory.TieredMemoryManager` orchestrates data movement across


### PR DESCRIPTION
## Summary
- document new snapshot scheduler
- add ledger replay API details
- update Quickstart and Docker instructions
- link snapshot helpers in aging scheduler docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e7f8f8a288326ae244f0d58f7b06a