### PR TITLE
Add /graph/history endpoint

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -68,6 +68,10 @@ List entries in the event ledger.
 Return a snapshot of the graph reconstructed from ledger events.
 - **Query parameters**: optional `end_offset`, optional `end_timestamp`.
 
+### GET `/graph/history`
+Return a snapshot of the graph as it existed at a past point in time.
+- **Query parameters**: optional `offset`, optional `timestamp`.
+
 ### GET `/policies`
 List available Rego policy files.
 

--- a/src/ume/ledger_routes.py
+++ b/src/ume/ledger_routes.py
@@ -44,3 +44,17 @@ def replay_ledger(
         event_ledger, end_offset=end_offset, end_timestamp=end_timestamp
     )
     return graph.dump()
+
+
+@router.get("/graph/history")
+def graph_history(
+    offset: int | None = Query(None, ge=0),
+    timestamp: int | None = Query(None, ge=0),
+    _: str = Depends(deps.get_current_role),
+) -> Dict[str, Any]:
+    """Return a snapshot of the graph at ``offset`` or ``timestamp``."""
+
+    graph = build_graph_from_ledger(
+        event_ledger, end_offset=offset, end_timestamp=timestamp
+    )
+    return graph.dump()

--- a/tests/test_api_graph_history.py
+++ b/tests/test_api_graph_history.py
@@ -1,0 +1,63 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from ume.api import app
+from ume.config import settings
+from ume.event_ledger import EventLedger
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return res.json()["access_token"]
+
+
+def test_graph_history_offset(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    ledger.append(
+        0,
+        {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "a", "payload": {"node_id": "a"}},
+    )
+    ledger.append(
+        1,
+        {"event_type": "CREATE_NODE", "timestamp": 2, "node_id": "b", "payload": {"node_id": "b"}},
+    )
+    monkeypatch.setattr("ume.ledger_routes.event_ledger", ledger)
+
+    client = TestClient(app)
+    token = _token(client)
+    res = client.get(
+        "/graph/history",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"offset": 0},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert set(data["nodes"].keys()) == {"a"}
+
+
+def test_graph_history_timestamp(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    ledger.append(
+        0,
+        {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "c", "payload": {"node_id": "c"}},
+    )
+    ledger.append(
+        1,
+        {"event_type": "CREATE_NODE", "timestamp": 3, "node_id": "d", "payload": {"node_id": "d"}},
+    )
+    monkeypatch.setattr("ume.ledger_routes.event_ledger", ledger)
+
+    client = TestClient(app)
+    token = _token(client)
+    res = client.get(
+        "/graph/history",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"timestamp": 1},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert set(data["nodes"].keys()) == {"c"}
+


### PR DESCRIPTION
## Summary
- support reading graph state at a historical point
- expose helper `fetch_graph_history` in `ume.client`
- document `/graph/history` in API reference
- test the new endpoint

## Testing
- `pre-commit run --files docs/API_REFERENCE.md src/ume/client.py src/ume/ledger_routes.py tests/test_api_graph_history.py`
- `pytest -q tests/test_api_graph_history.py`

------
https://chatgpt.com/codex/tasks/task_e_686f2375769c83268d1c514c53e3b39e