### PR TITLE
Add snapshot scheduler CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,6 +677,15 @@ This section outlines the basic programmatic steps to interact with the UME comp
     enable_snapshot_autosave_and_restore(graph_adapter, "ume_snapshot.json")
     ```
 
+    Or run the scheduler from the command line:
+
+    ```bash
+    ume-cli snapshot-schedule --interval 300
+    ```
+
+    This writes updates to the path configured by `UME_SNAPSHOT_PATH` every
+    5 minutes until stopped with `Ctrl+C`.
+
 6.  **Load Graph from Snapshot (Optional):**
     Restore a graph's state from a previously saved snapshot file:
     ```python


### PR DESCRIPTION
## Summary
- support `ume-cli snapshot-schedule` for periodic snapshots
- document how to use the scheduler
- test that the CLI subcommand invokes the scheduler
- stub heavy ume imports in test so it runs without optional deps
- fix CLI smoke tests by clearing `UME_ROLE`

## Testing
- `pre-commit run --files ume_cli.py README.md tests/test_cli_smoke.py`
- `pytest -q tests/test_cli_smoke.py::test_cli_redact_node_and_edge tests/test_cli_smoke.py::test_cli_snapshot_schedule`


------
https://chatgpt.com/codex/tasks/task_e_686e7f8a520c83268f6a6433514d8d40