### PR TITLE
Add vector backend registry with plugin support

### DIFF
--- a/examples/vector_backend_plugin.py
+++ b/examples/vector_backend_plugin.py
@@ -1,0 +1,52 @@
+
+"""Example vector backend plugin."""
+
+from typing import Dict
+
+import numpy as np
+
+from ume.vector_backends import register_backend
+from ume.vector_store import VectorBackend
+
+
+class MemoryBackend(VectorBackend):
+    """Naive in-memory backend demonstrating the plugin API."""
+
+    def __init__(self, dim: int, **_: object) -> None:
+        self.dim = dim
+        self.vectors: Dict[str, list[float]] = {}
+
+    def add(self, item_id: str, vector: list[float], *, persist: bool = False) -> None:
+        self.vectors[item_id] = list(vector)
+
+    def add_many(self, vectors: Dict[str, list[float]], *, persist: bool = False) -> None:
+        for vid, vec in vectors.items():
+            self.add(vid, vec)
+
+    def delete(self, item_id: str) -> None:
+        self.vectors.pop(item_id, None)
+
+    def query(self, vector: list[float], k: int = 5) -> list[str]:
+        if not self.vectors:
+            return []
+        arr = np.asarray([self.vectors[i] for i in self.vectors], dtype="float32")
+        q = np.asarray(vector, dtype="float32")
+        dists = np.linalg.norm(arr - q, axis=1)
+        ids = list(self.vectors)
+        idxs = np.argsort(dists)[:k]
+        return [ids[i] for i in idxs]
+
+    def save(self, path: str | None = None) -> None:
+        pass
+
+    def load(self, path: str | None = None) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def get_vector_timestamps(self) -> Dict[str, int]:
+        return {k: 0 for k in self.vectors}
+
+
+register_backend("memory", MemoryBackend)

--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -104,8 +104,10 @@ def create_default_store() -> VectorBackend:  # pragma: no cover - trivial wrapp
     """Instantiate a vector store using ``ume.config.settings``."""
     backend_name = settings.UME_VECTOR_BACKEND.lower()
     cls = get_backend(backend_name)
+    import inspect
+
     kwargs: Dict[str, Any] = {}
-    if cls is FaissBackend:
+    if "use_gpu" in inspect.signature(cls).parameters:
         kwargs["use_gpu"] = settings.UME_VECTOR_USE_GPU
     dim = _resolve_vector_dim(settings.UME_VECTOR_DIM)
     return cls(
@@ -138,7 +140,8 @@ else:
             store_cls = get_backend(backend_name)
             dim = kwargs.pop("dim", settings.UME_VECTOR_DIM)
             kwargs["dim"] = _resolve_vector_dim(dim)
-            if store_cls is FaissBackend:
+            import inspect
+            if "use_gpu" in inspect.signature(store_cls).parameters:
                 kwargs.setdefault("use_gpu", settings.UME_VECTOR_USE_GPU)
             return store_cls(*args, **kwargs)
 

--- a/tests/test_vector_backend_plugins.py
+++ b/tests/test_vector_backend_plugins.py
@@ -1,0 +1,46 @@
+import types
+import importlib.metadata as metadata
+import importlib
+
+from ume.vector_backends import get_backend, available_backends, load_entrypoints
+from ume.vector_store import VectorBackend
+
+
+class DummyBackend(VectorBackend):
+    def add(self, item_id: str, vector: list[float], *, persist: bool = False) -> None:
+        pass
+
+    def add_many(self, vectors: dict[str, list[float]], *, persist: bool = False) -> None:
+        pass
+
+    def delete(self, item_id: str) -> None:
+        pass
+
+    def query(self, vector: list[float], k: int = 5) -> list[str]:
+        return []
+
+    def save(self, path: str | None = None) -> None:
+        pass
+
+    def load(self, path: str | None = None) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def get_vector_timestamps(self) -> dict[str, int]:
+        return {}
+
+
+def test_entrypoint_registration(monkeypatch):
+    module = types.ModuleType("dummy_mod")
+    module.DummyBackend = DummyBackend
+    monkeypatch.setitem(importlib.sys.modules, "dummy_mod", module)
+
+    ep = metadata.EntryPoint(name="dummy", value="dummy_mod:DummyBackend", group="ume.vector_backends")
+    monkeypatch.setattr(metadata, "entry_points", lambda group=None: (ep,) if group == "ume.vector_backends" else ())
+
+    load_entrypoints()
+
+    assert "dummy" in available_backends()
+    assert get_backend("dummy") is DummyBackend


### PR DESCRIPTION
## Summary
- implement entrypoint discovery in `ume.vector_backends`
- refactor vector store factory to look for `use_gpu` arg dynamically
- add example memory backend plugin
- document how to create custom vector store backends
- test entrypoint registration mechanism

## Testing
- `pre-commit run --files README.md src/ume/vector_backends/__init__.py src/ume/vector_store.py examples/vector_backend_plugin.py tests/test_vector_backend_plugins.py`
- `pytest tests/test_vector_store_unit.py tests/test_vector_store.py tests/test_vector_backend_plugins.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6871d32ece1c8326a6b47fa8fe62242c