### PR TITLE
Add unified graph adapter factory

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -60,6 +60,13 @@ below lists all available variables and their default values.
 | --- | --- | --- |
 | `UME_DB_PATH` | `ume_graph.db` | SQLite database used by `PersistentGraph`. |
 | `UME_GRAPH_BACKEND` | `sqlite` | Backend for graph storage (`sqlite`, `postgres`, `redis`, or `neo4j`). |
+
+Valid values for `UME_GRAPH_BACKEND` are:
+
+- `sqlite` – local SQLite database via `PersistentGraph`.
+- `postgres` – PostgreSQL backend using `PostgresGraph`.
+- `redis` – Redis-backed `RedisGraphAdapter`.
+- `neo4j` – Neo4j graph database via `Neo4jGraph`.
 | `UME_SNAPSHOT_PATH` | `ume_snapshot.json` | Path to graph snapshot file. |
 | `UME_SNAPSHOT_DIR` | `.` | Directory that snapshot APIs will accept paths from. |
 | `UME_AUDIT_LOG_PATH` | `audit.log` | Location of the audit log. |

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -83,10 +83,9 @@ from .agent_orchestrator import (
     ReflectionAgent,
 )
 from .message_bus import MessageEnvelope
+from .factories import create_graph_adapter, create_vector_store
 from .resources import (
-    create_graph_adapter,
     create_graph,
-    create_vector_store,
     graph_factory,
     vector_store_factory,
 )

--- a/src/ume/api_deps.py
+++ b/src/ume/api_deps.py
@@ -34,7 +34,7 @@ def configure_graph(graph: IGraphAdapter | None = None) -> None:
     from .api import app  # Local import to avoid circular dependency
 
     if graph is None:
-        from .resources import create_graph_adapter
+        from .factories import create_graph_adapter
 
         graph = create_graph_adapter()
 

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
 
     # UME Core
     UME_DB_PATH: str = "ume_graph.db"
-    UME_GRAPH_BACKEND: str = "sqlite"  # sqlite, postgres, or redis
+    UME_GRAPH_BACKEND: str = "sqlite"  # sqlite, postgres, redis, or neo4j
     UME_SNAPSHOT_PATH: str = "ume_snapshot.json"
     UME_SNAPSHOT_DIR: str = "."
     UME_COLD_DB_PATH: str = "ume_cold.db"

--- a/src/ume/factories.py
+++ b/src/ume/factories.py
@@ -5,6 +5,17 @@ from .persistent_graph import PersistentGraph
 from .postgres_graph import PostgresGraph
 from .redis_graph_adapter import RedisGraphAdapter
 from .rbac_adapter import RoleBasedGraphAdapter
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for optional dependency hints
+    from .neo4j_graph import Neo4jGraph
+else:  # pragma: no cover - optional dependency
+    try:
+        from .neo4j_graph import Neo4jGraph
+    except Exception:
+        class Neo4jGraph:
+            def __init__(self, *_: object, **__: object) -> None:
+                raise ImportError("neo4j is required for Neo4jGraph")
 from .vector_store import VectorBackend, create_vector_store as _create_vector_store
 from .memory import EpisodicMemory, SemanticMemory
 
@@ -24,6 +35,12 @@ def create_graph_adapter(
         base = PostgresGraph(db_path or settings.UME_DB_PATH)
     elif backend == "redis":
         base = RedisGraphAdapter(db_path or settings.UME_DB_PATH)
+    elif backend == "neo4j":
+        base = Neo4jGraph(
+            settings.NEO4J_URI,
+            settings.NEO4J_USER,
+            settings.NEO4J_PASSWORD,
+        )
     else:
         base = PersistentGraph(db_path or settings.UME_DB_PATH)
     if is_tracing_enabled():

--- a/src/ume/resources.py
+++ b/src/ume/resources.py
@@ -3,24 +3,8 @@
 
 from typing import Callable
 
-from .config import settings
 from .graph_adapter import IGraphAdapter
-from .persistent_graph import PersistentGraph
-from .postgres_graph import PostgresGraph
-from .redis_graph_adapter import RedisGraphAdapter
-from .rbac_adapter import RoleBasedGraphAdapter
-from .tracing import TracingGraphAdapter, is_tracing_enabled
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover - for type hints only
-    from .neo4j_graph import Neo4jGraph
-else:  # pragma: no cover - optional dependency
-    try:
-        from .neo4j_graph import Neo4jGraph
-    except Exception:
-        class Neo4jGraph:
-            def __init__(self, *_: object, **__: object) -> None:
-                raise ImportError("neo4j is required for Neo4jGraph")
+from .factories import create_graph_adapter as _create_base_adapter
 from .vector_store import VectorBackend, create_default_store
 
 
@@ -31,28 +15,7 @@ def create_graph_adapter(
 ) -> IGraphAdapter:
     """Instantiate the configured :class:`IGraphAdapter`."""
 
-    backend = settings.UME_GRAPH_BACKEND.lower()
-    if backend == "postgres":
-        base: IGraphAdapter = PostgresGraph(db_path or settings.UME_DB_PATH)
-    elif backend == "redis":
-        base = RedisGraphAdapter(db_path or settings.UME_DB_PATH)
-    elif backend == "neo4j":
-        base = Neo4jGraph(
-            settings.NEO4J_URI,
-            settings.NEO4J_USER,
-            settings.NEO4J_PASSWORD,
-        )
-    else:
-        base = PersistentGraph(db_path or settings.UME_DB_PATH)
-
-    if is_tracing_enabled():
-        base = TracingGraphAdapter(base)
-
-    role = role if role is not None else settings.UME_ROLE
-    if role:
-        base = RoleBasedGraphAdapter(base, role=role)
-
-    return base
+    return _create_base_adapter(db_path, role=role)
 
 
 def _default_graph_factory() -> IGraphAdapter:


### PR DESCRIPTION
## Summary
- centralize graph adapter creation in `factories.create_graph_adapter`
- re-export factory from `resources`
- use the factory in API setup
- document all available `UME_GRAPH_BACKEND` values

## Testing
- `ruff check .`
- `pytest tests/test_factories.py::test_create_graph_adapter_with_role_and_tracing -q`

------
https://chatgpt.com/codex/tasks/task_e_6877f57deaec832685d1b40d172dda6a