### PR TITLE
Fix env file warning logic

### DIFF
--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -512,14 +512,33 @@ def test_cli_env_file_warning(
 
     importlib.reload(cli)
 
-    env_example = tmp_path / "env.example"
-    env_example.write_text("UME_AUDIT_SIGNING_KEY=<your-key>\n")
+    env_file = tmp_path / ".env"
+    env_file.write_text("UME_AUDIT_SIGNING_KEY=default-key\n")
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(cli, "__file__", str(tmp_path / "ume_cli.py"))
-    monkeypatch.setattr(cli.secrets, "token_hex", lambda *_: "default-key")
+    monkeypatch.setattr(cli.secrets, "token_hex", lambda *_: "new-key")
 
     cli._ensure_env_file()
 
     out = capsys.readouterr().out
     assert "insecure default key" in out
+
+
+def test_cli_env_file_no_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import importlib
+    import ume_cli as cli
+
+    importlib.reload(cli)
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("UME_AUDIT_SIGNING_KEY=old-key\n")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(cli.secrets, "token_hex", lambda *_: "default-key")
+
+    cli._ensure_env_file()
+
+    out = capsys.readouterr().out
+    assert "insecure default key" not in out

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -644,9 +644,11 @@ def _ensure_env_file(env_file: Path = Path(".env")) -> None:
         created = True
 
     new_key = secrets.token_hex(32)
+    prev_key: str | None = None
     replaced = False
     for i, line in enumerate(env_lines):
         if line.startswith("UME_AUDIT_SIGNING_KEY="):
+            prev_key = line.split("=", 1)[1]
             env_lines[i] = f"UME_AUDIT_SIGNING_KEY={new_key}"
             replaced = True
             break
@@ -656,7 +658,7 @@ def _ensure_env_file(env_file: Path = Path(".env")) -> None:
 
     env_content = "\n".join(env_lines) + "\n"
     env_file.write_text(env_content)
-    if new_key == "default-key":
+    if prev_key == "default-key":
         print(
             "WARNING: UME_AUDIT_SIGNING_KEY uses the insecure default key. "
             "Edit .env and set a unique value."


### PR DESCRIPTION
## Summary
- check the existing UME_AUDIT_SIGNING_KEY before replacement
- update the CLI smoke tests for env file warning logic

## Testing
- `ruff check .`
- `pytest tests/test_cli_smoke.py::test_cli_env_file_warning tests/test_cli_smoke.py::test_cli_env_file_no_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_6871c37d1b3c83269320233ac13d62bb