### PR TITLE
Implement ReplayMixin

### DIFF
--- a/src/ume/neo4j_graph.py
+++ b/src/ume/neo4j_graph.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, cast, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, cast
 import time
 
 from neo4j import GraphDatabase, Driver
@@ -13,13 +13,10 @@ from .processing import DEFAULT_VERSION
 from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .graph_algorithms import GraphAlgorithmsMixin
-from .replay import replay_from_ledger
-
-if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from .event_ledger import EventLedger
+from .replay_mixin import ReplayMixin
 
 
-class Neo4jGraph(GraphAlgorithmsMixin, IGraphAdapter):
+class Neo4jGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
     """Graph adapter using the Neo4j Bolt driver."""
 
     def __init__(
@@ -319,19 +316,3 @@ class Neo4jGraph(GraphAlgorithmsMixin, IGraphAdapter):
             )
             return {rec["id"]: rec["score"] for rec in result}
 
-    def replay_from_ledger(
-        self,
-        ledger: "EventLedger",
-        start_offset: int = 0,
-        end_offset: int | None = None,
-        *,
-        end_timestamp: int | None = None,
-    ) -> int:
-        """Delegate to :func:`ume.replay.replay_from_ledger`."""
-        return replay_from_ledger(
-            self,
-            ledger,
-            start_offset=start_offset,
-            end_offset=end_offset,
-            end_timestamp=end_timestamp,
-        )

--- a/src/ume/persistent_graph.py
+++ b/src/ume/persistent_graph.py
@@ -1,19 +1,16 @@
 import sqlite3
 import json
 import time
-from typing import Dict, Any, Optional, List, Tuple, cast, TYPE_CHECKING
+from typing import Dict, Any, Optional, List, Tuple, cast
 from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .audit import log_audit_entry
 from .config import settings
 from .graph_algorithms import GraphAlgorithmsMixin
-from .replay import replay_from_ledger
-
-if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from .event_ledger import EventLedger
+from .replay_mixin import ReplayMixin
 
 
-class PersistentGraph(GraphAlgorithmsMixin, IGraphAdapter):
+class PersistentGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
     """SQLite-backed persistent graph implementation."""
 
     def __init__(self, db_path: str | None = None, *, check_same_thread: bool | None = None) -> None:
@@ -280,20 +277,4 @@ class PersistentGraph(GraphAlgorithmsMixin, IGraphAdapter):
             )
             self.conn.execute("DELETE FROM nodes WHERE created_at < ?", (cutoff,))
 
-    def replay_from_ledger(
-        self,
-        ledger: "EventLedger",
-        start_offset: int = 0,
-        end_offset: int | None = None,
-        *,
-        end_timestamp: int | None = None,
-    ) -> int:
-        """Delegate to :func:`ume.replay.replay_from_ledger`."""
-        return replay_from_ledger(
-            self,
-            ledger,
-            start_offset=start_offset,
-            end_offset=end_offset,
-            end_timestamp=end_timestamp,
-        )
 

--- a/src/ume/replay_mixin.py
+++ b/src/ume/replay_mixin.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from .graph_adapter import IGraphAdapter
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .event_ledger import EventLedger
+
+
+class ReplayMixin:
+    """Provide ledger replay capabilities for graph adapters."""
+
+    def replay_from_ledger(
+        self,
+        ledger: "EventLedger",
+        start_offset: int = 0,
+        end_offset: int | None = None,
+        *,
+        end_timestamp: int | None = None,
+    ) -> int:
+        """Replay ledger events into ``self`` starting from ``start_offset``."""
+        last = start_offset
+        from .event import parse_event
+        from .processing import apply_event_to_graph
+
+        adapter = cast(IGraphAdapter, self)
+
+        for off, data in ledger.range(start=start_offset, end=end_offset):
+            if end_timestamp is not None and data.get("timestamp", 0) > end_timestamp:
+                break
+            event = parse_event(data)
+            apply_event_to_graph(event, adapter)
+            last = off
+        return last


### PR DESCRIPTION
## Summary
- add `ReplayMixin` providing common `replay_from_ledger` logic
- use the mixin in `PersistentGraph` and `Neo4jGraph`
- fix vector store unit tests to load config and backends modules correctly

## Testing
- `ruff check .`
- `mypy .`
- `pytest tests/test_vector_store_unit.py -q`
- `pytest tests/test_event_ledger.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6870717977108326a1033e0e594be464