### PR TITLE
Add event request schema and validation

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -130,6 +130,18 @@ curl -X POST http://localhost:8000/events \
   -d '{"event_type":"CREATE_NODE","timestamp":1,"node_id":"n1","payload":{"node_id":"n1"}}'
 ```
 
+### POST `/events/batch`
+Apply multiple events sequentially.
+
+Example request:
+
+```bash
+curl -X POST http://localhost:8000/events/batch \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '[{"event_type":"CREATE_NODE","timestamp":1,"node_id":"n1","payload":{"node_id":"n1"}}]'
+```
+
 ### GET `/recall`
 Retrieve attribute data for the `k` nearest nodes to a query.
 

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -23,6 +23,7 @@ try:  # pragma: no cover - optional dependency
 except Exception:  # pragma: no cover - allow tests without opentelemetry installed
     trace = None
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 
 from .metrics import REQUEST_COUNT, REQUEST_LATENCY
@@ -211,5 +212,13 @@ async def access_denied_handler(
     request: Request, exc: AccessDeniedError
 ) -> JSONResponse:
     return JSONResponse(status_code=403, content={"detail": str(exc)})
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_error_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Return 400 for request validation errors."""
+    return JSONResponse(status_code=400, content={"detail": exc.errors()})
 
 

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -79,6 +79,19 @@ class SnapshotPathRequest(BaseModel):
     path: str
 
 
+class EventRequest(BaseModel):
+    """Schema for a single event."""
+
+    event_type: str
+    timestamp: int
+    event_id: str | None = None
+    source: str | None = None
+    node_id: str | None = None
+    target_node_id: str | None = None
+    label: str | None = None
+    payload: Dict[str, Any] | None = None
+
+
 @router.get("/query")
 def run_cypher(
     cypher: str,
@@ -180,13 +193,16 @@ def api_redact_node(
 
 @router.post("/events/batch")
 def api_post_events_batch(
-    events: List[Dict[str, Any]] = Body(...),
+    events: List[EventRequest] = Body(...),
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: None = Depends(deps.require_token),
 ) -> Dict[str, Any]:
     """Apply multiple events sequentially to the graph."""
     try:
-        ingest_events_batch(events, graph)
+        ingest_events_batch(
+            [e.model_dump(exclude_none=True) for e in events],
+            graph,
+        )
     except (EventError, ProcessingError) as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
@@ -293,13 +309,13 @@ def api_get_document(
 
 @router.post("/events")
 def api_post_event(
-    data: Dict[str, Any] = Body(...),
+    req: EventRequest,
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: None = Depends(deps.require_token),
 ) -> Dict[str, Any]:
     """Validate and apply an event to the graph."""
     try:
-        ingest_event(data, graph)
+        ingest_event(req.model_dump(exclude_none=True), graph)
     except (EventError, ProcessingError) as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -102,3 +102,14 @@ def test_post_events_batch_invalid(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 400
+
+
+def test_post_event_missing_field(client_and_graph) -> None:
+    client, _ = client_and_graph
+    token = _token(client)
+    res = client.post(
+        "/events",
+        json={"timestamp": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- define `EventRequest` pydantic model
- use `EventRequest` in `/events` and `/events/batch`
- add validation error handler returning 400
- document batch event endpoint with curl example
- test missing field failure

## Testing
- `pre-commit run --files src/ume/graph_routes.py src/ume/api.py tests/test_api_events.py`
- `pytest -q tests/test_api_events.py::test_post_event_invalid tests/test_api_events.py::test_post_events_batch_invalid tests/test_api_events.py::test_post_event_missing_field`


------
https://chatgpt.com/codex/tasks/task_e_6874728629f88326b21dd45f892eb119