### PR TITLE
Update token endpoint in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,10 +488,10 @@ Open <http://localhost:8001/dashboard/> once the API is running. For additional 
 
 ### API Authentication
 
-Obtain an OAuth2 token via the `/token` endpoint using the password grant:
+Obtain an OAuth2 token via the `/auth/token` endpoint using the password grant:
 
 ```bash
-curl -X POST -d "username=ume&password=password" http://localhost:8000/token
+curl -X POST -d "username=ume&password=password" http://localhost:8000/auth/token
 ```
 
 Include the returned access token in the `Authorization` header for subsequent
@@ -818,7 +818,7 @@ broker communication errors so they can be handled cleanly.
 ## Async gRPC Client
 
 `AsyncUMEClient` provides asynchronous access to the gRPC API. Pass the token
-returned from `/token` using the `token` parameter so the client can include it
+returned from `/auth/token` using the `token` parameter so the client can include it
 as `authorization` metadata on every RPC call. The examples below read the
 token from the `UME_GRPC_TOKEN` environment variable.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -2,7 +2,7 @@
 
 
 This document summarizes the HTTP routes exposed by the UME FastAPI application.
-Acquire a token from `/token` using the OAuth2 password flow and include it as a
+Acquire a token from `/auth/token` using the OAuth2 password flow and include it as a
 `Bearer` token in the `Authorization` header. Tokens expire after `UME_OAUTH_TTL` seconds.
 
 For gRPC clients, send the configured `UME_GRPC_TOKEN` as a bearer token in the

--- a/docs/VECTOR_BENCHMARKS.md
+++ b/docs/VECTOR_BENCHMARKS.md
@@ -14,7 +14,7 @@ ume> benchmark_vectors --gpu --num-vectors 100000 --num-queries 100 --runs 3
 or via the HTTP API:
 
 ```bash
-TOKEN=$(curl -s -X POST -d "username=ume&password=password" http://localhost:8000/token | jq -r .access_token)
+TOKEN=$(curl -s -X POST -d "username=ume&password=password" http://localhost:8000/auth/token | jq -r .access_token)
 curl -H "Authorization: Bearer $TOKEN" \
   'http://localhost:8000/vectors/benchmark?use_gpu=true&num_vectors=100000&num_queries=100&runs=3'
 


### PR DESCRIPTION
## Summary
- update README authentication instructions with new `/auth/token` path
- update API reference and vector benchmark docs accordingly

## Testing
- `grep -nR '/token' README.md docs`

------
https://chatgpt.com/codex/tasks/task_e_68747d21fd888326adafb9af385cde0d