### PR TITLE
Add frontend GraphExplorer tests & integrate vitest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,11 @@ jobs:
           npm ci
           npm run build
 
+      - name: Run frontend tests
+        if: steps.changes.outputs.run == 'true'
+        working-directory: frontend
+        run: npm test
+
   unit-tests:
     runs-on: ubuntu-latest
     needs: lint-and-install

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/frontend/src/GraphExplorer.jsx
+++ b/frontend/src/GraphExplorer.jsx
@@ -1,0 +1,13 @@
+import NodeSearch from './NodeSearch';
+import GraphView from './GraphView';
+
+export default function GraphExplorer({ token }) {
+  if (!token) return null;
+  return (
+    <div style={{ marginTop: '8px' }}>
+      <h3>Graph Explorer</h3>
+      <NodeSearch token={token} />
+      <GraphView token={token} />
+    </div>
+  );
+}

--- a/frontend/src/GraphExplorer.test.jsx
+++ b/frontend/src/GraphExplorer.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import GraphExplorer from './GraphExplorer';
+
+function mockFetch() {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ nodes: {}, edges: [] }) })
+  );
+}
+
+describe('GraphExplorer', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders subcomponents', () => {
+    mockFetch();
+    render(<GraphExplorer token="t" />);
+    expect(screen.getByText('Graph Explorer')).toBeInTheDocument();
+    expect(screen.getByText('Node Search')).toBeInTheDocument();
+    expect(screen.getByText('Graph')).toBeInTheDocument();
+  });
+
+  it('returns null without token', () => {
+    const { container } = render(<GraphExplorer token="" />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: './vitest.setup.js',
+    globals: true,
   },
 });

--- a/src/ume/bootstrap/config.py
+++ b/src/ume/bootstrap/config.py
@@ -40,6 +40,7 @@ def load_config(package: str) -> tuple[types.ModuleType, type]:
             UME_LOG_JSON=False,
             UME_GRAPH_RETENTION_DAYS=30,
             UME_RELIABILITY_THRESHOLD=0.5,
+            UME_LEDGER_OFFSET_WINDOW=1000,
             WATCH_PATHS=["."],
             DAG_RESOURCES={"cpu": 1, "io": 1},
             UME_VALUE_STORE_PATH=None,


### PR DESCRIPTION
## Summary
- configure vitest to use globals
- change npm test script to use `vitest run`
- add GraphExplorer component and tests
- run frontend tests in CI
- fix Python tests by defining `UME_LEDGER_OFFSET_WINDOW` in stub settings

## Testing
- `poetry run pre-commit run --files src/ume/bootstrap/config.py frontend/src/GraphExplorer.jsx frontend/src/GraphExplorer.test.jsx frontend/vitest.config.js frontend/package.json .github/workflows/ci.yml`
- `poetry run pytest tests/test_vector_store.py::test_create_default_store_dimension_mismatch tests/test_vector_store.py::test_create_default_store_dimension_autoset tests/test_vector_store_unit.py::test_create_default_store_selects_backend tests/integration/test_integration_clients.py::test_integration_clients -q`


------
https://chatgpt.com/codex/tasks/task_e_687d315cb81483269800801f50b37a70