### PR TITLE
Add graph & recall views

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,6 +18,13 @@ npm run dev
 
 The app will be available at <http://localhost:5173>. The development server proxies requests to the running API at `http://localhost:8000`.
 
+Run the frontend unit tests with Vitest (after `npm install` has installed all
+dependencies):
+
+```bash
+npm test
+```
+
 The dashboard shows a counter of how many event payloads have been redacted for PII. It polls the `/pii/redactions` endpoint every second. Clicking a policy name opens an inline editor where you can modify the Rego code, validate it via the API, and save your changes.
 
 ## Building

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,8 @@ import PiiStatus from './PiiStatus';
 import PolicyEditor from './PolicyEditor';
 import Recommendations from './Recommendations';
 import ConsentLedger from './ConsentLedger';
+import Recall from './Recall';
+import GraphView from './GraphView';
 
 const POLICY_CONTENT = {
   'allow.rego': `package ume
@@ -151,6 +153,8 @@ function App() {
       <PiiStatus token={token} />
       <Recommendations token={token} />
       <ConsentLedger token={token} />
+      <Recall token={token} />
+      <GraphView token={token} />
       <h3>Policies</h3>
       <ul>
         {policies.map((p) => (

--- a/frontend/src/GraphView.jsx
+++ b/frontend/src/GraphView.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+
+export default function GraphView({ token }) {
+  const [graph, setGraph] = useState(null);
+
+  const load = async () => {
+    const res = await fetch('/ledger/replay', {
+      headers: { Authorization: 'Bearer ' + token },
+    });
+    if (res.ok) setGraph(await res.json());
+  };
+
+  useEffect(() => {
+    if (token) load();
+  }, [token]);
+
+  if (!token) return null;
+
+  return (
+    <div style={{ marginTop: '8px' }}>
+      <h3>Graph</h3>
+      <button onClick={load}>Refresh</button>
+      {graph && (
+        <>
+          <h4>Nodes</h4>
+          <ul>
+            {Object.entries(graph.nodes).map(([id, attrs]) => (
+              <li key={id}>
+                {id} {JSON.stringify(attrs)}
+              </li>
+            ))}
+          </ul>
+          <h4>Edges</h4>
+          <ul>
+            {graph.edges.map(([s, t, l]) => (
+              <li key={`${s}-${t}-${l}`}>{s} -[{l}]-&gt; {t}</li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/GraphView.test.jsx
+++ b/frontend/src/GraphView.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import GraphView from './GraphView';
+
+function mockFetch(responses) {
+  global.fetch = vi.fn((url) => {
+    const res = responses[url] || { nodes: {}, edges: [] };
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(res) });
+  });
+}
+
+describe('GraphView', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('loads graph structure', async () => {
+    const data = { nodes: { n1: {} }, edges: [['n1', 'n2', 'e']] };
+    mockFetch({ '/ledger/replay': data });
+    render(<GraphView token="t" />);
+    await waitFor(() => screen.getByText('n1 {}'));
+    expect(screen.getByText('n1 {}')).toBeInTheDocument();
+    expect(screen.getByText('n1 -[e]-> n2')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/Recall.jsx
+++ b/frontend/src/Recall.jsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+export default function Recall({ token }) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState([]);
+
+  const search = async () => {
+    if (!query) return;
+    const params = new URLSearchParams({ query });
+    const res = await fetch(`/recall?${params}`, {
+      headers: { Authorization: 'Bearer ' + token },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setResults(data.nodes || []);
+    }
+  };
+
+  return (
+    <div style={{ marginTop: '8px' }}>
+      <h3>Recall</h3>
+      <input value={query} onChange={(e) => setQuery(e.target.value)} />
+      <button onClick={search} style={{ marginLeft: '4px' }}>
+        Search
+      </button>
+      <ul>
+        {results.map((n) => (
+          <li key={n.id}>
+            {n.id} {JSON.stringify(n.attributes)}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/Recall.test.jsx
+++ b/frontend/src/Recall.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import Recall from './Recall';
+
+function mockFetch(responses) {
+  global.fetch = vi.fn((url) => {
+    const res = responses[url] || { nodes: [] };
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(res) });
+  });
+}
+
+describe('Recall', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('loads recall results', async () => {
+    mockFetch({ '/recall?query=q': { nodes: [{ id: 'n1', attributes: {} }] } });
+    render(<Recall token="t" />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByText('Search'));
+    await waitFor(() => screen.getByText('n1 {}'));
+    expect(screen.getByText('n1 {}')).toBeInTheDocument();
+  });
+});

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -299,6 +299,7 @@ __all__ = [
     "vector_store",
     "embedding",
     "api",
+    "policy",
 
 ]
 
@@ -315,6 +316,7 @@ _KNOWN_SUBMODULES = {
     "embedding",
     "resources",
     "api",
+    "policy",
 }
 
 def __getattr__(name: str) -> object:  # pragma: no cover - thin wrapper

--- a/src/ume/policy/__init__.py
+++ b/src/ume/policy/__init__.py
@@ -1,2 +1,6 @@
 """Policy definitions and utilities for UME access control."""
 
+from .api_client import PolicyAPI
+
+__all__ = ["PolicyAPI"]
+

--- a/src/ume/policy/api_client.py
+++ b/src/ume/policy/api_client.py
@@ -1,0 +1,43 @@
+"""HTTP client helpers for managing Rego policies via the API."""
+
+from __future__ import annotations
+
+import httpx
+
+
+class PolicyAPI:
+    """Simple wrapper for the policy management endpoints."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.Client(timeout=5)
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+
+    def save_policy(self, name: str, content: str) -> None:
+        """Create a new policy file on the server."""
+        files = {"file": (name, content.encode("utf-8"))}
+        resp = self._client.post(f"{self.base_url}/policies/{name}", files=files, headers=self._headers())
+        resp.raise_for_status()
+
+    def edit_policy(self, name: str, content: str) -> None:
+        """Replace an existing policy on the server."""
+        files = {"file": (name, content.encode("utf-8"))}
+        resp = self._client.put(f"{self.base_url}/policies/{name}", files=files, headers=self._headers())
+        resp.raise_for_status()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "PolicyAPI":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        self.close()

--- a/tests/test_policy_api.py
+++ b/tests/test_policy_api.py
@@ -1,0 +1,17 @@
+import pytest
+import httpx
+from ume.policy import PolicyAPI
+
+respx = pytest.importorskip("respx")
+
+
+def test_save_and_edit_policy() -> None:
+    with respx.mock(assert_all_called=True) as mock:
+        save_route = mock.post("http://ume/policies/p.rego").mock(return_value=httpx.Response(200))
+        edit_route = mock.put("http://ume/policies/p.rego").mock(return_value=httpx.Response(200))
+        api = PolicyAPI(base_url="http://ume", api_key="t")
+        api.save_policy("p.rego", "allow = true")
+        api.edit_policy("p.rego", "allow = false")
+        assert save_route.called
+        assert edit_route.called
+


### PR DESCRIPTION
## Summary
- add Recall and GraphView components to visualize search results and graph structure
- expose PolicyAPI helper and tests for managing Rego policies
- wire new components into the dashboard
- document running Vitest
- clarify that `npm test` requires installed dependencies

## Testing
- `pre-commit run --files src/ume/__init__.py src/ume/policy/__init__.py src/ume/policy/api_client.py tests/test_policy_api.py`
- `pytest tests/test_policy_api.py -q`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_686e7f8836a88326bf19df9298a5822a