### PR TITLE
Add configuration loader with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,12 +739,12 @@ from :class:`ume.config.Settings` and overridden by environment variables at
 runtime.
 
 ```python
-from ume.config import Settings
+from ume.config import load_settings
 from ume.client import UMEClient, UMEClientError
 import time
 
-# Create Settings (environment variables may override defaults)
-settings = Settings()
+# Load Settings (environment variables may override defaults)
+settings = load_settings()
 
 # Connect to the broker and topic defined in Settings
 with UMEClient(settings) as client:

--- a/examples/agent_integration.py
+++ b/examples/agent_integration.py
@@ -6,7 +6,7 @@ import time
 
 from ume import Event, EventType
 from ume.client import UMEClient
-from ume.config import Settings
+from ume.config.loader import load_settings
 
 # Configure logging so we can observe the flow
 configure_logging()
@@ -34,7 +34,7 @@ def forward_to_culture(events: list[Event]) -> None:
 
 
 if __name__ == "__main__":
-    settings = Settings()
+    settings = load_settings()
     client = UMEClient(settings)
 
     # Step 1: AutoDev produces an event

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -97,14 +97,21 @@ class Settings(BaseSettings):  # type: ignore[misc]
     def model_post_init(self, __context: Any) -> None:  # noqa: D401
         """Validate settings after initialization."""
         if self.UME_AUDIT_SIGNING_KEY == DEFAULT_AUDIT_SIGNING_KEY:
+
             logging.getLogger(__name__).warning(
                 "Edit the generated .env file to replace the placeholder "
                 "UME_AUDIT_SIGNING_KEY."
             )
+
             raise ValueError(
                 "UME_AUDIT_SIGNING_KEY must be set to a non-default value"
+
             )
 
+from .loader import load_settings  # noqa: E402
+load_settings.cache_clear()
 
 # Create a single, importable instance
-settings = Settings()
+settings = load_settings()
+
+__all__ = ["Settings", "settings", "load_settings", "DEFAULT_AUDIT_SIGNING_KEY"]

--- a/src/ume/config/loader.py
+++ b/src/ume/config/loader.py
@@ -1,0 +1,7 @@
+from functools import lru_cache
+from . import Settings
+
+@lru_cache(maxsize=1)
+def load_settings() -> Settings:
+    """Return a cached :class:`Settings` instance."""
+    return Settings()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,27 +1,31 @@
 import pytest
 
-from ume.config import Settings
+from ume.config.loader import load_settings
 
 
 def test_audit_key_default_raises(monkeypatch):
     monkeypatch.setenv("UME_AUDIT_SIGNING_KEY", "default-key")
+    load_settings.cache_clear()
     with pytest.raises(ValueError):
-        Settings()
+        load_settings()
 
 
 def test_audit_key_custom(monkeypatch):
     monkeypatch.setenv("UME_AUDIT_SIGNING_KEY", "mykey")
-    s = Settings()
+    load_settings.cache_clear()
+    s = load_settings()
     assert s.UME_AUDIT_SIGNING_KEY == "mykey"
 
 
 def test_rate_limit_default(monkeypatch):
     monkeypatch.delenv("UME_RATE_LIMIT_REDIS", raising=False)
-    s = Settings()
+    load_settings.cache_clear()
+    s = load_settings()
     assert s.UME_RATE_LIMIT_REDIS is None
 
 
 def test_rate_limit_env(monkeypatch):
     monkeypatch.setenv("UME_RATE_LIMIT_REDIS", "redis://localhost:6379/0")
-    s = Settings()
+    load_settings.cache_clear()
+    s = load_settings()
     assert s.UME_RATE_LIMIT_REDIS == "redis://localhost:6379/0"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -91,7 +91,9 @@ sys.modules["ume.graph"] = graph_module
 spec_graph.loader.exec_module(graph_module)
 MockGraph = graph_module.MockGraph
 
-spec_config = importlib.util.spec_from_file_location("ume.config", root / "src" / "ume" / "config.py")
+spec_config = importlib.util.spec_from_file_location(
+    "ume.config", root / "src" / "ume" / "config" / "__init__.py"
+)
 assert spec_config and spec_config.loader
 config_module = importlib.util.module_from_spec(spec_config)
 sys.modules["ume.config"] = config_module


### PR DESCRIPTION
## Summary
- add `ume.config.loader` to cache settings and expose `load_settings`
- load cached settings in `ume.config` and clear cache on reload
- update documentation and example usage
- refresh unit tests to use `load_settings`
- fix metrics test import path

## Testing
- `ruff check .`
- `poetry run pytest tests/test_config.py tests/test_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686e7f81ac7c83269aa8e0d59b6ea951