### PR TITLE
Add `ume up` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ settings.
 The `ume` CLI can spin up all services for local development. From the repository root run:
 
 ```bash
-poetry run python ume_cli.py up --no-confirm
+poetry run ume up --no-confirm
 
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ grpc_server = ["grpcio"]
 [tool.poetry.scripts]
 produce_demo = "ume.producer_demo:main"
 ume-cli = "ume_cli:main"
+ume = "ume.__main__:main"
 compile-protos = "scripts.compile_protos:main"
 
 

--- a/src/ume/__main__.py
+++ b/src/ume/__main__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+import argparse
+
+from ume_cli import _quickstart
+
+
+def main() -> None:
+    """Entry point for the ``ume`` console script."""
+    parser = argparse.ArgumentParser(description="UME helper commands")
+    sub = parser.add_subparsers(dest="command")
+
+    up_parser = sub.add_parser(
+        "up", help="Create .env, generate certs and start the stack"
+    )
+    up_parser.add_argument(
+        "--no-confirm",
+        action="store_true",
+        help="Create .env and certs without prompting",
+    )
+
+    args = parser.parse_args()
+    if args.command == "up":
+        _quickstart(args.no_confirm)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -341,6 +341,28 @@ def test_cli_up_and_down(monkeypatch: pytest.MonkeyPatch, capsys: pytest.Capture
     assert "Stack stopped." in out_down
 
 
+def test_top_level_ume_up(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure the top-level ``ume up`` command runs ``_quickstart``."""
+    import importlib
+    import ume.__main__ as main
+
+    importlib.reload(main)
+
+    called: dict[str, bool] = {}
+
+    def fake_quickstart(no_confirm: bool = False) -> None:
+        called["flag"] = no_confirm
+
+    monkeypatch.setattr(main, "_quickstart", fake_quickstart)
+
+    argv = sys.argv[:]
+    sys.argv = ["ume", "up", "--no-confirm"]
+    main.main()
+    sys.argv = argv
+
+    assert called.get("flag") is True
+
+
 def test_cli_up_custom_compose(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -513,7 +535,7 @@ def test_cli_env_file_warning(
     importlib.reload(cli)
 
     env_file = tmp_path / ".env"
-    env_file.write_text("UME_AUDIT_SIGNING_KEY=default-key\n")
+    env_file.write_text("UME_AUDIT_SIGNING_KEY=default-key\n")  # pragma: allowlist secret
 
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(cli.secrets, "token_hex", lambda *_: "new-key")


### PR DESCRIPTION
## Summary
- add a simple `ume` console script
- document `ume up` usage in README
- hook up `ume` console script in poetry
- test the new command

## Testing
- `pre-commit run --files README.md pyproject.toml tests/test_cli_smoke.py src/ume/__main__.py`
- `PYTHONPATH=src pytest tests/test_cli_smoke.py::test_top_level_ume_up -q`

------
https://chatgpt.com/codex/tasks/task_e_68747285e0a48326a93117ef7921941c