### PR TITLE
Move ledger replay helpers

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -96,8 +96,7 @@ adapter layer.
 
 Sanitized events are appended to a lightweight ledger along with their
 Redpanda offsets. The ledger can be queried via the `/ledger/events` API and
-used with `PersistentGraph.replay_from_ledger()` to rebuild state from any
-offset.
+used with `ume.replay.replay_from_ledger()` to rebuild state from any offset.
 
 ## Policy DSL Flow
 

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -139,7 +139,7 @@ events up to a specified offset or timestamp:
 
 ```python
 from ume.event_ledger import EventLedger
-from ume.persistent_graph import build_graph_from_ledger
+from ume.replay import build_graph_from_ledger
 
 ledger = EventLedger("ledger.db")
 graph = build_graph_from_ledger(ledger, end_offset=10)

--- a/src/ume/ledger_routes.py
+++ b/src/ume/ledger_routes.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 
 from .event_ledger import event_ledger
-from .persistent_graph import build_graph_from_ledger
+from .replay import build_graph_from_ledger
 from . import api_deps as deps
 
 router = APIRouter()

--- a/src/ume/neo4j_graph.py
+++ b/src/ume/neo4j_graph.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Dict, List, Optional, cast, TYPE_CHECKING
 import time
 
 from neo4j import GraphDatabase, Driver
@@ -13,6 +13,10 @@ from .processing import DEFAULT_VERSION
 from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .graph_algorithms import GraphAlgorithmsMixin
+from .replay import replay_from_ledger
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .event_ledger import EventLedger
 
 
 class Neo4jGraph(GraphAlgorithmsMixin, IGraphAdapter):
@@ -314,3 +318,20 @@ class Neo4jGraph(GraphAlgorithmsMixin, IGraphAdapter):
                 {"window": window},
             )
             return {rec["id"]: rec["score"] for rec in result}
+
+    def replay_from_ledger(
+        self,
+        ledger: "EventLedger",
+        start_offset: int = 0,
+        end_offset: int | None = None,
+        *,
+        end_timestamp: int | None = None,
+    ) -> int:
+        """Delegate to :func:`ume.replay.replay_from_ledger`."""
+        return replay_from_ledger(
+            self,
+            ledger,
+            start_offset=start_offset,
+            end_offset=end_offset,
+            end_timestamp=end_timestamp,
+        )

--- a/src/ume/postgres_graph.py
+++ b/src/ume/postgres_graph.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 import importlib
 import json
 import time
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast, TYPE_CHECKING
 
 from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .graph_algorithms import GraphAlgorithmsMixin
 from .audit import log_audit_entry
 from .config import settings
+from .replay import replay_from_ledger
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .event_ledger import EventLedger
 
 _spec = importlib.util.find_spec("psycopg")
 psycopg = importlib.import_module("psycopg") if _spec is not None else None
@@ -232,5 +236,22 @@ class PostgresGraph(GraphAlgorithmsMixin, IGraphAdapter):
                 (cutoff, cutoff),
             )
             cur.execute("DELETE FROM nodes WHERE created_at < %s", (cutoff,))
+
+    def replay_from_ledger(
+        self,
+        ledger: "EventLedger",
+        start_offset: int = 0,
+        end_offset: int | None = None,
+        *,
+        end_timestamp: int | None = None,
+    ) -> int:
+        """Delegate to :func:`ume.replay.replay_from_ledger`."""
+        return replay_from_ledger(
+            self,
+            ledger,
+            start_offset=start_offset,
+            end_offset=end_offset,
+            end_timestamp=end_timestamp,
+        )
 
 

--- a/src/ume/redis_graph_adapter.py
+++ b/src/ume/redis_graph_adapter.py
@@ -3,13 +3,17 @@ from __future__ import annotations
 
 import importlib
 import json
-from typing import Any, Dict, List, Optional, Tuple, cast
+from typing import Any, Dict, List, Optional, Tuple, cast, TYPE_CHECKING
 
 from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .graph_algorithms import GraphAlgorithmsMixin
 from .audit import log_audit_entry
 from .config import settings
+from .replay import replay_from_ledger
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .event_ledger import EventLedger
 
 _spec = importlib.util.find_spec("redis")
 redis = importlib.import_module("redis") if _spec is not None else None
@@ -172,5 +176,22 @@ class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
         log_audit_entry(
             settings.UME_AGENT_ID,
             f"redact_edge {source_node_id} {target_node_id} {label}",
+        )
+
+    def replay_from_ledger(
+        self,
+        ledger: "EventLedger",
+        start_offset: int = 0,
+        end_offset: int | None = None,
+        *,
+        end_timestamp: int | None = None,
+    ) -> int:
+        """Delegate to :func:`ume.replay.replay_from_ledger`."""
+        return replay_from_ledger(
+            self,
+            ledger,
+            start_offset=start_offset,
+            end_offset=end_offset,
+            end_timestamp=end_timestamp,
         )
 

--- a/src/ume/replay.py
+++ b/src/ume/replay.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .graph_adapter import IGraphAdapter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .event_ledger import EventLedger
+
+
+def replay_from_ledger(
+    graph: IGraphAdapter,
+    ledger: "EventLedger",
+    start_offset: int = 0,
+    end_offset: int | None = None,
+    *,
+    end_timestamp: int | None = None,
+) -> int:
+    """Replay ledger events into ``graph`` starting from ``start_offset``."""
+    last = start_offset
+    from .event import parse_event
+    from .processing import apply_event_to_graph
+
+    for off, data in ledger.range(start=start_offset, end=end_offset):
+        if end_timestamp is not None and data.get("timestamp", 0) > end_timestamp:
+            break
+        event = parse_event(data)
+        apply_event_to_graph(event, graph)
+        last = off
+    return last
+
+
+def build_graph_from_ledger(
+    ledger: "EventLedger",
+    graph: IGraphAdapter | None = None,
+    *,
+    end_offset: int | None = None,
+    end_timestamp: int | None = None,
+    db_path: str | None = ":memory:",
+) -> IGraphAdapter:
+    """Return ``graph`` populated from ``ledger``."""
+    if graph is None:
+        from .persistent_graph import PersistentGraph
+
+        graph = PersistentGraph(db_path, check_same_thread=False)
+    replay_from_ledger(
+        graph,
+        ledger,
+        start_offset=0,
+        end_offset=end_offset,
+        end_timestamp=end_timestamp,
+    )
+    return graph

--- a/src/ume/snapshot_routes.py
+++ b/src/ume/snapshot_routes.py
@@ -7,7 +7,7 @@ from .api_deps import get_graph, get_current_role
 from .graph_adapter import IGraphAdapter
 from .snapshot import snapshot_graph_to_file, load_graph_into_existing
 from .event_ledger import event_ledger
-from .persistent_graph import build_graph_from_ledger
+from .replay import build_graph_from_ledger
 from .api_deps import configure_graph
 from .config import settings
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,16 +21,11 @@ import pytest
 # Ensure the src directory is importable when UME isn't installed
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-# Force the vector backend to chroma to avoid faiss dependency during tests
-from ume.config import settings as _settings
-object.__setattr__(_settings, "UME_VECTOR_BACKEND", "chroma")
-
 # Stub optional dependencies so importing ume modules doesn't fail when they
 # aren't installed. Tests that rely on these packages will provide their own
 # implementations.
 if importlib.util.find_spec("httpx") is None:
     sys.modules.setdefault("httpx", types.ModuleType("httpx"))
-
 
 yaml_stub = types.ModuleType("yaml")
 yaml_stub.safe_load = lambda _: {}
@@ -88,6 +83,10 @@ jsonschema_stub.validate = _validate  # type: ignore[attr-defined]
 jsonschema_stub.ValidationError = _ValidationError  # type: ignore[attr-defined]
 if importlib.util.find_spec("jsonschema") is None:
     sys.modules.setdefault("jsonschema", jsonschema_stub)
+
+# Force the vector backend to chroma to avoid faiss dependency during tests
+from ume.config import settings as _settings  # noqa: E402
+object.__setattr__(_settings, "UME_VECTOR_BACKEND", "chroma")
 
 # Additional optional packages used in some modules. These are large or
 # platform-specific dependencies that aren't needed for most unit tests, so we

--- a/tests/test_event_ledger.py
+++ b/tests/test_event_ledger.py
@@ -1,5 +1,6 @@
 from ume.event_ledger import EventLedger
 from ume.persistent_graph import PersistentGraph
+from ume.replay import replay_from_ledger
 import pytest
 
 
@@ -11,7 +12,7 @@ def test_replay_from_offset(tmp_path):
     ledger.append(1, event2)
 
     g = PersistentGraph(":memory:")
-    last = g.replay_from_ledger(ledger, 0)
+    last = replay_from_ledger(g, ledger, 0)
     assert g.get_node("n1") is not None
     assert g.get_node("n2") is not None
     assert last == 1
@@ -60,13 +61,13 @@ def test_replay_from_timestamp(tmp_path):
 
     # Replay up to timestamp 2
     g = PersistentGraph(":memory:")
-    g.replay_from_ledger(ledger, 0, end_timestamp=2)
+    replay_from_ledger(g, ledger, 0, end_timestamp=2)
     assert set(g.get_all_node_ids()) == {"n0", "n1", "n2"}
 
     # Replay up to timestamp 4
 
     g2 = PersistentGraph(":memory:")
-    g2.replay_from_ledger(ledger, 0, end_timestamp=4)
+    replay_from_ledger(g2, ledger, 0, end_timestamp=4)
     assert set(g2.get_all_node_ids()) == {"n0", "n1", "n2", "n3", "n4"}
 
     ledger.close()


### PR DESCRIPTION
## Summary
- introduce `ume.replay` module with `replay_from_ledger` and `build_graph_from_ledger`
- delegate replay methods in graph adapters to the new functions
- update routes, docs, and tests to import from `ume.replay`
- stub optional dependencies earlier in `tests/conftest.py`

## Testing
- `ruff check src tests`
- `mypy`
- `pytest tests/test_event_ledger.py tests/test_postgres_ledger_replay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6870469417a48326bf15be1e4281b192