### PR TITLE
Fix integration tests after client refactor

### DIFF
--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,17 +1,13 @@
 import httpx
 import pytest
 
-from ume.integrations.base import BaseClient
-from ume.integrations.langgraph import LangGraph
-from ume.integrations.letta import Letta
-from ume.integrations.memgpt import MemGPT
-from ume.integrations.supermemory import SuperMemory
+from ume.integrations import BaseClient, LangGraph, Letta, MemGPT, SuperMemory
 
 respx = pytest.importorskip("respx")
 
 
 def test_base_client_forwards() -> None:
-    client = BaseClient(base_url="http://ume", api_key="token")
+    client = BaseClient(base_url="http://ume", api_key="dummy-token")  # pragma: allowlist secret
     with respx.mock(assert_all_called=True) as mock:
         evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
         recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"ok": True}))
@@ -24,7 +20,7 @@ def test_base_client_forwards() -> None:
 
 
 def test_langgraph_wrapper_forwards() -> None:
-    client = LangGraph(base_url="http://ume", api_key="token")
+    client = LangGraph(base_url="http://ume", api_key="dummy-token")  # pragma: allowlist secret
     assert isinstance(client, BaseClient)
     with respx.mock(assert_all_called=True) as mock:
         evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))

--- a/tests/test_integrations_async.py
+++ b/tests/test_integrations_async.py
@@ -2,18 +2,20 @@ import asyncio
 import httpx
 import pytest
 
-from ume.integrations.base import AsyncBaseClient
-from ume.integrations.langgraph import AsyncLangGraph
-from ume.integrations.letta import AsyncLetta
-from ume.integrations.memgpt import AsyncMemGPT
-from ume.integrations.supermemory import AsyncSuperMemory
+from ume.integrations import (
+    AsyncBaseClient,
+    AsyncLangGraph,
+    AsyncLetta,
+    AsyncMemGPT,
+    AsyncSuperMemory,
+)
 
 respx = pytest.importorskip("respx")
 
 
 def test_async_base_client_forwards() -> None:
     async def runner():
-        async with AsyncBaseClient(base_url="http://ume", api_key="token") as client:
+        async with AsyncBaseClient(base_url="http://ume", api_key="dummy-token") as client:  # pragma: allowlist secret
             with respx.mock(assert_all_called=True) as mock:
                 evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))
                 recall = mock.get("http://ume/recall").mock(return_value=httpx.Response(200, json={"ok": True}))
@@ -29,7 +31,7 @@ def test_async_base_client_forwards() -> None:
 
 def test_async_langgraph_wrapper_forwards() -> None:
     async def runner():
-        async with AsyncLangGraph(base_url="http://ume", api_key="token") as client:
+        async with AsyncLangGraph(base_url="http://ume", api_key="dummy-token") as client:  # pragma: allowlist secret
             assert isinstance(client, AsyncBaseClient)
             with respx.mock(assert_all_called=True) as mock:
                 evt = mock.post("http://ume/events").mock(return_value=httpx.Response(200))


### PR DESCRIPTION
## Summary
- update imports for new integration client module
- use dummy tokens for tests
- ensure live integration tests run with new base client

## Testing
- `pre-commit run --files tests/test_integrations.py tests/test_integrations_async.py tests/test_live_integrations.py`
- `pytest tests/test_integrations.py tests/test_integrations_async.py tests/test_live_integrations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d333f8f883268f1eb267cb967cb9