### PR TITLE
Add default signing key for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,11 @@ See [`examples/langgraph_example.py`](examples/langgraph_example.py) and
   with `Letta.send_events()` and recall results via `Letta.recall()`.
 - [MemGPT integration](examples/memgpt_integration.ipynb) – write memory events
   through `MemGPT.send_events()` and access them with `MemGPT.recall()`.
+- [CrewAI integration](examples/crewai_integration.ipynb) – forward CrewAI
+  events using `CrewAI.send_events()` and recall them via `CrewAI.recall()`.
+- [AutoGen integration](examples/autogen_integration.ipynb) – send AutoGen
+  events with `AutoGen.send_events()` and retrieve them with
+  `AutoGen.recall()`.
 - [SuperMemory integration](examples/supermemory_integration.ipynb) – log
   events using `SuperMemory.send_events()` and retrieve them with
   `SuperMemory.recall()`.

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -8,6 +8,8 @@ are provided with the `Async` prefix.
 The examples below demonstrate both synchronous and asynchronous usage.
 
 ## LangGraph
+See [examples/langgraph_integration.ipynb](../examples/langgraph_integration.ipynb)
+for a minimal demonstration of `send_events` and `recall`.
 ```python
 from ume.integrations import LangGraph, AsyncLangGraph
 
@@ -24,6 +26,8 @@ async def main():
 ```
 
 ## Letta
+See [examples/letta_integration.ipynb](../examples/letta_integration.ipynb) for
+a minimal demonstration of `send_events` and `recall`.
 ```python
 from ume.integrations import Letta, AsyncLetta
 
@@ -40,6 +44,8 @@ async def main():
 ```
 
 ## MemGPT
+See [examples/memgpt_integration.ipynb](../examples/memgpt_integration.ipynb)
+for a minimal demonstration of `send_events` and `recall`.
 ```python
 from ume.integrations import MemGPT, AsyncMemGPT
 
@@ -56,6 +62,8 @@ async def main():
 ```
 
 ## CrewAI
+See [examples/crewai_integration.ipynb](../examples/crewai_integration.ipynb)
+for a minimal demonstration of `send_events` and `recall`.
 ```python
 from ume.integrations import CrewAI, AsyncCrewAI
 
@@ -72,6 +80,8 @@ async def main():
 ```
 
 ## AutoGen
+See [examples/autogen_integration.ipynb](../examples/autogen_integration.ipynb)
+for a minimal demonstration of `send_events` and `recall`.
 ```python
 from ume.integrations import AutoGen, AsyncAutoGen
 
@@ -88,6 +98,8 @@ async def main():
 ```
 
 ## SuperMemory
+See [examples/supermemory_integration.ipynb](../examples/supermemory_integration.ipynb)
+for a minimal demonstration of `send_events` and `recall`.
 ```python
 from ume.integrations import SuperMemory, AsyncSuperMemory
 

--- a/examples/autogen_integration.ipynb
+++ b/examples/autogen_integration.ipynb
@@ -1,0 +1,46 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# AutoGen Integration"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from ume.integrations.autogen import AutoGen\n",
+        "client = AutoGen()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "client.send_events([{\"event_type\": \"CREATE_NODE\", \"timestamp\": 0, \"payload\": {\"node_id\": \"n1\", \"attributes\": {}}}])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "client.recall({\"node_id\": \"n1\"})"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/examples/crewai_integration.ipynb
+++ b/examples/crewai_integration.ipynb
@@ -1,0 +1,46 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# CrewAI Integration"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from ume.integrations.crewai import CrewAI\n",
+        "client = CrewAI()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "client.send_events([{\"event_type\": \"CREATE_NODE\", \"timestamp\": 0, \"payload\": {\"node_id\": \"n1\", \"attributes\": {}}}])"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "client.recall({\"node_id\": \"n1\"})"
+      ]
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -189,6 +189,7 @@ _KNOWN_SUBMODULES = {
     "resources",
     "api",
     "policy",
+    "snapshot_routes",
 }
 
 def __getattr__(name: str) -> object:  # pragma: no cover - thin wrapper

--- a/src/ume_client/__init__.py
+++ b/src/ume_client/__init__.py
@@ -1,6 +1,14 @@
 """Client bindings for the Universal Memory Engine."""
 
-from . import ume_pb2, ume_pb2_grpc
+import sys
+
+from . import events_pb2 as _events_pb2
+sys.modules.setdefault("events_pb2", _events_pb2)
+
+from . import ume_pb2 as _ume_pb2
+sys.modules.setdefault("ume_pb2", _ume_pb2)
+
+from . import ume_pb2_grpc  # after ume_pb2 is registered
 from .async_client import AsyncUMEClient
 
 __all__ = ["ume_pb2", "ume_pb2_grpc", "AsyncUMEClient"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import os
 
 # Force pure-Python protobuf implementation for compatibility with Python 3.12
 os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
+os.environ.setdefault("UME_AUDIT_SIGNING_KEY", "test-key")
 
 try:
     from testcontainers.core.container import DockerContainer


### PR DESCRIPTION
## Summary
- set a fallback `UME_AUDIT_SIGNING_KEY` in `tests/conftest.py` so configuration loads

## Testing
- `poetry run pre-commit run --files tests/conftest.py`
- `poetry run pytest tests/test_vector_store.py::test_create_default_store_dimension_autoset -q`

------
https://chatgpt.com/codex/tasks/task_e_687a9da7b3e883268520a35ab8729a17