### PR TITLE
Add /store endpoint alias

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -110,7 +110,8 @@ Return recent audit log entries, newest first.
 - **Query parameters**: optional `limit` (default `10`).
 
 ### POST `/events`
-Validate and apply an event to the graph.
+Validate and apply an event to the graph. This endpoint is also available as
+`/store`.
 
 **Body Parameters**
 
@@ -131,7 +132,8 @@ curl -X POST http://localhost:8000/events \
 ```
 
 ### POST `/events/batch`
-Apply multiple events sequentially.
+Apply multiple events sequentially. This endpoint is also available as
+`/store/batch`.
 
 Example request:
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -1,8 +1,9 @@
 # Integration Adapters
 
 UME ships with simple wrappers for popular frameworks. Each adapter forwards events
-to a running UME instance and exposes a `send_events` and `recall` API. Async
-variants are also available with the `Async` prefix.
+to a running UME instance and exposes a `send_events` and `recall` API. A
+`store_events` alias using the `/store` endpoint is also available. Async variants
+are provided with the `Async` prefix.
 
 The examples below demonstrate both synchronous and asynchronous usage.
 

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -209,6 +209,24 @@ def api_post_events_batch(
     return {"status": "ok"}
 
 
+@router.post("/store/batch")
+def api_store_events_batch(
+    events: List[EventRequest] = Body(...),
+    graph: IGraphAdapter = Depends(deps.get_graph),
+    _: None = Depends(deps.require_token),
+) -> Dict[str, Any]:
+    """Alias for :func:`api_post_events_batch`."""
+    try:
+        ingest_events_batch(
+            [e.model_dump(exclude_none=True) for e in events],
+            graph,
+        )
+    except (EventError, ProcessingError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return {"status": "ok"}
+
+
 @router.post("/redact/edge")
 def api_redact_edge(
     req: RedactEdgeRequest,
@@ -314,6 +332,21 @@ def api_post_event(
     _: None = Depends(deps.require_token),
 ) -> Dict[str, Any]:
     """Validate and apply an event to the graph."""
+    try:
+        ingest_event(req.model_dump(exclude_none=True), graph)
+    except (EventError, ProcessingError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return {"status": "ok"}
+
+
+@router.post("/store")
+def api_store_event(
+    req: EventRequest,
+    graph: IGraphAdapter = Depends(deps.get_graph),
+    _: None = Depends(deps.require_token),
+) -> Dict[str, Any]:
+    """Alias for :func:`api_post_event`."""
     try:
         ingest_event(req.model_dump(exclude_none=True), graph)
     except (EventError, ProcessingError) as exc:

--- a/src/ume/integrations/base.py
+++ b/src/ume/integrations/base.py
@@ -40,6 +40,25 @@ class BaseClient:
         except httpx.HTTPError as exc:
             raise IntegrationError(str(exc)) from exc
 
+    def store_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        """Alias for :meth:`send_events` that uses the ``/store`` endpoint."""
+        headers = self._auth_headers()
+        events_list = list(events)
+        if not events_list:
+            return
+        try:
+            if len(events_list) > 1:
+                resp = self._client.post(
+                    f"{self.base_url}/store/batch", json=events_list, headers=headers
+                )
+            else:
+                resp = self._client.post(
+                    f"{self.base_url}/store", json=events_list[0], headers=headers
+                )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise IntegrationError(str(exc)) from exc
+
     def recall(self, payload: Mapping[str, Any]) -> Any:
         headers = self._auth_headers()
         try:
@@ -85,6 +104,25 @@ class AsyncBaseClient:
             else:
                 resp = await self._client.post(
                     f"{self.base_url}/events", json=events_list[0], headers=headers
+                )
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise IntegrationError(str(exc)) from exc
+
+    async def store_events(self, events: Iterable[Mapping[str, Any]]) -> None:
+        """Alias for :meth:`send_events` that uses the ``/store`` endpoint."""
+        headers = self._auth_headers()
+        events_list = list(events)
+        if not events_list:
+            return
+        try:
+            if len(events_list) > 1:
+                resp = await self._client.post(
+                    f"{self.base_url}/store/batch", json=events_list, headers=headers
+                )
+            else:
+                resp = await self._client.post(
+                    f"{self.base_url}/store", json=events_list[0], headers=headers
                 )
             resp.raise_for_status()
         except httpx.HTTPError as exc:

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -113,3 +113,44 @@ def test_post_event_missing_field(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 400
+
+
+def test_store_event_success(client_and_graph) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+    event = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n3",
+        "payload": {"node_id": "n3", "attributes": {"text": "store"}},
+    }
+    res = client.post("/store", json=event, headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    assert g.get_node("n3") == {"text": "store"}
+
+
+def test_store_events_batch(client_and_graph) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+    events = [
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 1,
+            "node_id": "n4",
+            "payload": {"node_id": "n4", "attributes": {"text": "x"}},
+        },
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 2,
+            "node_id": "n5",
+            "payload": {"node_id": "n5", "attributes": {"text": "y"}},
+        },
+    ]
+    res = client.post(
+        "/store/batch",
+        json=events,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert g.get_node("n4") == {"text": "x"}
+    assert g.get_node("n5") == {"text": "y"}

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -84,6 +84,14 @@ def test_wrapper_batch_endpoint() -> None:
         assert batch.called
 
 
+def test_store_events_alias() -> None:
+    client = BaseClient(base_url="http://ume")
+    with respx.mock(assert_all_called=True) as mock:
+        evt = mock.post("http://ume/store").mock(return_value=httpx.Response(200))
+        client.store_events([{"foo": "bar"}])
+        assert evt.called
+
+
 def test_env_token(monkeypatch) -> None:
     monkeypatch.setenv("UME_API_TOKEN", "token")
     client = BaseClient(base_url="http://ume")

--- a/tests/test_integrations_async.py
+++ b/tests/test_integrations_async.py
@@ -110,6 +110,17 @@ def test_async_wrapper_batch_endpoint() -> None:
     asyncio.run(runner())
 
 
+def test_async_store_events_alias() -> None:
+    async def runner():
+        async with AsyncBaseClient(base_url="http://ume") as client:
+            with respx.mock(assert_all_called=True) as mock:
+                evt = mock.post("http://ume/store").mock(return_value=httpx.Response(200))
+                await client.store_events([{"foo": "bar"}])
+                assert evt.called
+
+    asyncio.run(runner())
+
+
 def test_async_env_token(monkeypatch) -> None:
     async def runner():
         monkeypatch.setenv("UME_API_TOKEN", "async-token")

--- a/tests/test_new_integrations.py
+++ b/tests/test_new_integrations.py
@@ -34,6 +34,14 @@ def test_autogen_wrapper_forwards() -> None:
         assert dict(recall.calls.last.request.url.params) == {"v": "2"}
 
 
+def test_store_events_method() -> None:
+    client = CrewAI(base_url="http://ume")
+    with respx.mock(assert_all_called=True) as mock:
+        evt = mock.post("http://ume/store").mock(return_value=httpx.Response(200))
+        client.store_events([{"foo": 3}])
+        assert evt.called
+
+
 def test_crewai_env_and_error(monkeypatch) -> None:
     monkeypatch.setenv("CREWAI_UME_API_TOKEN", "tok")
     client = CrewAI(base_url="http://ume")


### PR DESCRIPTION
## Summary
- support POST /store and /store/batch aliases in `graph_routes`
- add `store_events` helper to integration clients
- document the new alias
- test that both /events and /store work

## Testing
- `pre-commit run --files docs/API_REFERENCE.md docs/INTEGRATIONS.md src/ume/graph_routes.py src/ume/integrations/base.py tests/test_api_events.py tests/test_integrations.py tests/test_integrations_async.py tests/test_new_integrations.py`
- `poetry run pytest tests/test_api_events.py tests/test_integrations.py tests/test_integrations_async.py tests/test_new_integrations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68747d205b248326be096f440ca80d5b