### PR TITLE
Add graph visualization route

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -149,3 +149,16 @@ The web dashboard now includes a view showing the overseer's recommended
 actions. Data is fetched from the `/recommendations` endpoint and each
 item can be accepted or rejected. User feedback is stored for future
 analysis and helps refine subsequent suggestions.
+
+## Graph Viewer
+
+The `/graph` page visualizes the current knowledge graph. The React component
+fetches data from `/graph/dump` and renders it using `vis-network`.
+
+```javascript
+fetch('/graph/dump', { headers: { Authorization: 'Bearer TOKEN' } })
+  .then((r) => r.json())
+  .then((data) => {
+    // pass data.nodes and data.edges to vis-network
+  });
+```

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -7,7 +7,9 @@ import uvicorn
 
 def create_app(directory: str) -> FastAPI:
     app = FastAPI()
-    app.mount("/dashboard", StaticFiles(directory=directory, html=True), name="dashboard")
+    static = StaticFiles(directory=directory, html=True)
+    app.mount("/dashboard", static, name="dashboard")
+    app.mount("/graph", static, name="graph")
     return app
 
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,9 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
+    "vis-network": "^9.1.2"
   },
   "devDependencies": {
     "vite": "^5.2.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react';
+import { BrowserRouter, Routes, Route, Link } from 'react-router-dom';
 import PiiStatus from './PiiStatus';
 import PolicyEditor from './PolicyEditor';
 import Recommendations from './Recommendations';
 import ConsentLedger from './ConsentLedger';
 import Recall from './Recall';
 import GraphView from './GraphView';
+import GraphNetwork from './GraphNetwork';
 import NodeSearch from './NodeSearch';
 import EdgeList from './EdgeList';
 import LedgerHistory from './LedgerHistory';
@@ -120,25 +122,7 @@ function App() {
     setEditingPolicy(name);
   };
 
-  if (!token) {
-    return (
-      <form onSubmit={login} style={{ padding: '20px' }}>
-        <input placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
-        <input
-          placeholder="Password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          style={{ marginLeft: '4px' }}
-        />
-        <button type="submit" style={{ marginLeft: '4px' }}>
-          Login
-        </button>
-      </form>
-    );
-  }
-
-  return (
+  const Dashboard = () => (
     <div style={{ padding: '20px', fontFamily: 'sans-serif' }}>
       <button onClick={loadStats}>Refresh Stats</button>
       <button onClick={loadEvents} style={{ marginLeft: '4px' }}>
@@ -180,6 +164,39 @@ function App() {
       </ul>
       <PolicyEditor token={token} policy={editingPolicy} onSaved={loadPolicies} />
     </div>
+  );
+
+  if (!token) {
+    return (
+      <form onSubmit={login} style={{ padding: '20px' }}>
+        <input placeholder="Username" value={username} onChange={(e) => setUsername(e.target.value)} />
+        <input
+          placeholder="Password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          style={{ marginLeft: '4px' }}
+        />
+        <button type="submit" style={{ marginLeft: '4px' }}>
+          Login
+        </button>
+      </form>
+    );
+  }
+
+  return (
+    <BrowserRouter>
+      <nav style={{ padding: '8px' }}>
+        <Link to="/">Dashboard</Link>
+        <Link to="/graph" style={{ marginLeft: '8px' }}>
+          Graph
+        </Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/graph" element={<GraphNetwork token={token} />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/src/GraphNetwork.jsx
+++ b/frontend/src/GraphNetwork.jsx
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react';
+import { Network } from 'vis-network/standalone';
+
+export default function GraphNetwork({ token }) {
+  const container = useRef(null);
+
+  useEffect(() => {
+    if (!token) return;
+    const load = async () => {
+      const res = await fetch('/graph/dump', {
+        headers: { Authorization: 'Bearer ' + token },
+      });
+      if (!res.ok) return;
+      const data = await res.json();
+      const nodes = Object.keys(data.nodes).map((id) => ({ id, label: id }));
+      const edges = data.edges.map(([from, to, label]) => ({ from, to, label }));
+      new Network(container.current, { nodes, edges }, {});
+    };
+    load();
+  }, [token]);
+
+  if (!token) return null;
+  return (
+    <div style={{ marginTop: '8px' }}>
+      <div ref={container} style={{ height: '400px' }}></div>
+    </div>
+  );
+}

--- a/frontend/src/GraphNetwork.test.jsx
+++ b/frontend/src/GraphNetwork.test.jsx
@@ -1,0 +1,27 @@
+import { render, waitFor, cleanup } from '@testing-library/react';
+import { vi, describe, it, expect, afterEach } from 'vitest';
+import GraphNetwork from './GraphNetwork';
+import { Network } from 'vis-network/standalone';
+
+vi.mock('vis-network/standalone', () => ({ Network: vi.fn() }));
+
+function mockFetch(response) {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(response) })
+  );
+}
+
+describe('GraphNetwork', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('fetches graph dump and renders network', async () => {
+    const data = { nodes: { n1: {} }, edges: [['n1', 'n2', 'e']] };
+    mockFetch(data);
+    render(<GraphNetwork token="t" />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(Network).toHaveBeenCalled();
+  });
+});

--- a/src/ume_client/__init__.py
+++ b/src/ume_client/__init__.py
@@ -3,12 +3,11 @@
 import sys
 
 from . import events_pb2 as _events_pb2
-sys.modules.setdefault("events_pb2", _events_pb2)
-
 from . import ume_pb2 as _ume_pb2
-sys.modules.setdefault("ume_pb2", _ume_pb2)
-
 from . import ume_pb2_grpc  # after ume_pb2 is registered
 from .async_client import AsyncUMEClient
+
+sys.modules.setdefault("events_pb2", _events_pb2)
+sys.modules.setdefault("ume_pb2", _ume_pb2)
 
 __all__ = ["ume_pb2", "ume_pb2_grpc", "AsyncUMEClient"]


### PR DESCRIPTION
## Summary
- create a GraphNetwork component using vis-network
- mount a new `/graph` static route in the dashboard server
- route the React app with `react-router-dom`
- document the new `/graph` page
- fix import order causing ruff E402

## Testing
- `npm test --silent -- --run`
- `poetry run ruff check .`
- `poetry run pytest tests/test_graph.py::test_dump_structure -q`


------
https://chatgpt.com/codex/tasks/task_e_687d3159a3e883269de5733c8cca327b