### PR TITLE
Add graph backend factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ The engine is built from a few key components:
 - **FastAPI API** (`src/ume/api.py`)
   - HTTP service exposing graph queries and analytics endpoints.
   - Enforces role-based access to graph operations.
-- **Graph Adapters** (`src/ume/graph_adapter.py`, `src/ume/neo4j_graph.py`)
-  - Define a common interface for manipulating different graph backends.
-  - Includes adapters for in-memory, SQLite, and Neo4j storage as well as RBAC wrappers.
+  - **Graph Adapters** (`src/ume/graph_adapter.py`, `src/ume/neo4j_graph.py`)
+    - Define a common interface for manipulating different graph backends.
+    - Includes adapters for in-memory, SQLite, Postgres, Redis, and Neo4j storage as well as RBAC wrappers.
+    - The active backend is selected via `UME_GRAPH_BACKEND`.
 - **Vector Store** (`src/ume/vector_store.py`)
   - Maintains a vector index of node embeddings for similarity search.
   - Use `VectorStore()` or `create_default_store()` to instantiate one from

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -59,7 +59,7 @@ below lists all available variables and their default values.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `UME_DB_PATH` | `ume_graph.db` | SQLite database used by `PersistentGraph`. |
-| `UME_GRAPH_BACKEND` | `sqlite` | Backend for graph storage (`sqlite`, `postgres`, or `redis`). |
+| `UME_GRAPH_BACKEND` | `sqlite` | Backend for graph storage (`sqlite`, `postgres`, `redis`, or `neo4j`). |
 | `UME_SNAPSHOT_PATH` | `ume_snapshot.json` | Path to graph snapshot file. |
 | `UME_SNAPSHOT_DIR` | `.` | Directory that snapshot APIs will accept paths from. |
 | `UME_AUDIT_LOG_PATH` | `audit.log` | Location of the audit log. |

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -182,6 +182,7 @@ from .agent_orchestrator import (
 )
 from .message_bus import MessageEnvelope
 from .resources import (
+    create_graph_adapter,
     create_graph,
     create_vector_store,
     graph_factory,
@@ -257,6 +258,7 @@ __all__ = [
     "VectorStore",
     "VectorStoreListener",
     "create_default_store",
+    "create_graph_adapter",
     "create_graph",
     "create_vector_store",
     "graph_factory",

--- a/src/ume/api_deps.py
+++ b/src/ume/api_deps.py
@@ -29,9 +29,14 @@ TOKENS: Dict[str, tuple[str, float]] = {}
 TOKENS_LOCK = threading.Lock()
 
 
-def configure_graph(graph: IGraphAdapter) -> None:
-    """Set ``app.state.graph`` applying RBAC if configured."""
+def configure_graph(graph: IGraphAdapter | None = None) -> None:
+    """Create and register the API's graph adapter."""
     from .api import app  # Local import to avoid circular dependency
+
+    if graph is None:
+        from .resources import create_graph_adapter
+
+        graph = create_graph_adapter()
 
     role = settings.UME_API_ROLE
     if role:

--- a/src/ume/resources.py
+++ b/src/ume/resources.py
@@ -3,9 +3,56 @@
 
 from typing import Callable
 
+from .config import settings
 from .graph_adapter import IGraphAdapter
+from .persistent_graph import PersistentGraph
+from .postgres_graph import PostgresGraph
+from .redis_graph_adapter import RedisGraphAdapter
+from .rbac_adapter import RoleBasedGraphAdapter
+from .tracing import TracingGraphAdapter, is_tracing_enabled
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from .neo4j_graph import Neo4jGraph
+else:  # pragma: no cover - optional dependency
+    try:
+        from .neo4j_graph import Neo4jGraph
+    except Exception:
+        class Neo4jGraph:
+            def __init__(self, *_: object, **__: object) -> None:
+                raise ImportError("neo4j is required for Neo4jGraph")
 from .vector_store import VectorBackend, create_default_store
-from .factories import create_graph_adapter
+
+
+def create_graph_adapter(
+    db_path: str | None = None,
+    *,
+    role: str | None = None,
+) -> IGraphAdapter:
+    """Instantiate the configured :class:`IGraphAdapter`."""
+
+    backend = settings.UME_GRAPH_BACKEND.lower()
+    if backend == "postgres":
+        base: IGraphAdapter = PostgresGraph(db_path or settings.UME_DB_PATH)
+    elif backend == "redis":
+        base = RedisGraphAdapter(db_path or settings.UME_DB_PATH)
+    elif backend == "neo4j":
+        base = Neo4jGraph(
+            settings.NEO4J_URI,
+            settings.NEO4J_USER,
+            settings.NEO4J_PASSWORD,
+        )
+    else:
+        base = PersistentGraph(db_path or settings.UME_DB_PATH)
+
+    if is_tracing_enabled():
+        base = TracingGraphAdapter(base)
+
+    role = role if role is not None else settings.UME_ROLE
+    if role:
+        base = RoleBasedGraphAdapter(base, role=role)
+
+    return base
 
 
 def _default_graph_factory() -> IGraphAdapter:
@@ -35,6 +82,7 @@ def create_vector_store() -> VectorBackend:
     return vector_store_factory()
 
 __all__ = [
+    "create_graph_adapter",
     "create_graph",
     "create_vector_store",
     "graph_factory",

--- a/tests/test_snapshot_routes.py
+++ b/tests/test_snapshot_routes.py
@@ -47,7 +47,7 @@ sys.modules.setdefault("faiss", types.ModuleType("faiss"))
 from ume.config import settings
 object.__setattr__(settings, "UME_VECTOR_BACKEND", "faiss")
 
-from ume.factories import create_graph_adapter
+from ume.resources import create_graph_adapter
 from ume.api import app, configure_graph
 from ume.event_ledger import EventLedger
 

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -26,7 +26,7 @@ from ume import (  # noqa: E402
     apply_event_to_graph,
     load_graph_into_existing,
     snapshot_graph_to_file,
-    PersistentGraph,
+    create_graph_adapter,
     RoleBasedGraphAdapter,
     enable_snapshot_autosave_and_restore,
     ProcessingError,
@@ -58,7 +58,7 @@ class UMEPrompt(Cmd):
     def __init__(self):
         super().__init__()
         db_path = settings.UME_CLI_DB
-        base_graph = PersistentGraph(db_path)
+        base_graph = create_graph_adapter(db_path, role=None)
         self.base_graph = base_graph
         role = settings.UME_ROLE
         if role:
@@ -701,7 +701,7 @@ def _snapshot_schedule(interval: int) -> None:
     """Run periodic snapshotting until interrupted."""
     from ume.auto_snapshot import enable_periodic_snapshot, disable_periodic_snapshot
 
-    graph = PersistentGraph(settings.UME_CLI_DB)
+    graph = create_graph_adapter(settings.UME_CLI_DB, role=None)
     thread, stop = enable_periodic_snapshot(
         graph, settings.UME_SNAPSHOT_PATH, interval
     )


### PR DESCRIPTION
## Summary
- support new UME_GRAPH_BACKEND setting via `create_graph_adapter`
- update CLI and API to use the factory
- adjust tests for new import path
- document new graph backends
- document graph backend selection in README

## Testing
- `ruff check src/ume/__init__.py src/ume/api_deps.py src/ume/resources.py tests/test_snapshot_routes.py ume_cli.py`
- `mypy src/ume/resources.py src/ume/api_deps.py src/ume/__init__.py ume_cli.py tests/test_snapshot_routes.py`
- `pytest tests/test_snapshot_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6870717891748326a652c45a45c3fc36