### PR TITLE
Document vector backend entry points

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -114,3 +114,57 @@ async def main():
         await client.send_events([{"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1"}])
         print(await client.recall({"node_id": "n1"}))
 ```
+
+## Custom Vector Backends
+
+Third-party packages can provide additional vector store implementations. A
+backend must implement the `ume.vector_store.VectorBackend` interface and
+register itself using `ume.vector_backends.register_backend` or via the
+`ume.vector_backends` entry point group. The
+`examples/vector_backend_plugin.py` file demonstrates a minimal in-memory
+backend:
+
+```python
+from ume.vector_store import VectorBackend
+from ume.vector_backends import register_backend
+
+class MemoryBackend(VectorBackend):
+    def __init__(self, dim: int, **_):
+        self.dim = dim
+        self.vectors: dict[str, list[float]] = {}
+
+    def add(self, item_id: str, vector: list[float], *, persist: bool = False) -> None:
+        self.vectors[item_id] = list(vector)
+
+    def add_many(self, vectors: dict[str, list[float]], *, persist: bool = False) -> None:
+        for vid, vec in vectors.items():
+            self.add(vid, vec)
+
+    def delete(self, item_id: str) -> None:
+        self.vectors.pop(item_id, None)
+
+    def query(self, vector: list[float], k: int = 5) -> list[str]:
+        import numpy as np
+        if not self.vectors:
+            return []
+        arr = np.asarray([self.vectors[i] for i in self.vectors], dtype="float32")
+        q = np.asarray(vector, dtype="float32")
+        dists = np.linalg.norm(arr - q, axis=1)
+        ids = list(self.vectors)
+        idxs = np.argsort(dists)[:k]
+        return [ids[i] for i in idxs]
+
+    # save/load omitted for brevity
+
+register_backend("memory", MemoryBackend)
+```
+
+Expose the backend automatically by declaring an entry point in your package:
+
+```toml
+[project.entry-points."ume.vector_backends"]
+memory = "yourpkg.memory_backend:MemoryBackend"
+```
+
+Setting `UME_VECTOR_BACKEND=memory` will then use the plugin when creating a
+vector store.

--- a/examples/vector_backend_plugin.py
+++ b/examples/vector_backend_plugin.py
@@ -9,7 +9,7 @@ from ume.vector_backends import register_backend
 from ume.vector_store import VectorBackend
 
 
-class MemoryBackend(VectorBackend):
+class MemoryBackend(VectorBackend):  # type: ignore[misc]
     """Naive in-memory backend demonstrating the plugin API."""
 
     def __init__(self, dim: int, **_: object) -> None:

--- a/tests/test_vector_backend_plugins.py
+++ b/tests/test_vector_backend_plugins.py
@@ -44,3 +44,28 @@ def test_entrypoint_registration(monkeypatch):
 
     assert "dummy" in available_backends()
     assert get_backend("dummy") is DummyBackend
+
+
+def test_backend_loaded_on_import(monkeypatch):
+    module = types.ModuleType("dummy_mod")
+    module.DummyBackend = DummyBackend
+    monkeypatch.setitem(importlib.sys.modules, "dummy_mod", module)
+
+    ep = metadata.EntryPoint(
+        name="dummy_imp",
+        value="dummy_mod:DummyBackend",
+        group="ume.vector_backends",
+    )
+    monkeypatch.setattr(
+        metadata,
+        "entry_points",
+        lambda group=None: (ep,) if group == "ume.vector_backends" else (),
+    )
+
+    import sys
+
+    sys.modules.pop("ume.vector_backends", None)
+    reloaded = importlib.import_module("ume.vector_backends")
+
+    assert "dummy_imp" in reloaded.available_backends()
+    assert reloaded.get_backend("dummy_imp") is DummyBackend


### PR DESCRIPTION
## Summary
- document plugin interface and entrypoint group
- provide a skeleton vector backend example
- test that entrypoints load during import

## Testing
- `ruff check examples/vector_backend_plugin.py tests/test_vector_backend_plugins.py`
- `PYTHONPATH=src mypy examples/vector_backend_plugin.py tests/test_vector_backend_plugins.py`
- `pytest tests/test_vector_backend_plugins.py::test_entrypoint_registration tests/test_vector_backend_plugins.py::test_backend_loaded_on_import -q`

------
https://chatgpt.com/codex/tasks/task_e_687d2aec89e883269e239274e6a67645