### PR TITLE
Implement thread-safe token storage

### DIFF
--- a/src/ume/auth_routes.py
+++ b/src/ume/auth_routes.py
@@ -8,7 +8,7 @@ from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel
 
 from .config import settings
-from .api_deps import TOKENS
+from .api_deps import TOKENS, TOKENS_LOCK
 
 router = APIRouter(prefix="/auth")
 
@@ -26,6 +26,7 @@ def issue_token(form_data: OAuth2PasswordRequestForm = Depends()) -> TokenRespon
     ):
         token = str(uuid4())
         expires_at = time.time() + settings.UME_OAUTH_TTL
-        TOKENS[token] = (settings.UME_OAUTH_ROLE, expires_at)
+        with TOKENS_LOCK:
+            TOKENS[token] = (settings.UME_OAUTH_ROLE, expires_at)
         return TokenResponse(access_token=token)
     raise HTTPException(status_code=400, detail="Invalid credentials")


### PR DESCRIPTION
## Summary
- add a global lock protecting TOKENS
- use the lock when issuing or validating tokens
- test concurrent token issuance
- remove test tokens after concurrent issuance

## Testing
- `pre-commit run --files tests/test_api.py src/ume/api_deps.py src/ume/auth_routes.py`
- `pytest tests/test_api.py -k test_issue_tokens_concurrently -q`


------
https://chatgpt.com/codex/tasks/task_e_6870639b7a44832696371bdc46155bed