### PR TITLE
Restrict snapshot paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,7 +697,8 @@ This section outlines the basic programmatic steps to interact with the UME comp
     ```
 
     This writes updates to the path configured by `UME_SNAPSHOT_PATH` every
-    5 minutes until stopped with `Ctrl+C`.
+    5 minutes until stopped with `Ctrl+C`. Snapshot paths must reside under
+    the directory specified by `UME_SNAPSHOT_DIR`.
 
 6.  **Load Graph from Snapshot (Optional):**
     Restore a graph's state from a previously saved snapshot file:

--- a/docs/AGING_SCHEDULERS.md
+++ b/docs/AGING_SCHEDULERS.md
@@ -12,7 +12,8 @@ side by side and each focuses on a specific layer of storage.
   when embeddings exceed the `UME_VECTOR_MAX_AGE_DAYS` threshold.
 - `enable_periodic_snapshot` periodically writes the graph to
   `UME_SNAPSHOT_PATH`. Use `enable_snapshot_autosave_and_restore` to restore
-  the previous snapshot at startup and schedule future saves.
+  the previous snapshot at startup and schedule future saves. Snapshot files
+  must be located within `UME_SNAPSHOT_DIR`.
 
 Applications can start these schedulers independently. Each function returns the
 background thread and a stop callback so lifecycles can be coordinated.

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -61,6 +61,7 @@ below lists all available variables and their default values.
 | `UME_DB_PATH` | `ume_graph.db` | SQLite database used by `PersistentGraph`. |
 | `UME_GRAPH_BACKEND` | `sqlite` | Backend for graph storage (`sqlite`, `postgres`, or `redis`). |
 | `UME_SNAPSHOT_PATH` | `ume_snapshot.json` | Path to graph snapshot file. |
+| `UME_SNAPSHOT_DIR` | `.` | Directory that snapshot APIs will accept paths from. |
 | `UME_AUDIT_LOG_PATH` | `audit.log` | Location of the audit log. |
 | `UME_AUDIT_SIGNING_KEY` | `default-key` | Key used to sign audit entries. Must be changed from the default or startup will fail. |
 | `UME_AGENT_ID` | `SYSTEM` | Identifier recorded in audit logs. |

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -156,7 +156,8 @@ Call :func:`ume.enable_periodic_snapshot` to write the graph to
 ``UME_SNAPSHOT_PATH`` at a fixed interval (default 3600 seconds). The function
 returns the background thread and a stop callback. Use
 :func:`ume.enable_snapshot_autosave_and_restore` to restore an existing snapshot
-before scheduling future saves.
+before scheduling future saves. Snapshot locations are validated against
+``UME_SNAPSHOT_DIR``.
 
 ## Memory aging
 

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -21,6 +21,7 @@ except ImportError:  # pragma: no cover - allow import without environment setup
     stub.settings = SimpleNamespace(  # type: ignore[attr-defined]
         UME_DB_PATH="ume_graph.db",
         UME_SNAPSHOT_PATH="ume_snapshot.json",
+        UME_SNAPSHOT_DIR=".",
         UME_COLD_DB_PATH="ume_cold.db",
         UME_COLD_SNAPSHOT_PATH="ume_cold_snapshot.json",
         UME_COLD_EVENT_AGE_DAYS=180,

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_DB_PATH: str = "ume_graph.db"
     UME_GRAPH_BACKEND: str = "sqlite"  # sqlite, postgres, or redis
     UME_SNAPSHOT_PATH: str = "ume_snapshot.json"
+    UME_SNAPSHOT_DIR: str = "."
     UME_COLD_DB_PATH: str = "ume_cold.db"
     UME_COLD_SNAPSHOT_PATH: str = "ume_cold_snapshot.json"
     UME_COLD_EVENT_AGE_DAYS: int = 180


### PR DESCRIPTION
## Summary
- restrict snapshot REST APIs to a whitelisted directory
- expose `UME_SNAPSHOT_DIR` setting
- validate snapshot paths in snapshot routes
- document snapshot directory restriction
- test valid and invalid snapshot paths

## Testing
- `ruff check src/ume/snapshot_routes.py tests/test_snapshot_routes.py src/ume/config/__init__.py src/ume/__init__.py`
- `mypy --config-file mypy.ini src/ume/snapshot_routes.py tests/test_snapshot_routes.py src/ume/config/__init__.py src/ume/__init__.py`
- `PYTHONPATH=src pytest tests/test_snapshot_routes.py -k test_snapshot_dir_restrictions -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0d1186448326ac7116eb826222d3