### PR TITLE
Refactor initializer into bootstrap modules

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -2,84 +2,15 @@
 
 # ruff: noqa: E402
 
-import importlib  # noqa: E402
-import sys  # noqa: E402
-import types  # noqa: E402
-from types import SimpleNamespace
+from .bootstrap import (
+    load_config,
+    load_neo4j,
+    load_vector_modules,
+    load_embedding,
+)
 
-def _make_stub(name: str) -> types.ModuleType:
-    stub = types.ModuleType(name)
-    return stub
-
-try:  # Expose config for tests as early as possible
-    config = importlib.import_module(".config", __name__)
-    Settings = config.Settings
-    setattr(sys.modules[__name__], "config", config)
-except ImportError:  # pragma: no cover - allow import without environment setup
-    stub = _make_stub("ume.config")
-    sys.modules["ume.config"] = stub
-    stub.settings = SimpleNamespace(  # type: ignore[attr-defined]
-        UME_DB_PATH="ume_graph.db",
-        UME_SNAPSHOT_PATH="ume_snapshot.json",
-        UME_SNAPSHOT_DIR=".",
-        UME_COLD_DB_PATH="ume_cold.db",
-        UME_COLD_SNAPSHOT_PATH="ume_cold_snapshot.json",
-        UME_COLD_EVENT_AGE_DAYS=180,
-        UME_AUDIT_LOG_PATH="/tmp/audit.log",
-        UME_AUDIT_SIGNING_KEY="stub",
-        UME_CONSENT_LEDGER_PATH="consent_ledger.db",
-        UME_EVENT_LEDGER_PATH="event_ledger.db",
-        UME_FEEDBACK_DB_PATH="feedback.db",
-        UME_AGENT_ID="SYSTEM",
-        UME_EMBED_MODEL="all-MiniLM-L6-v2",
-        UME_CLI_DB="ume_graph.db",
-        UME_ROLE=None,
-        UME_API_ROLE=None,
-        UME_RATE_LIMIT_REDIS=None,
-        UME_LOG_LEVEL="INFO",
-        UME_LOG_JSON=False,
-        UME_GRAPH_RETENTION_DAYS=30,
-        UME_RELIABILITY_THRESHOLD=0.5,
-        WATCH_PATHS=["."],
-        DAG_RESOURCES={"cpu": 1, "io": 1},
-        UME_VALUE_STORE_PATH=None,
-        UME_VECTOR_BACKEND="faiss",
-        UME_VECTOR_DIM=0,
-        UME_VECTOR_INDEX="vectors.faiss",
-        UME_VECTOR_USE_GPU=False,
-        UME_VECTOR_GPU_MEM_MB=256,
-        UME_VECTOR_MAX_AGE_DAYS=90,
-        NEO4J_URI="bolt://localhost:7687",
-        NEO4J_USER="neo4j",
-        NEO4J_PASSWORD="password",  # pragma: allowlist secret
-        KAFKA_BOOTSTRAP_SERVERS="localhost:9092",
-        KAFKA_RAW_EVENTS_TOPIC="ume-raw-events",
-        KAFKA_CLEAN_EVENTS_TOPIC="ume-clean-events",
-        KAFKA_QUARANTINE_TOPIC="ume-quarantine-events",
-        KAFKA_EDGE_TOPIC="ume_edges",
-        KAFKA_NODE_TOPIC="ume_nodes",
-        KAFKA_GROUP_ID="ume_client_group",
-        KAFKA_PRIVACY_AGENT_GROUP_ID="ume-privacy-agent-group",
-        KAFKA_PRODUCER_BATCH_SIZE=10,
-        UME_OAUTH_USERNAME="ume",
-        UME_OAUTH_PASSWORD="password",  # pragma: allowlist secret
-        UME_OAUTH_ROLE="AnalyticsAgent",
-        UME_OAUTH_TTL=3600,
-        UME_API_TOKEN=None,
-        OPA_URL=None,
-        OPA_TOKEN=None,
-        UME_OTLP_ENDPOINT=None,
-        LLM_FERRY_API_URL="https://example.com/api",
-        LLM_FERRY_API_KEY="",
-        TWITTER_BEARER_TOKEN=None,
-        ANGEL_BRIDGE_LOOKBACK_HOURS=24,
-    )
-    class _StubSettings:
-        pass
-    Settings = _StubSettings
-    stub.Settings = _StubSettings  # type: ignore[attr-defined]
-    config = stub
-    setattr(sys.modules[__name__], "config", stub)
+# Expose config for tests as early as possible
+config, Settings = load_config(__name__)
 
 
 from .event import Event, EventType, parse_event, EventError
