### PR TITLE
Add ledger compaction scheduler

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 172
+        "line_number": 179
       }
     ],
     "tests/test_anonymizer.py": [
@@ -146,5 +146,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-09T13:34:16Z"
+  "generated_at": "2025-07-20T17:49:44Z"
 }

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -97,6 +97,11 @@ adapter layer.
 Sanitized events are appended to a lightweight ledger along with their
 Redpanda offsets. The ledger can be queried via the `/ledger/events` API and
 used with `ume.replay.replay_from_ledger()` to rebuild state from any offset.
+On startup the API launches a scheduler that periodically calls
+`event_ledger.compact()` to remove entries older than
+`UME_LEDGER_OFFSET_WINDOW` offsets from the latest processed bookmark. The
+interval between compaction runs is configurable via
+`UME_LEDGER_COMPACTION_INTERVAL`.
 
 ## Policy DSL Flow
 

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -29,7 +29,12 @@ from .auto_snapshot import (
     disable_periodic_snapshot,
     enable_snapshot_autosave_and_restore,
 )
-from .retention import start_retention_scheduler, stop_retention_scheduler
+from .retention import (
+    start_retention_scheduler,
+    stop_retention_scheduler,
+    start_ledger_compaction_scheduler,
+    stop_ledger_compaction_scheduler,
+)
 from .memory_aging import (
     start_memory_aging_scheduler,
     stop_memory_aging_scheduler,
@@ -131,6 +136,8 @@ __all__ = [
     "stop_memory_aging_scheduler",
     "start_vector_age_scheduler",
     "stop_vector_age_scheduler",
+    "start_ledger_compaction_scheduler",
+    "stop_ledger_compaction_scheduler",
     "validate_event_dict",
     "GraphSchema",
     "load_default_schema",

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -27,6 +27,10 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
 
 from .metrics import REQUEST_COUNT, REQUEST_LATENCY
+from .retention import (
+    start_ledger_compaction_scheduler,
+    stop_ledger_compaction_scheduler,
+)
 
 from .rbac_adapter import AccessDeniedError
 from .graph_adapter import IGraphAdapter  # noqa: F401
@@ -57,6 +61,7 @@ configure_vector_store = api_deps.configure_vector_store  # noqa: F401 re-export
 TOKEN_CLEANUP_INTERVAL = 60.0
 
 _token_cleanup_task: asyncio.Task | None = None
+_ledger_compaction_stop: Callable[[], None] | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -140,9 +145,18 @@ async def _token_cleanup_loop(interval: float) -> None:
 @app.on_event("startup")
 async def _start_token_cleanup() -> None:
     """Launch background task for expired token cleanup."""
-    global _token_cleanup_task
+    from .event_ledger import event_ledger
+
+    global _token_cleanup_task, _ledger_compaction_stop
     interval = min(TOKEN_CLEANUP_INTERVAL, settings.UME_OAUTH_TTL)
     _token_cleanup_task = asyncio.create_task(_token_cleanup_loop(interval))
+
+    _, stop = start_ledger_compaction_scheduler(
+        event_ledger,
+        interval_seconds=settings.UME_LEDGER_COMPACTION_INTERVAL,
+        offset_window=settings.UME_LEDGER_OFFSET_WINDOW,
+    )
+    _ledger_compaction_stop = stop
 
 
 @app.on_event("shutdown")
@@ -156,7 +170,7 @@ def _close_vector_store() -> None:
 @app.on_event("shutdown")
 async def _stop_token_cleanup() -> None:
     """Cancel the background token cleanup task if running."""
-    global _token_cleanup_task
+    global _token_cleanup_task, _ledger_compaction_stop
     if _token_cleanup_task is not None:
         _token_cleanup_task.cancel()
         try:
@@ -164,6 +178,9 @@ async def _stop_token_cleanup() -> None:
         except Exception:
             pass
         _token_cleanup_task = None
+    if _ledger_compaction_stop is not None:
+        stop_ledger_compaction_scheduler()
+        _ledger_compaction_stop = None
 
 
 @app.middleware("http")

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -34,6 +34,8 @@ class Settings(BaseSettings):  # type: ignore[misc]
     UME_LOG_LEVEL: str = "INFO"
     UME_LOG_JSON: bool = False
     UME_GRAPH_RETENTION_DAYS: int = 30
+    UME_LEDGER_OFFSET_WINDOW: int = 1000
+    UME_LEDGER_COMPACTION_INTERVAL: float = 24 * 3600
     UME_RELIABILITY_THRESHOLD: float = 0.5
     WATCH_PATHS: list[str] = ["."]
     DAG_RESOURCES: dict[str, int] = {"cpu": 1, "io": 1}

--- a/src/ume/retention.py
+++ b/src/ume/retention.py
@@ -17,6 +17,10 @@ _vector_thread: threading.Thread | None = None
 _vector_stop: threading.Event | None = None
 _vector_params: tuple[Any, ...] | None = None
 
+_ledger_thread: threading.Thread | None = None
+_ledger_stop: threading.Event | None = None
+_ledger_params: tuple[Any, ...] | None = None
+
 
 class _SupportsPurge(Protocol):
     """Graph-like object able to purge old records."""
@@ -150,3 +154,65 @@ def stop_vector_age_scheduler() -> None:
     _vector_thread = None
     _vector_stop = None
     _vector_params = None
+
+
+def start_ledger_compaction_scheduler(
+    ledger: Any,
+    *,
+    interval_seconds: float = 24 * 3600,
+    offset_window: int = settings.UME_LEDGER_OFFSET_WINDOW,
+) -> tuple[threading.Thread, Callable[[], None]]:
+    """Compact the event ledger periodically in a background thread."""
+
+    global _ledger_thread, _ledger_stop, _ledger_params
+
+    params = (ledger, interval_seconds, offset_window)
+
+    if _ledger_thread and _ledger_thread.is_alive():
+        if params == _ledger_params:
+            return _ledger_thread, lambda: None
+        stop_ledger_compaction_scheduler()
+
+    stop_event = threading.Event()
+
+    def _run() -> None:
+        def _compact() -> None:
+            cutoff = ledger.last_processed_offset - offset_window
+            ledger.compact(cutoff)
+
+        try:
+            _compact()
+        except Exception:  # pragma: no cover - log and continue
+            logger.exception("Failed to compact event ledger")
+
+        while not stop_event.wait(interval_seconds):
+            try:
+                _compact()
+            except Exception:  # pragma: no cover - log and continue
+                logger.exception("Failed to compact event ledger")
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    _ledger_thread = thread
+    _ledger_stop = stop_event
+    _ledger_params = params
+
+    def stop() -> None:
+        stop_event.set()
+        thread.join()
+
+    return thread, stop
+
+
+def stop_ledger_compaction_scheduler() -> None:
+    """Stop the ledger compaction scheduler if running."""
+
+    global _ledger_thread, _ledger_stop, _ledger_params
+    if _ledger_stop is not None:
+        _ledger_stop.set()
+    if _ledger_thread is not None:
+        _ledger_thread.join()
+    _ledger_thread = None
+    _ledger_stop = None
+    _ledger_params = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,9 @@ if importlib.util.find_spec("prometheus_client") is None:
     sys.modules.setdefault("prometheus_client", prom_stub)
 
 if importlib.util.find_spec("numpy") is None:
-    sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+    numpy_stub = types.ModuleType("numpy")
+    numpy_stub.asarray = lambda x, dtype=None: list(x)
+    sys.modules.setdefault("numpy", numpy_stub)
 
 jsonschema_stub = types.ModuleType("jsonschema")
 class _ValidationError(Exception):
@@ -97,6 +99,11 @@ _OPTIONAL_PACKAGES = [
     "structlog",
     "neo4j",
     "faiss",
+    "fastapi_limiter",
+    "sse_starlette",
+    "networkx",
+    "grpc",
+    "aiosqlite",
 ]
 
 for _package in _OPTIONAL_PACKAGES:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,6 +4,7 @@ import pytest
 from typing import Any
 import time
 import threading
+from pathlib import Path
 
 faiss = pytest.importorskip("faiss")
 if not hasattr(faiss, "IndexFlatL2"):
@@ -305,6 +306,25 @@ def test_token_cleanup_task(monkeypatch: MonkeyPatch) -> None:
         assert token in deps.TOKENS
         time.sleep(0.05)
         assert token not in deps.TOKENS
+
+
+def test_api_ledger_compaction(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    from ume.event_ledger import EventLedger
+
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    for i in range(5):
+        ledger.append(i, {"event_type": "E", "timestamp": i})
+    ledger.update_bookmark(4)
+
+    monkeypatch.setattr("ume.event_ledger.event_ledger", ledger)
+    monkeypatch.setattr(settings, "UME_LEDGER_OFFSET_WINDOW", 2)
+    monkeypatch.setattr(settings, "UME_LEDGER_COMPACTION_INTERVAL", 0.01)
+
+    with TestClient(app) as client:
+        _token(client)
+        time.sleep(0.05)
+
+    assert [o for o, _ in ledger.range()] == [2, 3, 4]
 
 
 def test_issue_tokens_concurrently() -> None:

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -27,6 +27,8 @@ from ume.retention import (
     stop_retention_scheduler,
     start_vector_age_scheduler,
     stop_vector_age_scheduler,
+    start_ledger_compaction_scheduler,
+    stop_ledger_compaction_scheduler,
     _check_stale_vectors,
 )
 import ume.retention as retention
@@ -201,3 +203,23 @@ def test_vector_age_scheduler_reuses_thread(monkeypatch: pytest.MonkeyPatch) -> 
     stop1()
     stop_vector_age_scheduler()
     assert thread1 is thread2
+
+
+def test_ledger_compaction_scheduler(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from ume.event_ledger import EventLedger
+
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    for i in range(5):
+        ledger.append(i, {"event_type": "E", "timestamp": i})
+    ledger.update_bookmark(4)
+
+    monkeypatch.setattr(settings, "UME_LEDGER_OFFSET_WINDOW", 2)
+
+    thread, stop = start_ledger_compaction_scheduler(
+        ledger, interval_seconds=0.01, offset_window=2
+    )
+    time.sleep(0.02)
+    stop()
+    stop_ledger_compaction_scheduler()
+
+    assert [o for o, _ in ledger.range()] == [2, 3, 4]


### PR DESCRIPTION
## Summary
- implement a scheduler that periodically compacts the event ledger
- launch the compaction scheduler when the API starts
- expose interval and offset settings via `Settings`
- document ledger compaction
- stub optional packages in tests so unit tests run without extra dependencies

## Testing
- `pre-commit run --files src/ume/retention.py src/ume/api.py src/ume/config/__init__.py src/ume/__init__.py tests/test_api.py tests/test_retention.py docs/ARCHITECTURE_OVERVIEW.md tests/conftest.py`
- `pytest tests/test_retention.py::test_ledger_compaction_scheduler tests/test_api.py::test_api_ledger_compaction -q`

------
https://chatgpt.com/codex/tasks/task_e_687d236766e88326928480ec316fb3fd