### PR TITLE
Add ledger logging for privacy agent

### DIFF
--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -48,14 +48,18 @@ def test_redact_event_payload_without_pii(privacy_agent, monkeypatch):
 
 
 class FakeMessage:
-    def __init__(self, value):
+    def __init__(self, value, offset=0):
         self._value = value
+        self._offset = offset
 
     def value(self):
         return self._value
 
     def error(self):
         return None
+
+    def offset(self):
+        return self._offset
 
 
 class FakeConsumer:

--- a/tests/test_privacy_agent_ledger.py
+++ b/tests/test_privacy_agent_ledger.py
@@ -1,0 +1,95 @@
+import json
+
+from ume.pipeline import privacy_agent
+from ume.event_ledger import EventLedger
+from ume.replay import replay_from_ledger
+from ume.persistent_graph import PersistentGraph
+
+
+class FakeAnalyzer:
+    def analyze(self, text: str, language: str = "en"):
+        return []
+
+
+class FakeAnonymizer:
+    def anonymize(self, text: str, analyzer_results):
+        return type("Result", (), {"text": text})()
+
+
+class FakeMessage:
+    def __init__(self, value: bytes, offset: int = 0):
+        self._value = value
+        self._offset = offset
+
+    def value(self) -> bytes:
+        return self._value
+
+    def error(self):
+        return None
+
+    def offset(self) -> int:
+        return self._offset
+
+
+class FakeConsumer:
+    def __init__(self, messages):
+        self._messages = messages
+
+    def poll(self, timeout=1.0):
+        if self._messages:
+            return self._messages.pop(0)
+        raise KeyboardInterrupt
+
+    def subscribe(self, topics):
+        pass
+
+    def close(self):
+        pass
+
+
+class FakeProducer:
+    def __init__(self):
+        self.produced = []
+        self.flush_calls = 0
+
+    def produce(self, topic, value, *args, **kwargs):
+        self.produced.append((topic, value))
+
+    def flush(self):
+        self.flush_calls += 1
+
+
+def test_privacy_agent_writes_to_ledger_and_replay(tmp_path, monkeypatch):
+    event = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n1",
+        "payload": {"node_id": "n1"},
+    }
+    msg = FakeMessage(json.dumps(event).encode("utf-8"), offset=5)
+
+    consumer = FakeConsumer([msg])
+    producer = FakeProducer()
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+
+    monkeypatch.setattr(privacy_agent, "Consumer", lambda conf: consumer)
+    monkeypatch.setattr(privacy_agent, "Producer", lambda conf: producer)
+    monkeypatch.setattr(privacy_agent, "event_ledger", ledger)
+    monkeypatch.setattr(privacy_agent, "_ANALYZER", FakeAnalyzer())
+    monkeypatch.setattr(privacy_agent, "_ANONYMIZER", FakeAnonymizer())
+    monkeypatch.setattr(privacy_agent.settings, "KAFKA_PRODUCER_BATCH_SIZE", 1)
+    monkeypatch.setattr(privacy_agent, "BATCH_SIZE", 1)
+
+    privacy_agent.run_privacy_agent()
+
+    entries = ledger.range()
+    assert len(entries) == 1
+    assert entries[0][0] == 5
+    assert entries[0][1]["node_id"] == "n1"
+
+    graph = PersistentGraph(":memory:")
+    last = replay_from_ledger(graph, ledger)
+    assert graph.get_node("n1") is not None
+    assert last == 5
+    graph.close()
+    ledger.close()

--- a/tests/test_privacy_agent_rego.py
+++ b/tests/test_privacy_agent_rego.py
@@ -15,14 +15,18 @@ class FakeAnonymizer:
         return SimpleNamespace(text=text)
 
 class FakeMessage:
-    def __init__(self, value: bytes) -> None:
+    def __init__(self, value: bytes, offset: int = 0) -> None:
         self._value = value
+        self._offset = offset
 
     def value(self) -> bytes:
         return self._value
 
     def error(self) -> None:
         return None
+
+    def offset(self) -> int:
+        return self._offset
 
 class FakeConsumer:
     def __init__(self, messages: list[FakeMessage]) -> None:


### PR DESCRIPTION
## Summary
- log sanitized events to the local event ledger using the consumed Kafka offset
- provide offset on fake messages used in tests
- test that ledger receives sanitized events and replay works

## Testing
- `pre-commit run --files src/ume/pipeline/privacy_agent.py tests/test_privacy_agent.py tests/test_privacy_agent_rego.py tests/test_privacy_agent_ledger.py`
- `pytest tests/test_privacy_agent.py tests/test_privacy_agent_rego.py tests/test_privacy_agent_ledger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68713f1474408326a5e1bc5b07ca94a0