@@ -92,14 +23,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     from .neo4j_graph import Neo4jGraph
 else:  # pragma: no cover - optional dependency
-    try:
-        from .neo4j_graph import Neo4jGraph
-    except Exception:
-        class Neo4jGraph:
-            """Placeholder when neo4j dependencies are missing."""
-
-            def __init__(self, *_: object, **__: object) -> None:
-                raise ImportError("neo4j is required for Neo4jGraph")
+    Neo4jGraph = load_neo4j(__name__)
 from .auto_snapshot import (
     enable_periodic_snapshot,
     disable_periodic_snapshot,
@@ -139,36 +63,14 @@ if TYPE_CHECKING:  # pragma: no cover - used for type hints only
     )
     from .vector_backends import FaissBackend, ChromaBackend
 else:  # pragma: no cover - optional dependency
-    try:
-        from .vector_store import (
-            VectorBackend,
-            VectorStore,
-            VectorStoreListener,
-            create_default_store,
-        )
-        from .vector_backends import FaissBackend, ChromaBackend
-    except Exception:
-        vector_stub = types.ModuleType("ume.vector_store")
-
-        class VectorStore:
-            def __init__(self, *_: object, **__: object) -> None:
-                raise ImportError("faiss is required for VectorStore")
-
-        class VectorStoreListener:
-            def __init__(self, *_: object, **__: object) -> None:
-                raise ImportError("faiss is required for VectorStoreListener")
-
-        def create_default_store(*_: object, **__: object) -> None:
-            raise ImportError("faiss is required for create_default_store")
-
-        vector_stub.VectorStore = VectorStore
-        vector_stub.VectorBackend = VectorStore
-        vector_stub.FaissBackend = VectorStore
-        vector_stub.ChromaBackend = VectorStore
-        vector_stub.VectorStoreListener = VectorStoreListener
-        vector_stub.create_default_store = create_default_store
-        sys.modules[__name__ + ".vector_store"] = vector_stub
-        setattr(sys.modules[__name__], "vector_store", vector_stub)
+    (
+        VectorBackend,
+        VectorStore,
+        VectorStoreListener,
+        create_default_store,
+        FaissBackend,
+        ChromaBackend,
+    ) = load_vector_modules(__name__)
 
 
 from .llm_ferry import LLMFerry
@@ -197,19 +99,9 @@ from .resource_scheduler import ResourceScheduler, ScheduledTask
 from .reliability import score_text, filter_low_confidence  # noqa: E402
 from ._internal.listeners import register_listener  # noqa: E402
 
