### PR TITLE
Add ingestion service layer

### DIFF
--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -16,8 +16,9 @@ from .document_guru import reformat_document
 from .reliability import filter_low_confidence
 from .graph_adapter import IGraphAdapter
 from .query import Neo4jQueryEngine
-from .event import parse_event, EventError
-from .processing import apply_event_to_graph, ProcessingError
+from .event import EventError
+from .processing import ProcessingError
+from .services.ingest import ingest_event, ingest_events_batch
 
 # import shared API dependencies
 from . import api_deps as deps
@@ -185,9 +186,7 @@ def api_post_events_batch(
 ) -> Dict[str, Any]:
     """Apply multiple events sequentially to the graph."""
     try:
-        for data in events:
-            event = parse_event(data)
-            apply_event_to_graph(event, graph)
+        ingest_events_batch(events, graph)
     except (EventError, ProcessingError) as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
@@ -300,8 +299,7 @@ def api_post_event(
 ) -> Dict[str, Any]:
     """Validate and apply an event to the graph."""
     try:
-        event = parse_event(data)
-        apply_event_to_graph(event, graph)
+        ingest_event(data, graph)
     except (EventError, ProcessingError) as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 

--- a/src/ume/grpc_server/__init__.py
+++ b/src/ume/grpc_server/__init__.py
@@ -14,8 +14,9 @@ from ..vector_store import VectorStore
 from ..audit import get_audit_entries
 from ..config import settings
 from ..logging_utils import configure_logging
-from ..event import parse_event, EventError
-from ..processing import apply_event_to_graph, ProcessingError
+from ..event import EventError
+from ..processing import ProcessingError
+from ..services.ingest import ingest_event
 
 from ume_client import ume_pb2, ume_pb2_grpc  # type: ignore
 
@@ -137,8 +138,7 @@ class UMEServicer(ume_pb2_grpc.UMEServicer):
                 "target_node_id": meta.target_node_id or None,
                 "label": meta.label or None,
             }
-            event = parse_event(event_dict)
-            apply_event_to_graph(event, self.graph)
+            ingest_event(event_dict, self.graph)
         except (EventError, ProcessingError) as exc:
             await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(exc))
 

--- a/src/ume/services/__init__.py
+++ b/src/ume/services/__init__.py
@@ -1,0 +1,5 @@
+"""Utility service functions for UME."""
+
+from .ingest import ingest_event, ingest_events_batch
+
+__all__ = ["ingest_event", "ingest_events_batch"]

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -1,0 +1,23 @@
+"""Event ingestion helpers used by API and gRPC layers."""
+
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any
+
+from ..event import parse_event
+from ..processing import apply_event_to_graph
+from ..graph_adapter import IGraphAdapter
+
+__all__ = ["ingest_event", "ingest_events_batch"]
+
+
+def ingest_event(data: Dict[str, Any], graph: IGraphAdapter) -> None:
+    """Parse and apply a single event to ``graph``."""
+    event = parse_event(data)
+    apply_event_to_graph(event, graph)
+
+
+def ingest_events_batch(events: Iterable[Dict[str, Any]], graph: IGraphAdapter) -> None:
+    """Sequentially ingest multiple events into ``graph``."""
+    for data in events:
+        ingest_event(data, graph)

