### PR TITLE
Add gRPC snapshot support

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -9,6 +9,11 @@ For gRPC clients, send the configured `UME_GRPC_TOKEN` as a bearer token in the
 `authorization` metadata. The helper class `AsyncUMEClient` accepts this token
 via its `token` argument and attaches it automatically.
 
+The gRPC service also exposes `SaveSnapshot` and `LoadSnapshot` RPCs which
+mirror the `/snapshot/save` and `/snapshot/load` HTTP endpoints. Both accept a
+`SnapshotPath` message containing the target file path and return an empty
+response on success.
+
 ## Endpoints
 
 ### GET `/query`

--- a/protos/ume.proto
+++ b/protos/ume.proto
@@ -61,6 +61,10 @@ message PublishEventRequest {
   EventEnvelope envelope = 1;
 }
 
+message SnapshotPath {
+  string path = 1;
+}
+
 service UME {
   rpc RunCypher(CypherQuery) returns (CypherResult);
   // Server streaming variant of RunCypher
@@ -69,6 +73,8 @@ service UME {
   rpc Recall(RecallRequest) returns (RecallResponse);
   rpc GetAuditEntries(AuditRequest) returns (AuditResponse);
   rpc PublishEvent(PublishEventRequest) returns (google.protobuf.Empty);
+  rpc SaveSnapshot(SnapshotPath) returns (google.protobuf.Empty);
+  rpc LoadSnapshot(SnapshotPath) returns (google.protobuf.Empty);
 }
 
 message Task {

--- a/src/ume/proto/ume_pb2.py
+++ b/src/ume/proto/ume_pb2.py
@@ -27,7 +27,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 import events_pb2 as events__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tume.proto\x12\x03ume\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x0c\x65vents.proto\"\x1d\n\x0b\x43ypherQuery\x12\x0e\n\x06\x63ypher\x18\x01 \x01(\t\"8\n\x0c\x43ypherResult\x12(\n\x07records\x18\x01 \x03(\x0b\x32\x17.google.protobuf.Struct\"7\n\x0c\x43ypherRecord\x12\'\n\x06record\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\"0\n\x13VectorSearchRequest\x12\x0e\n\x06vector\x18\x01 \x03(\x02\x12\t\n\x01k\x18\x02 \x01(\x05\"#\n\x14VectorSearchResponse\x12\x0b\n\x03ids\x18\x01 \x03(\t\"?\n\x04Node\x12\n\n\x02id\x18\x01 \x01(\t\x12+\n\nattributes\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"9\n\rRecallRequest\x12\r\n\x05query\x18\x01 \x01(\t\x12\x0e\n\x06vector\x18\x02 \x03(\x02\x12\t\n\x01k\x18\x03 \x01(\x05\"*\n\x0eRecallResponse\x12\x18\n\x05nodes\x18\x01 \x03(\x0b\x32\t.ume.Node\"\x1d\n\x0c\x41uditRequest\x12\r\n\x05limit\x18\x01 \x01(\x05\"S\n\nAuditEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x11\n\tsignature\x18\x04 \x01(\t\"1\n\rAuditResponse\x12 \n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x0f.ume.AuditEntry\";\n\x13PublishEventRequest\x12$\n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x12.ume.EventEnvelope\"#\n\x04Task\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0f\n\x07payload\x18\x02 \x01(\t\">\n\nTaskResult\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x0f\n\x07task_id\x18\x02 \x01(\t\x12\r\n\x05score\x18\x03 \x01(\x01\" \n\x0bPlanRequest\x12\x11\n\tobjective\x18\x01 \x01(\t\"(\n\x0cPlanResponse\x12\x18\n\x05tasks\x18\x01 \x03(\x0b\x32\t.ume.Task2\xe3\x02\n\x03UME\x12\x30\n\tRunCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherResult\x12\x35\n\x0cStreamCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherRecord0\x01\x12\x44\n\rSearchVectors\x12\x18.ume.VectorSearchRequest\x1a\x19.ume.VectorSearchResponse\x12\x31\n\x06Recall\x12\x12.ume.RecallRequest\x1a\x13.ume.RecallResponse\x12\x38\n\x0fGetAuditEntries\x12\x11.ume.AuditRequest\x1a\x12.ume.AuditResponse\x12@\n\x0cPublishEvent\x12\x18.ume.PublishEventRequest\x1a\x16.google.protobuf.Empty2k\n\x11\x41gentOrchestrator\x12+\n\x04Plan\x12\x10.ume.PlanRequest\x1a\x11.ume.PlanResponse\x12)\n\x0b\x45xecuteTask\x12\t.ume.Task\x1a\x0f.ume.TaskResultb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tume.proto\x12\x03ume\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x0c\x65vents.proto\"\x1d\n\x0b\x43ypherQuery\x12\x0e\n\x06\x63ypher\x18\x01 \x01(\t\"8\n\x0c\x43ypherResult\x12(\n\x07records\x18\x01 \x03(\x0b\x32\x17.google.protobuf.Struct\"7\n\x0c\x43ypherRecord\x12\'\n\x06record\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\"0\n\x13VectorSearchRequest\x12\x0e\n\x06vector\x18\x01 \x03(\x02\x12\t\n\x01k\x18\x02 \x01(\x05\"#\n\x14VectorSearchResponse\x12\x0b\n\x03ids\x18\x01 \x03(\t\"?\n\x04Node\x12\n\n\x02id\x18\x01 \x01(\t\x12+\n\nattributes\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"9\n\rRecallRequest\x12\r\n\x05query\x18\x01 \x01(\t\x12\x0e\n\x06vector\x18\x02 \x03(\x02\x12\t\n\x01k\x18\x03 \x01(\x05\"*\n\x0eRecallResponse\x12\x18\n\x05nodes\x18\x01 \x03(\x0b\x32\t.ume.Node\"\x1d\n\x0c\x41uditRequest\x12\r\n\x05limit\x18\x01 \x01(\x05\"S\n\nAuditEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x11\n\tsignature\x18\x04 \x01(\t\"1\n\rAuditResponse\x12 \n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x0f.ume.AuditEntry\";\n\x13PublishEventRequest\x12$\n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x12.ume.EventEnvelope\"\x1c\n\x0cSnapshotPath\x12\x0c\n\x04path\x18\x01 \x01(\t\"#\n\x04Task\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0f\n\x07payload\x18\x02 \x01(\t\">\n\nTaskResult\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x0f\n\x07task_id\x18\x02 \x01(\t\x12\r\n\x05score\x18\x03 \x01(\x01\" \n\x0bPlanRequest\x12\x11\n\tobjective\x18\x01 \x01(\t\"(\n\x0cPlanResponse\x12\x18\n\x05tasks\x18\x01 \x03(\x0b\x32\t.ume.Task2\xd9\x03\n\x03UME\x12\x30\n\tRunCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherResult\x12\x35\n\x0cStreamCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherRecord0\x01\x12\x44\n\rSearchVectors\x12\x18.ume.VectorSearchRequest\x1a\x19.ume.VectorSearchResponse\x12\x31\n\x06Recall\x12\x12.ume.RecallRequest\x1a\x13.ume.RecallResponse\x12\x38\n\x0fGetAuditEntries\x12\x11.ume.AuditRequest\x1a\x12.ume.AuditResponse\x12@\n\x0cPublishEvent\x12\x18.ume.PublishEventRequest\x1a\x16.google.protobuf.Empty\x12\x39\n\x0cSaveSnapshot\x12\x11.ume.SnapshotPath\x1a\x16.google.protobuf.Empty\x12\x39\n\x0cLoadSnapshot\x12\x11.ume.SnapshotPath\x1a\x16.google.protobuf.Empty2k\n\x11\x41gentOrchestrator\x12+\n\x04Plan\x12\x10.ume.PlanRequest\x1a\x11.ume.PlanResponse\x12)\n\x0b\x45xecuteTask\x12\t.ume.Task\x1a\x0f.ume.TaskResultb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -58,16 +58,18 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_AUDITRESPONSE']._serialized_end=657
   _globals['_PUBLISHEVENTREQUEST']._serialized_start=659
   _globals['_PUBLISHEVENTREQUEST']._serialized_end=718
-  _globals['_TASK']._serialized_start=720
-  _globals['_TASK']._serialized_end=755
-  _globals['_TASKRESULT']._serialized_start=757
-  _globals['_TASKRESULT']._serialized_end=819
-  _globals['_PLANREQUEST']._serialized_start=821
-  _globals['_PLANREQUEST']._serialized_end=853
-  _globals['_PLANRESPONSE']._serialized_start=855
-  _globals['_PLANRESPONSE']._serialized_end=895
-  _globals['_UME']._serialized_start=898
-  _globals['_UME']._serialized_end=1253
-  _globals['_AGENTORCHESTRATOR']._serialized_start=1255
-  _globals['_AGENTORCHESTRATOR']._serialized_end=1362
+  _globals['_SNAPSHOTPATH']._serialized_start=720
+  _globals['_SNAPSHOTPATH']._serialized_end=748
+  _globals['_TASK']._serialized_start=750
+  _globals['_TASK']._serialized_end=785
+  _globals['_TASKRESULT']._serialized_start=787
+  _globals['_TASKRESULT']._serialized_end=849
+  _globals['_PLANREQUEST']._serialized_start=851
+  _globals['_PLANREQUEST']._serialized_end=883
+  _globals['_PLANRESPONSE']._serialized_start=885
+  _globals['_PLANRESPONSE']._serialized_end=925
+  _globals['_UME']._serialized_start=928
+  _globals['_UME']._serialized_end=1401
+  _globals['_AGENTORCHESTRATOR']._serialized_start=1403
+  _globals['_AGENTORCHESTRATOR']._serialized_end=1510
 # @@protoc_insertion_point(module_scope)

--- a/src/ume_client/async_client.py
+++ b/src/ume_client/async_client.py
@@ -62,6 +62,14 @@ class AsyncUMEClient:
         request = ume_pb2.PublishEventRequest(envelope=envelope)
         await self._stub.PublishEvent(request, metadata=self._metadata)
 
+    async def save_snapshot(self, path: str) -> None:
+        request = ume_pb2.SnapshotPath(path=path)
+        await self._stub.SaveSnapshot(request, metadata=self._metadata)
+
+    async def load_snapshot(self, path: str) -> None:
+        request = ume_pb2.SnapshotPath(path=path)
+        await self._stub.LoadSnapshot(request, metadata=self._metadata)
+
     async def close(self) -> None:
         await self._channel.close()
 

--- a/src/ume_client/ume_pb2.py
+++ b/src/ume_client/ume_pb2.py
@@ -27,7 +27,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 import events_pb2 as events__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tume.proto\x12\x03ume\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x0c\x65vents.proto\"\x1d\n\x0b\x43ypherQuery\x12\x0e\n\x06\x63ypher\x18\x01 \x01(\t\"8\n\x0c\x43ypherResult\x12(\n\x07records\x18\x01 \x03(\x0b\x32\x17.google.protobuf.Struct\"7\n\x0c\x43ypherRecord\x12\'\n\x06record\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\"0\n\x13VectorSearchRequest\x12\x0e\n\x06vector\x18\x01 \x03(\x02\x12\t\n\x01k\x18\x02 \x01(\x05\"#\n\x14VectorSearchResponse\x12\x0b\n\x03ids\x18\x01 \x03(\t\"?\n\x04Node\x12\n\n\x02id\x18\x01 \x01(\t\x12+\n\nattributes\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"9\n\rRecallRequest\x12\r\n\x05query\x18\x01 \x01(\t\x12\x0e\n\x06vector\x18\x02 \x03(\x02\x12\t\n\x01k\x18\x03 \x01(\x05\"*\n\x0eRecallResponse\x12\x18\n\x05nodes\x18\x01 \x03(\x0b\x32\t.ume.Node\"\x1d\n\x0c\x41uditRequest\x12\r\n\x05limit\x18\x01 \x01(\x05\"S\n\nAuditEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x11\n\tsignature\x18\x04 \x01(\t\"1\n\rAuditResponse\x12 \n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x0f.ume.AuditEntry\";\n\x13PublishEventRequest\x12$\n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x12.ume.EventEnvelope\"#\n\x04Task\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0f\n\x07payload\x18\x02 \x01(\t\">\n\nTaskResult\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x0f\n\x07task_id\x18\x02 \x01(\t\x12\r\n\x05score\x18\x03 \x01(\x01\" \n\x0bPlanRequest\x12\x11\n\tobjective\x18\x01 \x01(\t\"(\n\x0cPlanResponse\x12\x18\n\x05tasks\x18\x01 \x03(\x0b\x32\t.ume.Task2\xe3\x02\n\x03UME\x12\x30\n\tRunCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherResult\x12\x35\n\x0cStreamCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherRecord0\x01\x12\x44\n\rSearchVectors\x12\x18.ume.VectorSearchRequest\x1a\x19.ume.VectorSearchResponse\x12\x31\n\x06Recall\x12\x12.ume.RecallRequest\x1a\x13.ume.RecallResponse\x12\x38\n\x0fGetAuditEntries\x12\x11.ume.AuditRequest\x1a\x12.ume.AuditResponse\x12@\n\x0cPublishEvent\x12\x18.ume.PublishEventRequest\x1a\x16.google.protobuf.Empty2k\n\x11\x41gentOrchestrator\x12+\n\x04Plan\x12\x10.ume.PlanRequest\x1a\x11.ume.PlanResponse\x12)\n\x0b\x45xecuteTask\x12\t.ume.Task\x1a\x0f.ume.TaskResultb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tume.proto\x12\x03ume\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x0c\x65vents.proto\"\x1d\n\x0b\x43ypherQuery\x12\x0e\n\x06\x63ypher\x18\x01 \x01(\t\"8\n\x0c\x43ypherResult\x12(\n\x07records\x18\x01 \x03(\x0b\x32\x17.google.protobuf.Struct\"7\n\x0c\x43ypherRecord\x12\'\n\x06record\x18\x01 \x01(\x0b\x32\x17.google.protobuf.Struct\"0\n\x13VectorSearchRequest\x12\x0e\n\x06vector\x18\x01 \x03(\x02\x12\t\n\x01k\x18\x02 \x01(\x05\"#\n\x14VectorSearchResponse\x12\x0b\n\x03ids\x18\x01 \x03(\t\"?\n\x04Node\x12\n\n\x02id\x18\x01 \x01(\t\x12+\n\nattributes\x18\x02 \x01(\x0b\x32\x17.google.protobuf.Struct\"9\n\rRecallRequest\x12\r\n\x05query\x18\x01 \x01(\t\x12\x0e\n\x06vector\x18\x02 \x03(\x02\x12\t\n\x01k\x18\x03 \x01(\x05\"*\n\x0eRecallResponse\x12\x18\n\x05nodes\x18\x01 \x03(\x0b\x32\t.ume.Node\"\x1d\n\x0c\x41uditRequest\x12\r\n\x05limit\x18\x01 \x01(\x05\"S\n\nAuditEntry\x12\x11\n\ttimestamp\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x0e\n\x06reason\x18\x03 \x01(\t\x12\x11\n\tsignature\x18\x04 \x01(\t\"1\n\rAuditResponse\x12 \n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x0f.ume.AuditEntry\";\n\x13PublishEventRequest\x12$\n\x08\x65nvelope\x18\x01 \x01(\x0b\x32\x12.ume.EventEnvelope\"\x1c\n\x0cSnapshotPath\x12\x0c\n\x04path\x18\x01 \x01(\t\"#\n\x04Task\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0f\n\x07payload\x18\x02 \x01(\t\">\n\nTaskResult\x12\x10\n\x08\x61gent_id\x18\x01 \x01(\t\x12\x0f\n\x07task_id\x18\x02 \x01(\t\x12\r\n\x05score\x18\x03 \x01(\x01\" \n\x0bPlanRequest\x12\x11\n\tobjective\x18\x01 \x01(\t\"(\n\x0cPlanResponse\x12\x18\n\x05tasks\x18\x01 \x03(\x0b\x32\t.ume.Task2\xd9\x03\n\x03UME\x12\x30\n\tRunCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherResult\x12\x35\n\x0cStreamCypher\x12\x10.ume.CypherQuery\x1a\x11.ume.CypherRecord0\x01\x12\x44\n\rSearchVectors\x12\x18.ume.VectorSearchRequest\x1a\x19.ume.VectorSearchResponse\x12\x31\n\x06Recall\x12\x12.ume.RecallRequest\x1a\x13.ume.RecallResponse\x12\x38\n\x0fGetAuditEntries\x12\x11.ume.AuditRequest\x1a\x12.ume.AuditResponse\x12@\n\x0cPublishEvent\x12\x18.ume.PublishEventRequest\x1a\x16.google.protobuf.Empty\x12\x39\n\x0cSaveSnapshot\x12\x11.ume.SnapshotPath\x1a\x16.google.protobuf.Empty\x12\x39\n\x0cLoadSnapshot\x12\x11.ume.SnapshotPath\x1a\x16.google.protobuf.Empty2k\n\x11\x41gentOrchestrator\x12+\n\x04Plan\x12\x10.ume.PlanRequest\x1a\x11.ume.PlanResponse\x12)\n\x0b\x45xecuteTask\x12\t.ume.Task\x1a\x0f.ume.TaskResultb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -58,16 +58,18 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_AUDITRESPONSE']._serialized_end=657
   _globals['_PUBLISHEVENTREQUEST']._serialized_start=659
   _globals['_PUBLISHEVENTREQUEST']._serialized_end=718
-  _globals['_TASK']._serialized_start=720
-  _globals['_TASK']._serialized_end=755
-  _globals['_TASKRESULT']._serialized_start=757
-  _globals['_TASKRESULT']._serialized_end=819
-  _globals['_PLANREQUEST']._serialized_start=821
-  _globals['_PLANREQUEST']._serialized_end=853
-  _globals['_PLANRESPONSE']._serialized_start=855
-  _globals['_PLANRESPONSE']._serialized_end=895
-  _globals['_UME']._serialized_start=898
-  _globals['_UME']._serialized_end=1253
-  _globals['_AGENTORCHESTRATOR']._serialized_start=1255
-  _globals['_AGENTORCHESTRATOR']._serialized_end=1362
+  _globals['_SNAPSHOTPATH']._serialized_start=720
+  _globals['_SNAPSHOTPATH']._serialized_end=748
+  _globals['_TASK']._serialized_start=750
+  _globals['_TASK']._serialized_end=785
+  _globals['_TASKRESULT']._serialized_start=787
+  _globals['_TASKRESULT']._serialized_end=849
+  _globals['_PLANREQUEST']._serialized_start=851
+  _globals['_PLANREQUEST']._serialized_end=883
+  _globals['_PLANRESPONSE']._serialized_start=885
+  _globals['_PLANRESPONSE']._serialized_end=925
+  _globals['_UME']._serialized_start=928
+  _globals['_UME']._serialized_end=1401
+  _globals['_AGENTORCHESTRATOR']._serialized_start=1403
+  _globals['_AGENTORCHESTRATOR']._serialized_end=1510
 # @@protoc_insertion_point(module_scope)

--- a/src/ume_client/ume_pb2_grpc.py
+++ b/src/ume_client/ume_pb2_grpc.py
@@ -65,6 +65,16 @@ class UMEStub(object):
                 request_serializer=ume__pb2.PublishEventRequest.SerializeToString,
                 response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
                 _registered_method=True)
+        self.SaveSnapshot = channel.unary_unary(
+                '/ume.UME/SaveSnapshot',
+                request_serializer=ume__pb2.SnapshotPath.SerializeToString,
+                response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+                _registered_method=True)
+        self.LoadSnapshot = channel.unary_unary(
+                '/ume.UME/LoadSnapshot',
+                request_serializer=ume__pb2.SnapshotPath.SerializeToString,
+                response_deserializer=google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+                _registered_method=True)
 
 
 class UMEServicer(object):
@@ -107,6 +117,18 @@ class UMEServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def SaveSnapshot(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
+    def LoadSnapshot(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_UMEServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -138,6 +160,16 @@ def add_UMEServicer_to_server(servicer, server):
             'PublishEvent': grpc.unary_unary_rpc_method_handler(
                     servicer.PublishEvent,
                     request_deserializer=ume__pb2.PublishEventRequest.FromString,
+                    response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+            ),
+            'SaveSnapshot': grpc.unary_unary_rpc_method_handler(
+                    servicer.SaveSnapshot,
+                    request_deserializer=ume__pb2.SnapshotPath.FromString,
+                    response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
+            ),
+            'LoadSnapshot': grpc.unary_unary_rpc_method_handler(
+                    servicer.LoadSnapshot,
+                    request_deserializer=ume__pb2.SnapshotPath.FromString,
                     response_serializer=google_dot_protobuf_dot_empty__pb2.Empty.SerializeToString,
             ),
     }
@@ -302,6 +334,60 @@ class UME(object):
             target,
             '/ume.UME/PublishEvent',
             ume__pb2.PublishEventRequest.SerializeToString,
+            google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def SaveSnapshot(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/ume.UME/SaveSnapshot',
+            ume__pb2.SnapshotPath.SerializeToString,
+            google_dot_protobuf_dot_empty__pb2.Empty.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def LoadSnapshot(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/ume.UME/LoadSnapshot',
+            ume__pb2.SnapshotPath.SerializeToString,
             google_dot_protobuf_dot_empty__pb2.Empty.FromString,
             options,
             channel_credentials,

--- a/tests/test_grpc_snapshot.py
+++ b/tests/test_grpc_snapshot.py
@@ -1,0 +1,57 @@
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src" / "ume_client"))
+
+from ume_client.async_client import AsyncUMEClient  # noqa: E402
+from ume.graph import MockGraph  # noqa: E402
+from ume.grpc_server import serve  # noqa: E402
+
+
+class DummyQE:
+    def execute_cypher(self, cypher: str):
+        return []
+
+
+class DummyStore:
+    pass
+
+
+async def _run_server(graph: MockGraph, port_holder: list[int]):
+    server = serve(DummyQE(), DummyStore(), graph=graph, port=0)
+    port_holder.append(server.add_insecure_port("localhost:0"))
+    await server.start()
+    await server.wait_for_termination()
+
+
+async def _run_roundtrip(port: int, tmp_path: Path, graph: MockGraph):
+    path = tmp_path / "snap.json"
+    async with AsyncUMEClient(f"localhost:{port}") as client:
+        await client.save_snapshot(str(path))
+        assert path.is_file()
+        graph.clear()
+        await client.load_snapshot(str(path))
+        assert set(graph.get_all_node_ids()) == {"a", "b"}
+        assert ("a", "b", "L") in graph.get_all_edges()
+
+
+def test_grpc_snapshot_roundtrip(tmp_path: Path):
+    graph = MockGraph()
+    graph.add_node("a", {"x": 1})
+    graph.add_node("b", {"y": 2})
+    graph.add_edge("a", "b", "L")
+    ports: list[int] = []
+
+    async def runner():
+        server_task = asyncio.create_task(_run_server(graph, ports))
+        while not ports:
+            await asyncio.sleep(0.01)
+        await _run_roundtrip(ports[0], tmp_path, graph)
+        server_task.cancel()
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- extend protobuf schema with SaveSnapshot and LoadSnapshot RPCs
- implement snapshot handlers in UMEServicer
- expose helpers in AsyncUMEClient
- document usage in API reference
- test roundtrip snapshot save/load over gRPC

## Testing
- `pre-commit run --files docs/API_REFERENCE.md protos/ume.proto src/ume/grpc_server/__init__.py src/ume/proto/ume_pb2.py src/ume_client/async_client.py src/ume_client/ume_pb2.py src/ume_client/ume_pb2_grpc.py tests/test_grpc_snapshot.py`
- `pytest -q tests/test_grpc_snapshot.py`

------
https://chatgpt.com/codex/tasks/task_e_6871d32e60bc8326b5e67fc3710f9efd