### PR TITLE
Update AngelBridge to use event ledger

### DIFF
--- a/docs/ANGEL_BRIDGE.md
+++ b/docs/ANGEL_BRIDGE.md
@@ -1,12 +1,19 @@
 # Angel Bridge
 
-`AngelBridge` consumes recent events and emits a short daily summary. This can be
-used to keep external services informed about the system's activity without
-exposing the full event stream.
+`AngelBridge` consumes recent sanitized events and emits a short daily summary.
+The service keeps external systems informed about activity without exposing the
+full event stream.
 
-The implementation included here is a stub which counts events in a given
-lookback window. Real deployments might query a database or message queue and
-post the resulting summary to another service.
+Events are retrieved from the local SQLite based `event_ledger` that is filled
+by the privacy agent. If Kafka is configured, the bridge will read directly from
+the clean events topic instead. The returned summary aggregates the number of
+events for each `event_type`.
+
+Example output::
+
+    Summary for 2024-05-08:
+    CREATE_NODE: 2
+    CREATE_EDGE: 1
 
 ## Configuration
 

--- a/src/ume/angel_bridge.py
+++ b/src/ume/angel_bridge.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Iterable, Dict, Any, List
 import logging
 import time
-import json
 
-from .persistent_graph import PersistentGraph
+try:  # Optional Kafka dependency
+    from .client import UMEClient
+except Exception:  # pragma: no cover - confluent_kafka may be missing
+    UMEClient = None
 
+from .event_ledger import event_ledger
 from .config import settings
 
 logger = logging.getLogger(__name__)
@@ -24,56 +27,50 @@ class AngelBridge:
     def consume_events(self) -> List[Dict[str, Any]]:
         """Return events from the last ``lookback_hours``.
 
-        This stub implementation returns an empty list. A real implementation
-        would query an event store or database for events within the given time
-        window.
+        Events are fetched from the local :mod:`event_ledger`. If Kafka is
+        configured and available, it will be used instead.
         """
 
         logger.debug("Consuming events for last %s hours", self.lookback_hours)
         cutoff = int(time.time()) - self.lookback_hours * 3600
         events: List[Dict[str, Any]] = []
-        graph = PersistentGraph()
-        try:
-            cur = graph.conn.execute(
-                "SELECT id, attributes, created_at FROM nodes "
-                "WHERE redacted=0 AND created_at >= ?",
-                (cutoff,),
-            )
-            for row in cur.fetchall():
-                events.append(
-                    {
-                        "type": "node",
-                        "id": row["id"],
-                        "timestamp": row["created_at"],
-                        "attributes": json.loads(row["attributes"]),
-                    }
-                )
 
-            cur = graph.conn.execute(
-                "SELECT source, target, label, created_at FROM edges "
-                "WHERE redacted=0 AND created_at >= ?",
-                (cutoff,),
-            )
-            for row in cur.fetchall():
-                events.append(
-                    {
-                        "type": "edge",
-                        "source": row["source"],
-                        "target": row["target"],
-                        "label": row["label"],
-                        "timestamp": row["created_at"],
-                    }
-                )
-        finally:
-            graph.close()
+        used_kafka = False
+        if UMEClient is not None and settings.KAFKA_BOOTSTRAP_SERVERS:
+            try:
+                with UMEClient(settings) as client:
+                    for event in client.consume_events(timeout=0.5):
+                        if event.timestamp >= cutoff:
+                            events.append(
+                                {
+                                    "event_type": event.event_type,
+                                    "timestamp": event.timestamp,
+                                }
+                            )
+                used_kafka = True
+            except Exception as exc:  # pragma: no cover - Kafka optional
+                logger.warning("Kafka read failed: %s", exc)
+
+        if not used_kafka:
+            for _, data in event_ledger.range():
+                ts = data.get("timestamp", 0)
+                if ts >= cutoff:
+                    events.append(data)
 
         return events
 
     def generate_summary(self, events: Iterable[Dict[str, Any]]) -> str:
         """Generate a text summary for the provided events."""
-        count = len(list(events))
-        today = datetime.utcnow().date()
-        return f"Summary for {today}: {count} events"
+        counts: Dict[str, int] = {}
+        for ev in events:
+            etype = ev.get("event_type") or ev.get("type", "unknown")
+            counts[etype] = counts.get(etype, 0) + 1
+
+        today = datetime.now(timezone.utc).date()
+        lines = [f"Summary for {today}:"]
+        for etype, num in sorted(counts.items()):
+            lines.append(f"{etype}: {num}")
+        return "\n".join(lines)
 
     def emit_daily_summary(self) -> str:
         """Consume events and return the summary string."""

