### PR TITLE
Add setup_dev_env script

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ Ensure you have installed the development dependencies:
 ```bash
 poetry install --with dev
 ```
+To also install all optional packages used by the tests, run:
+```bash
+scripts/setup_dev_env.sh
+```
 (This project uses `pre-commit` for linting and type checks. To run the same
 checks as CI, execute:)
 ```bash

--- a/scripts/setup_dev_env.sh
+++ b/scripts/setup_dev_env.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Install all development and optional dependencies for local testing
+set -euo pipefail
+
+poetry install --with dev --all-extras "$@"

--- a/tests/README.md
+++ b/tests/README.md
@@ -21,3 +21,8 @@ The test suite requires several optional packages that are not installed with th
 - `grpcio-tools`
 
 Many tests also rely on `faiss` and `sentence-transformers`, but these are optional. Tests that require them will be skipped if the packages are not available.
+
+Install all of the above dependencies in one step with:
+```bash
+poetry install --with dev --all-extras
+```


### PR DESCRIPTION
## Summary
- add quick optional dependency installation command
- provide setup_dev_env.sh to install dev deps and all extras
- link the script from the README

## Testing
- `poetry run pre-commit run --files README.md tests/README.md scripts/setup_dev_env.sh`
- `poetry run pytest -k test_ci_should_run.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870405761a08326b60c7547e7b549b7