--- a/tests/test_ingest_consistency.py
+++ b/tests/test_ingest_consistency.py
@@ -1,0 +1,137 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import grpc
+from fastapi.testclient import TestClient
+
+# Make generated gRPC client importable
+base = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(base / "src" / "ume_client"))  # noqa: E402
+
+from google.protobuf import struct_pb2  # noqa: E402
+from ume.api import app, configure_graph  # noqa: E402
+from ume.config import settings  # noqa: E402
+from ume.graph import MockGraph  # noqa: E402
+from ume.grpc_server import UMEServicer  # noqa: E402
+from ume_client import events_pb2, ume_pb2_grpc  # type: ignore  # noqa: E402
+from ume_client.async_client import AsyncUMEClient  # type: ignore  # noqa: E402
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return res.json()["access_token"]
+
+
+def _dict_to_envelope(data: dict[str, object]) -> events_pb2.EventEnvelope:
+    from ume.event import parse_event
+    evt = parse_event(data)
+    struct_payload = struct_pb2.Struct()
+    struct_payload.update(evt.payload)
+    meta = events_pb2.BaseEvent(
+        event_id=evt.event_id,
+        event_type=evt.event_type,
+        timestamp=evt.timestamp,
+        source=evt.source or "",
+        node_id=evt.node_id or "",
+        target_node_id=evt.target_node_id or "",
+        label=evt.label or "",
+        payload=struct_payload,
+    )
+    if evt.event_type == "CREATE_NODE":
+        return events_pb2.EventEnvelope(create_node=events_pb2.CreateNode(meta=meta))
+    if evt.event_type == "UPDATE_NODE_ATTRIBUTES":
+        return events_pb2.EventEnvelope(update_node_attributes=events_pb2.UpdateNodeAttributes(meta=meta))
+    if evt.event_type == "CREATE_EDGE":
+        return events_pb2.EventEnvelope(create_edge=events_pb2.CreateEdge(meta=meta))
+    if evt.event_type == "DELETE_EDGE":
+        return events_pb2.EventEnvelope(delete_edge=events_pb2.DeleteEdge(meta=meta))
+    raise ValueError(evt.event_type)
+
+
+class DummyQE:
+    def execute_cypher(self, cypher: str):
+        return []
+
+
+class DummyStore:
+    pass
+
+
+async def _run_server(port_holder: list[int], graph: MockGraph):
+    server = grpc.aio.server()
+    svc = UMEServicer(DummyQE(), DummyStore(), graph)
+    ume_pb2_grpc.add_UMEServicer_to_server(svc, server)
+    port_holder.append(server.add_insecure_port("localhost:0"))
+    await server.start()
+    try:
+        await server.wait_for_termination()
+    finally:
+        await server.stop(None)
+
+
+def test_http_vs_grpc_ingest_consistency():
+    if not hasattr(settings, "UME_GRPC_TOKEN"):
+        object.__setattr__(settings, "UME_GRPC_TOKEN", None)
+    events = [
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 1,
+            "node_id": "n1",
+            "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
+        },
+        {
+            "event_type": "UPDATE_NODE_ATTRIBUTES",
+            "timestamp": 2,
+            "node_id": "n1",
+            "payload": {"node_id": "n1", "attributes": {"age": 30}},
+        },
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 3,
+            "node_id": "n2",
+            "payload": {"node_id": "n2", "attributes": {"name": "Bob"}},
+        },
+        {
+            "event_type": "CREATE_EDGE",
+            "timestamp": 4,
+            "node_id": "n1",
+            "target_node_id": "n2",
+            "label": "ASSOCIATED_WITH",
+            "payload": {},
+        },
+    ]
+
+    # HTTP ingestion
+    graph_http = MockGraph()
+    configure_graph(graph_http)
+    client = TestClient(app)
+    token = _token(client)
+    res = client.post("/events/batch", json=events, headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    state_http = graph_http.dump()
+
+    # gRPC ingestion
+    graph_grpc = MockGraph()
+    ports: list[int] = []
+
+    async def runner():
+        server_task = asyncio.create_task(_run_server(ports, graph_grpc))
+        while not ports:
+            await asyncio.sleep(0.01)
+        async with AsyncUMEClient(f"localhost:{ports[0]}") as client:
+            for evt in events:
+                await client.publish_event(_dict_to_envelope(evt))
+        server_task.cancel()
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(runner())
+    state_grpc = graph_grpc.dump()
+
+    assert state_http == state_grpc


### PR DESCRIPTION
## Summary
- add `ingest_event` and `ingest_events_batch` helpers
- use new ingest helpers in HTTP API and gRPC server
- expose new services package
- ensure HTTP and gRPC ingestion lead to identical graph state

## Testing
- `ruff check .`
- `pytest -q tests/test_ingest_consistency.py`

------
https://chatgpt.com/codex/tasks/task_e_686e7f7e3e208326a575c1155d5fa823