### PR TITLE
Refactor ingestion service

### DIFF
--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -18,7 +18,7 @@ from .graph_adapter import IGraphAdapter
 from .query import Neo4jQueryEngine
 from .event import EventError
 from .processing import ProcessingError
-from .services.ingest import ingest_event, ingest_events_batch
+from ume.services.ingest import ingest_event, ingest_events_batch
 
 # import shared API dependencies
 from . import api_deps as deps

--- a/src/ume/grpc_server/__init__.py
+++ b/src/ume/grpc_server/__init__.py
@@ -16,7 +16,7 @@ from ..config import settings
 from ..logging_utils import configure_logging
 from ..event import EventError
 from ..processing import ProcessingError
-from ..services.ingest import ingest_event
+from ume.services.ingest import ingest_event
 
 from ume_client import ume_pb2, ume_pb2_grpc  # type: ignore
 

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -4,17 +4,32 @@ from __future__ import annotations
 
 from typing import Iterable, Dict, Any
 
-from ..event import parse_event
+from ..event import Event, parse_event
 from ..processing import apply_event_to_graph
 from ..graph_adapter import IGraphAdapter
 
-__all__ = ["ingest_event", "ingest_events_batch"]
+__all__ = [
+    "validate_event",
+    "apply_event",
+    "ingest_event",
+    "ingest_events_batch",
+]
+
+
+def validate_event(data: Dict[str, Any]) -> Event:
+    """Parse ``data`` into an :class:`~ume.event.Event`."""
+    return parse_event(data)
+
+
+def apply_event(event: Event, graph: IGraphAdapter) -> None:
+    """Apply ``event`` to ``graph`` using :func:`~ume.processing.apply_event_to_graph`."""
+    apply_event_to_graph(event, graph)
 
 
 def ingest_event(data: Dict[str, Any], graph: IGraphAdapter) -> None:
-    """Parse and apply a single event to ``graph``."""
-    event = parse_event(data)
-    apply_event_to_graph(event, graph)
+    """Validate ``data`` and apply the resulting event to ``graph``."""
+    event = validate_event(data)
+    apply_event(event, graph)
 
 
 def ingest_events_batch(events: Iterable[Dict[str, Any]], graph: IGraphAdapter) -> None:

--- a/tests/test_ingest_consistency.py
+++ b/tests/test_ingest_consistency.py
@@ -27,8 +27,8 @@ def _token(client: TestClient) -> str:
 
 
 def _dict_to_envelope(data: dict[str, object]) -> events_pb2.EventEnvelope:
-    from ume.event import parse_event
-    evt = parse_event(data)
+    from ume.services.ingest import validate_event
+    evt = validate_event(data)
     struct_payload = struct_pb2.Struct()
     struct_payload.update(evt.payload)
     meta = events_pb2.BaseEvent(


### PR DESCRIPTION
## Summary
- expose `validate_event` and `apply_event` helpers in `ume.services.ingest`
- import ingestion helpers using the new `ume.services.ingest` path
- update ingest consistency test to use the new helper

## Testing
- `pre-commit run --files src/ume/services/ingest.py src/ume/graph_routes.py src/ume/grpc_server/__init__.py tests/test_ingest_consistency.py`
- `pytest tests/test_ingest_consistency.py::test_http_vs_grpc_ingest_consistency -q`

------
https://chatgpt.com/codex/tasks/task_e_686f23748de0832697507abb2b546a85