### PR TITLE
Handle empty gRPC token

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -94,7 +94,7 @@ Valid values for `UME_GRAPH_BACKEND` are:
 | `UME_OAUTH_PASSWORD` | `password` | Password for obtaining OAuth tokens. |
 | `UME_OAUTH_ROLE` | `AnalyticsAgent` | Role assigned to issued tokens. |
 | `UME_OAUTH_TTL` | `3600` | Lifetime of issued tokens in seconds. |
-| `UME_GRPC_TOKEN` | *(unset)* | Bearer token required by the gRPC server. |
+| `UME_GRPC_TOKEN` | *(unset)* | Bearer token required by the gRPC server. If empty, the server logs a warning and rejects requests. |
 | `UME_LOG_LEVEL` | `INFO` | Logging level used by `configure_logging`. |
 | `UME_LOG_JSON` | `False` | Output logs as JSON lines when set to `True`. |
 | `UME_GRAPH_RETENTION_DAYS` | `30` | Age in days before old nodes/edges are purged. |

--- a/src/ume/grpc_server/__init__.py
+++ b/src/ume/grpc_server/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import typing
 import asyncio
 import math
+import logging
 
 import grpc
 from google.protobuf import struct_pb2, empty_pb2
@@ -47,6 +48,12 @@ class UMEServicer(ume_pb2_grpc.UMEServicer):
 
     async def _require_auth(self, context: grpc.aio.ServicerContext) -> None:
         if self.api_token is None and self.auth_callback is None:
+            return
+        if self.api_token == "":
+            logging.getLogger(__name__).warning(
+                "UME_GRPC_TOKEN is empty; rejecting unauthenticated requests"
+            )
+            await context.abort(grpc.StatusCode.UNAUTHENTICATED, "Invalid token")
             return
         metadata = {k.lower(): v for k, v in context.invocation_metadata()}
         header = metadata.get("authorization")

--- a/tests/test_grpc_auth.py
+++ b/tests/test_grpc_auth.py
@@ -22,9 +22,11 @@ class DummyStore:
     pass
 
 
-async def _run_server(port_holder: list[int], svc_holder: list[UMEServicer]):
+async def _run_server(
+    port_holder: list[int], svc_holder: list[UMEServicer], token: str | None
+):
     server = grpc.aio.server()
-    svc = UMEServicer(DummyQE(), DummyStore(), api_token="secret")
+    svc = UMEServicer(DummyQE(), DummyStore(), api_token=token)
     svc_holder.append(svc)
     ume_pb2_grpc.add_UMEServicer_to_server(svc, server)
     port_holder.append(server.add_insecure_port("localhost:0"))
@@ -35,18 +37,27 @@ async def _run_server(port_holder: list[int], svc_holder: list[UMEServicer]):
         await server.stop(None)
 
 
-async def _run_tests(port: int):
+async def _run_tests(port: int, token: str | None, expect_success: bool = True):
     channel = grpc.aio.insecure_channel(f"localhost:{port}")
     stub = ume_pb2_grpc.UMEStub(channel)
     with pytest.raises(grpc.aio.AioRpcError) as exc:
         await stub.RunCypher(ume_pb2.CypherQuery(cypher="RETURN 1"))
     assert exc.value.code() == grpc.StatusCode.UNAUTHENTICATED
 
-    res = await stub.RunCypher(
-        ume_pb2.CypherQuery(cypher="RETURN 1"),
-        metadata=[("authorization", "Bearer secret")],
-    )
-    assert len(res.records) == 0
+    if token:
+        if expect_success:
+            res = await stub.RunCypher(
+                ume_pb2.CypherQuery(cypher="RETURN 1"),
+                metadata=[("authorization", f"Bearer {token}")],
+            )
+            assert len(res.records) == 0
+        else:
+            with pytest.raises(grpc.aio.AioRpcError) as exc:
+                await stub.RunCypher(
+                    ume_pb2.CypherQuery(cypher="RETURN 1"),
+                    metadata=[("authorization", f"Bearer {token}")],
+                )
+            assert exc.value.code() == grpc.StatusCode.UNAUTHENTICATED
     await channel.close()
 
 
@@ -55,10 +66,28 @@ def test_grpc_authentication():
     svcs: list[UMEServicer] = []
 
     async def runner():
-        task = asyncio.create_task(_run_server(ports, svcs))
+        task = asyncio.create_task(_run_server(ports, svcs, "secret"))
         while not ports:
             await asyncio.sleep(0.01)
-        await _run_tests(ports[0])
+        await _run_tests(ports[0], "secret")
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(runner())
+
+
+def test_grpc_authentication_no_token():
+    ports: list[int] = []
+    svcs: list[UMEServicer] = []
+
+    async def runner():
+        task = asyncio.create_task(_run_server(ports, svcs, ""))
+        while not ports:
+            await asyncio.sleep(0.01)
+        await _run_tests(ports[0], "secret", expect_success=False)
         task.cancel()
         try:
             await task


### PR DESCRIPTION
## Summary
- warn when `UME_GRPC_TOKEN` is empty
- expect 401 when no gRPC token configured
- note empty token behavior in config docs

## Testing
- `pytest tests/test_grpc_auth.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2366f3c08326a3606321cd330040