-try:  # Optional dependency
-    from .embedding import generate_embedding
-    _EMBEDDINGS_AVAILABLE = True
-except Exception:  # pragma: no cover - optional import
-    _EMBEDDINGS_AVAILABLE = False
-
-    def generate_embedding(text: str) -> list[float]:
-        raise ImportError("sentence-transformers is required to generate embeddings")
-
-if _EMBEDDINGS_AVAILABLE:
-    from .ontology import OntologyListener, configure_ontology_graph
-    _ONTOLOGY_LISTENER = OntologyListener()
-    register_listener(_ONTOLOGY_LISTENER)
+generate_embedding, OntologyListener, configure_ontology_graph = load_embedding(
+    __name__, register_listener
+)
 
 
 __all__ = [
@@ -248,16 +140,9 @@ __all__ = [
     "PolicyViolationError",
     "Settings",
     "config",
-    "vector_store",
     "log_audit_entry",
     "get_audit_entries",
     "ssl_config",
-    "VectorBackend",
-    "FaissBackend",
-    "ChromaBackend",
-    "VectorStore",
-    "VectorStoreListener",
-    "create_default_store",
     "create_graph_adapter",
     "create_graph",
     "create_vector_store",
@@ -280,27 +165,14 @@ __all__ = [
     "AgentOrchestrator",
     "Supervisor",
     "Critic",
-    "Overseer",
     "MessageEnvelope",
     "ReflectionAgent",
-    "ValueOverseer",
     "Task",
     "DAGExecutor",
     "DAGService",
     "ResourceScheduler",
     "ScheduledTask",
-    "TweetBot",
 
-    # Submodules
-    "audit",
-    "config",
-    "persistent_graph",
-    "plugins",
-    "grpc_server",
-    "vector_store",
-    "embedding",
-    "api",
-    "policy",
 
 ]
 

--- a/src/ume/bootstrap/__init__.py
+++ b/src/ume/bootstrap/__init__.py
@@ -1,0 +1,13 @@
+"""Helpers for bootstrapping the UME package."""
+
+from .config import load_config
+from .neo4j import load_neo4j
+from .vector import load_vector_modules
+from .embedding import load_embedding
+
+__all__ = [
+    "load_config",
+    "load_neo4j",
+    "load_vector_modules",
+    "load_embedding",
+]

--- a/src/ume/bootstrap/config.py
+++ b/src/ume/bootstrap/config.py
@@ -1,0 +1,85 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+__all__ = ["load_config"]
+
+def _make_stub(name: str) -> types.ModuleType:
+    stub = types.ModuleType(name)
+    return stub
+
+def load_config(package: str) -> tuple[types.ModuleType, type]:
+    """Load config module, returning (module, Settings class)."""
+    try:
+        config = importlib.import_module(".config", package)
+        Settings = config.Settings
+        setattr(sys.modules[package], "config", config)
+    except Exception:  # pragma: no cover - fall back to stub on any failure
+        stub = _make_stub(f"{package}.config")
+        sys.modules[f"{package}.config"] = stub
+        stub.settings = SimpleNamespace(  # type: ignore[attr-defined]
+            UME_DB_PATH="ume_graph.db",
+            UME_SNAPSHOT_PATH="ume_snapshot.json",
+            UME_SNAPSHOT_DIR=".",
+            UME_COLD_DB_PATH="ume_cold.db",
+            UME_COLD_SNAPSHOT_PATH="ume_cold_snapshot.json",
+            UME_COLD_EVENT_AGE_DAYS=180,
+            UME_AUDIT_LOG_PATH="/tmp/audit.log",
+            UME_AUDIT_SIGNING_KEY="stub",
+            UME_CONSENT_LEDGER_PATH="consent_ledger.db",
+            UME_EVENT_LEDGER_PATH="event_ledger.db",
+            UME_FEEDBACK_DB_PATH="feedback.db",
+            UME_AGENT_ID="SYSTEM",
+            UME_EMBED_MODEL="all-MiniLM-L6-v2",
+            UME_CLI_DB="ume_graph.db",
+            UME_ROLE=None,
+            UME_API_ROLE=None,
+            UME_RATE_LIMIT_REDIS=None,
+            UME_LOG_LEVEL="INFO",
+            UME_LOG_JSON=False,
+            UME_GRAPH_RETENTION_DAYS=30,
+            UME_RELIABILITY_THRESHOLD=0.5,
+            WATCH_PATHS=["."],
+            DAG_RESOURCES={"cpu": 1, "io": 1},
+            UME_VALUE_STORE_PATH=None,
+            UME_VECTOR_BACKEND="faiss",
+            UME_VECTOR_DIM=0,
+            UME_VECTOR_INDEX="vectors.faiss",
+            UME_VECTOR_USE_GPU=False,
+            UME_VECTOR_GPU_MEM_MB=256,
+            UME_VECTOR_MAX_AGE_DAYS=90,
+            NEO4J_URI="bolt://localhost:7687",
+            NEO4J_USER="neo4j",
+            NEO4J_PASSWORD="password",  # pragma: allowlist secret
+            KAFKA_BOOTSTRAP_SERVERS="localhost:9092",
+            KAFKA_RAW_EVENTS_TOPIC="ume-raw-events",
+            KAFKA_CLEAN_EVENTS_TOPIC="ume-clean-events",
+            KAFKA_QUARANTINE_TOPIC="ume-quarantine-events",
+            KAFKA_EDGE_TOPIC="ume_edges",
+            KAFKA_NODE_TOPIC="ume_nodes",
+            KAFKA_GROUP_ID="ume_client_group",
+            KAFKA_PRIVACY_AGENT_GROUP_ID="ume-privacy-agent-group",
+            KAFKA_PRODUCER_BATCH_SIZE=10,
+            UME_OAUTH_USERNAME="ume",
+            UME_OAUTH_PASSWORD="password",  # pragma: allowlist secret
+            UME_OAUTH_ROLE="AnalyticsAgent",
+            UME_OAUTH_TTL=3600,
+            UME_API_TOKEN=None,
+            OPA_URL=None,
+            OPA_TOKEN=None,
+            UME_OTLP_ENDPOINT=None,
+            LLM_FERRY_API_URL="https://example.com/api",
+            LLM_FERRY_API_KEY="",
+            TWITTER_BEARER_TOKEN=None,
+            ANGEL_BRIDGE_LOOKBACK_HOURS=24,
+        )
+
+        class _StubSettings:
+            pass
+
+        Settings = _StubSettings
+        stub.Settings = _StubSettings  # type: ignore[attr-defined]
+        config = stub
+        setattr(sys.modules[package], "config", stub)
+    return config, Settings

--- a/src/ume/bootstrap/embedding.py
+++ b/src/ume/bootstrap/embedding.py
@@ -1,0 +1,24 @@
+from importlib import import_module
+from typing import Callable, Any, Tuple, Type, Optional
+
+__all__ = ["load_embedding"]
+
+def load_embedding(
+    package: str, register_listener: Callable[[Any], None]
+) -> Tuple[Callable[[str], list[float]], Optional[Type[Any]], Optional[Callable[..., Any]]]:
+    """Return generate_embedding and optionally register OntologyListener."""
+    try:
+        embedding_mod = import_module(f"{package}.embedding")
+        generate_embedding = embedding_mod.generate_embedding
+        ontology_mod = import_module(f"{package}.ontology")
+        OntologyListener = ontology_mod.OntologyListener
+        configure_ontology_graph = ontology_mod.configure_ontology_graph
+        listener = OntologyListener()
+        register_listener(listener)
+        return generate_embedding, OntologyListener, configure_ontology_graph
+    except Exception:
+        def generate_embedding(_: str) -> list[float]:
+            raise ImportError(
+                "sentence-transformers is required to generate embeddings"
+            )
+        return generate_embedding, None, None

--- a/src/ume/bootstrap/neo4j.py
+++ b/src/ume/bootstrap/neo4j.py
@@ -1,0 +1,14 @@
+from importlib import import_module
+from typing import Any, cast
+
+__all__ = ["load_neo4j"]
+
+def load_neo4j(package: str) -> type[Any]:
+    """Return the Neo4jGraph class, using a stub if dependency missing."""
+    try:
+        return cast(type[Any], import_module(f"{package}.neo4j_graph").Neo4jGraph)
+    except Exception:
+        class Neo4jGraph:
+            def __init__(self, *_: object, **__: object) -> None:
+                raise ImportError("neo4j is required for Neo4jGraph")
+        return Neo4jGraph

--- a/src/ume/bootstrap/vector.py
+++ b/src/ume/bootstrap/vector.py
@@ -1,0 +1,59 @@
+from importlib import import_module
+import sys
+import types
+from typing import Callable, Any, Tuple, Type
+
+__all__ = [
+    "load_vector_modules",
+]
+
+def load_vector_modules(package: str) -> Tuple[
+    Type[Any],
+    Type[Any],
+    Type[Any],
+    Callable[..., Any],
+    Type[Any],
+    Type[Any],
+]:
+    """Load vector-store related classes, returning a tuple."""
+    try:
+        vs = import_module(f"{package}.vector_store")
+        backends = import_module(f"{package}.vector_backends")
+        return (
+            vs.VectorBackend,
+            vs.VectorStore,
+            vs.VectorStoreListener,
+            vs.create_default_store,
+            backends.FaissBackend,
+            backends.ChromaBackend,
+        )
+    except Exception:
+        stub = types.ModuleType(f"{package}.vector_store")
+
+        class VectorStore:
+            def __init__(self, *_: object, **__: object) -> None:
+                raise ImportError("faiss is required for VectorStore")
+
+        class VectorStoreListener:
+            def __init__(self, *_: object, **__: object) -> None:
+                raise ImportError("faiss is required for VectorStoreListener")
+
+        def create_default_store(*_: object, **__: object) -> None:
+            raise ImportError("faiss is required for create_default_store")
+
+        stub.VectorStore = VectorStore  # type: ignore[attr-defined]
+        stub.VectorBackend = VectorStore  # type: ignore[attr-defined]
+        stub.FaissBackend = VectorStore  # type: ignore[attr-defined]
+        stub.ChromaBackend = VectorStore  # type: ignore[attr-defined]
+        stub.VectorStoreListener = VectorStoreListener  # type: ignore[attr-defined]
+        stub.create_default_store = create_default_store  # type: ignore[attr-defined]
+        sys.modules[f"{package}.vector_store"] = stub
+        setattr(sys.modules[package], "vector_store", stub)
+        return (
+            stub.VectorBackend,
+            stub.VectorStore,
+            stub.VectorStoreListener,
+            stub.create_default_store,
+            stub.FaissBackend,
+            stub.ChromaBackend,
+        )


### PR DESCRIPTION
## Summary
- factor config and optional imports into new `ume.bootstrap` package
- expose only high-level helpers in `ume.__all__`
- load optional modules using `importlib` helpers
- handle config import errors gracefully

## Testing
- `pre-commit run --files src/ume/bootstrap/config.py src/ume/__init__.py`
- `pytest tests/test_config.py -q`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6871432b5cbc83268c6d8b2f4b2d8f52