### PR TITLE
Update audit key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,10 +338,11 @@ PYTHONPATH=src pytest
 ```
 
 Create a `.env` file in the project root before starting any services. Copy the
-template from [`env.example`](env.example) and set a
-non-default `UME_AUDIT_SIGNING_KEY` or UME will refuse to start. The
-`ume up` command described below automatically creates this file if it is
-missing and inserts a random signing key:
+template from [`env.example`](env.example) and set a unique
+`UME_AUDIT_SIGNING_KEY`. The `ume up` command described below automatically
+creates this file if it is missing. If an existing `.env` contains
+`UME_AUDIT_SIGNING_KEY=default-key` it will be regenerated with a secure random
+hex string:
 
 ```bash
 # .env


### PR DESCRIPTION
## Summary
- make `_ensure_env_file` always randomize the audit signing key and warn if it matches `default-key`
- update `.env` on `quickstart` only when the key equals `default-key`
- document this behavior in Quickstart instructions

## Testing
- `pre-commit run --files ume_cli.py README.md tests/test_cli_smoke.py`
- `pytest tests/test_cli_smoke.py::test_cli_env_file_warning -vv`

------
https://chatgpt.com/codex/tasks/task_e_6870639c3f2483269da68800789e1bb2