### PR TITLE
Add CrewAI and AutoGen integrations

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -31,6 +31,24 @@ client.send_events([{"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1
 print(client.recall({"node_id": "n1"}))
 ```
 
+## CrewAI
+```python
+from ume.integrations import CrewAI
+
+client = CrewAI()
+client.send_events([{"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1"}])
+print(client.recall({"node_id": "n1"}))
+```
+
+## AutoGen
+```python
+from ume.integrations import AutoGen
+
+client = AutoGen()
+client.send_events([{"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1"}])
+print(client.recall({"node_id": "n1"}))
+```
+
 ## SuperMemory
 ```python
 from ume.integrations import SuperMemory

--- a/src/ume/integrations/__init__.py
+++ b/src/ume/integrations/__init__.py
@@ -4,6 +4,8 @@ from .langgraph import LangGraph, AsyncLangGraph
 from .letta import Letta, AsyncLetta
 from .memgpt import MemGPT, AsyncMemGPT
 from .supermemory import SuperMemory, AsyncSuperMemory
+from .crewai import CrewAI, AsyncCrewAI
+from .autogen import AutoGen, AsyncAutoGen
 
 __all__ = [
     "LangGraph",
@@ -12,6 +14,10 @@ __all__ = [
     "AsyncLetta",
     "MemGPT",
     "AsyncMemGPT",
+    "CrewAI",
+    "AsyncCrewAI",
+    "AutoGen",
+    "AsyncAutoGen",
     "SuperMemory",
     "AsyncSuperMemory",
 ]

--- a/src/ume/integrations/autogen.py
+++ b/src/ume/integrations/autogen.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Any
+from types import TracebackType
+
+import httpx
+
+
+class AutoGen:
+    """Thin wrapper to forward events to a running UME instance."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.Client(timeout=5)
+
+    def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
+
+    def recall(self, payload: Mapping[str, Any]) -> Any:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        resp = self._client.get(
+            f"{self.base_url}/recall", params=payload, headers=headers
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "AutoGen":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+class AsyncAutoGen:
+    """Async wrapper to forward events to a running UME instance."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.AsyncClient(timeout=5)
+
+    async def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            await self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            await self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
+
+    async def recall(self, payload: Mapping[str, Any]) -> Any:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        resp = await self._client.get(
+            f"{self.base_url}/recall", params=payload, headers=headers
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncAutoGen":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()

--- a/src/ume/integrations/crewai.py
+++ b/src/ume/integrations/crewai.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Any
+from types import TracebackType
+
+import httpx
+
+
+class CrewAI:
+    """Thin wrapper to forward events to a running UME instance."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.Client(timeout=5)
+
+    def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
+
+    def recall(self, payload: Mapping[str, Any]) -> Any:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        resp = self._client.get(
+            f"{self.base_url}/recall", params=payload, headers=headers
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "CrewAI":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+class AsyncCrewAI:
+    """Async wrapper to forward events to a running UME instance."""
+
+    def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self._client = httpx.AsyncClient(timeout=5)
+
+    async def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        events_list = list(events)
+        if not events_list:
+            return
+        if len(events_list) > 1:
+            await self._client.post(
+                f"{self.base_url}/events/batch", json=events_list, headers=headers
+            )
+        else:
+            await self._client.post(
+                f"{self.base_url}/events", json=events_list[0], headers=headers
+            )
+
+    async def recall(self, payload: Mapping[str, Any]) -> Any:
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        resp = await self._client.get(
+            f"{self.base_url}/recall", params=payload, headers=headers
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncCrewAI":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.close()

--- a/tests/test_new_integrations.py
+++ b/tests/test_new_integrations.py
@@ -1,0 +1,33 @@
+import httpx
+import pytest
+
+from ume.integrations.crewai import CrewAI
+from ume.integrations.autogen import AutoGen
+
+respx = pytest.importorskip("respx")
+
+
+def test_crewai_wrapper_forwards() -> None:
+    client = CrewAI(base_url="http://ume")
+    with respx.mock(assert_all_called=True) as mock:
+        evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
+        recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"v": 1}))
+        client.send_events([{"foo": 1}])
+        result = client.recall({"v": 1})
+        assert evt.called
+        assert recall.called
+        assert result == {"v": 1}
+        assert dict(recall.calls.last.request.url.params) == {"v": "1"}
+
+
+def test_autogen_wrapper_forwards() -> None:
+    client = AutoGen(base_url="http://ume")
+    with respx.mock(assert_all_called=True) as mock:
+        evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
+        recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"v": 2}))
+        client.send_events([{"foo": 2}])
+        result = client.recall({"v": 2})
+        assert evt.called
+        assert recall.called
+        assert result == {"v": 2}
+        assert dict(recall.calls.last.request.url.params) == {"v": "2"}


### PR DESCRIPTION
## Summary
- add CrewAI integration wrappers
- add AutoGen integration wrappers
- export new wrappers in `ume.integrations`
- document usage of new integrations
- test forwarding for CrewAI and AutoGen wrappers

## Testing
- `ruff check src/ume/integrations/crewai.py src/ume/integrations/autogen.py src/ume/integrations/__init__.py tests/test_new_integrations.py docs/INTEGRATIONS.md`
- `pytest tests/test_integrations.py tests/test_new_integrations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870519ab8508326aa4c3775ba2e611c