--- a/tests/test_angel_bridge.py
+++ b/tests/test_angel_bridge.py
@@ -3,6 +3,7 @@ import sys
 from pathlib import Path
 import pytest
 import time
+from ume.event_ledger import EventLedger
 
 module_path = Path(__file__).resolve().parents[1] / "src" / "ume" / "angel_bridge.py"
 spec = importlib.util.spec_from_file_location("ume.angel_bridge", module_path)
@@ -12,41 +13,66 @@ sys.modules[spec.name] = angel_bridge
 spec.loader.exec_module(angel_bridge)
 
 AngelBridge = angel_bridge.AngelBridge  # type: ignore[attr-defined]
-PersistentGraph = angel_bridge.PersistentGraph  # type: ignore[attr-defined]
 settings = angel_bridge.settings
 
 
 def test_summary_generation() -> None:
     bridge = AngelBridge(lookback_hours=1)
-    bridge.consume_events = lambda: [{"foo": 1}, {"foo": 2}]  # type: ignore[assignment]
+    bridge.consume_events = lambda: [
+        {"event_type": "CREATE_NODE", "timestamp": 1},
+        {"event_type": "CREATE_EDGE", "timestamp": 1},
+        {"event_type": "CREATE_NODE", "timestamp": 1},
+    ]  # type: ignore[assignment]
     summary = bridge.emit_daily_summary()
-    assert "2 events" in summary
+    assert "CREATE_NODE: 2" in summary
+    assert "CREATE_EDGE: 1" in summary
 
 
 def test_consume_events_filters_by_time(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    db_path = tmp_path / "graph.db"
-    monkeypatch.setattr(settings, "UME_DB_PATH", str(db_path))
+    ledger_path = tmp_path / "ledger.db"
+    ledger = EventLedger(str(ledger_path))
+    monkeypatch.setattr(angel_bridge, "event_ledger", ledger)
 
-    graph = PersistentGraph(str(db_path))
     now = int(time.time())
-    graph.add_node("recent", {})
-    graph.add_node("old", {})
-    graph.add_edge("recent", "recent", "new")
-    graph.add_edge("recent", "old", "old")
-
-    old_ts = now - 5 * 3600
-    with graph.conn:
-        graph.conn.execute("UPDATE nodes SET created_at=? WHERE id='old'", (old_ts,))
-        graph.conn.execute("UPDATE edges SET created_at=? WHERE label='old'", (old_ts,))
+    ledger.append(0, {"event_type": "CREATE_NODE", "timestamp": now, "node_id": "recent", "payload": {}})
+    ledger.append(1, {"event_type": "CREATE_NODE", "timestamp": now - 5 * 3600, "node_id": "old", "payload": {}})
 
     bridge = AngelBridge(lookback_hours=2)
     events = bridge.consume_events()
 
-    node_ids = {e["id"] for e in events if e["type"] == "node"}
-    edge_labels = {e["label"] for e in events if e["type"] == "edge"}
+    ids = {e["node_id"] for e in events}
 
-    assert "recent" in node_ids
-    assert "old" not in node_ids
-    assert "new" in edge_labels
-    assert "old" not in edge_labels
+    assert "recent" in ids
+    assert "old" not in ids
+
+
+def test_kafka_fallback_to_ledger(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bridge should fall back to the ledger when Kafka raises an error."""
+
+    class BrokenClient:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def __enter__(self) -> "BrokenClient":
+            return self
+
+        def __exit__(self, exc_type: type | None, exc: BaseException | None, tb: object) -> None:
+            pass
+
+        def consume_events(self, timeout: float = 0.5):
+            raise RuntimeError("boom")
+
+    ledger_path = tmp_path / "ledger.db"
+    ledger = EventLedger(str(ledger_path))
+    ledger.append(0, {"event_type": "CREATE_NODE", "timestamp": int(time.time()), "node_id": "foo", "payload": {}})
+
+    monkeypatch.setattr(angel_bridge, "event_ledger", ledger)
+    monkeypatch.setattr(angel_bridge, "UMEClient", BrokenClient)
+    monkeypatch.setattr(settings, "KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+
+    bridge = AngelBridge(lookback_hours=2)
+    events = bridge.consume_events()
+
+    assert len(events) == 1
+    assert events[0]["node_id"] == "foo"
 


### PR DESCRIPTION
## Summary
- use timezone-aware dates in Angel Bridge summaries
- avoid buffering events when counting types
- show summary example in docs
- ensure Kafka failures fall back to the ledger
- test Kafka fallback

## Testing
- `ruff check src/ume/angel_bridge.py tests/test_angel_bridge.py`
- `pytest tests/test_angel_bridge.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68742e41aa4483268cc984f5deff3f94