### PR TITLE
Expose quickstart helper and type optional UMEClient

### DIFF
--- a/src/ume/__main__.py
+++ b/src/ume/__main__.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 import argparse
 
-from ume_cli import _quickstart
+from ume_cli import quickstart
+
+_quickstart = quickstart
 
 
 def main() -> None:

--- a/src/ume/angel_bridge.py
+++ b/src/ume/angel_bridge.py
@@ -3,17 +3,24 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Iterable, Dict, Any, List
+from .event_ledger import event_ledger
+from .config import settings
+from typing import Iterable, Dict, Any, List, Optional, TYPE_CHECKING
+import importlib
 import logging
 import time
 
-try:  # Optional Kafka dependency
-    from .client import UMEClient
-except Exception:  # pragma: no cover - confluent_kafka may be missing
-    UMEClient = None
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .client import UMEClient as UMEClientType  # noqa: F401
 
-from .event_ledger import event_ledger
-from .config import settings
+try:  # Optional Kafka dependency
+    _module = importlib.import_module("ume.client")
+    _UMEClientAny = getattr(_module, "UMEClient")
+except Exception:  # pragma: no cover - confluent_kafka may be missing
+    _UMEClientAny = None
+
+UMEClient: Optional[type[UMEClientType]]
+UMEClient = _UMEClientAny
 
 logger = logging.getLogger(__name__)
 

--- a/src/ume/vector_backends/__init__.py
+++ b/src/ume/vector_backends/__init__.py
@@ -11,6 +11,7 @@ import threading
 from importlib import metadata
 
 import numpy as np
+from numpy.typing import NDArray
 
 from ..config import settings
 from prometheus_client import Gauge, Histogram
@@ -352,7 +353,7 @@ class ChromaBackend(VectorBackend):
             if dirpath:
                 os.makedirs(dirpath, exist_ok=True)
         self.dim = dim
-        self.vectors: list[np.ndarray] = []
+        self.vectors: list[NDArray[np.float64]] = []
         self.id_to_idx: dict[str, int] = {}
         self.idx_to_id: list[str] = []
         self.vector_ts: dict[str, int] = {}

--- a/src/ume/vector_store.py
+++ b/src/ume/vector_store.py
@@ -102,17 +102,22 @@ class VectorStoreListener(GraphListener):
 
 def create_default_store() -> VectorBackend:  # pragma: no cover - trivial wrapper
     """Instantiate a vector store using ``ume.config.settings``."""
-    backend_name = settings.UME_VECTOR_BACKEND.lower()
+    import os
+    from .config import settings as cfg_settings
+
+    backend_name = os.getenv("UME_VECTOR_BACKEND", cfg_settings.UME_VECTOR_BACKEND).lower()
     cls = get_backend(backend_name)
     import inspect
 
     kwargs: Dict[str, Any] = {}
     if "use_gpu" in inspect.signature(cls).parameters:
-        kwargs["use_gpu"] = settings.UME_VECTOR_USE_GPU
-    dim = _resolve_vector_dim(settings.UME_VECTOR_DIM)
+        kwargs["use_gpu"] = cfg_settings.UME_VECTOR_USE_GPU
+    env_dim = os.getenv("UME_VECTOR_DIM")
+    dim_setting = int(env_dim) if env_dim is not None else cfg_settings.UME_VECTOR_DIM
+    dim = _resolve_vector_dim(dim_setting)
     return cls(
         dim=dim,
-        path=settings.UME_VECTOR_INDEX,
+        path=cfg_settings.UME_VECTOR_INDEX,
         query_latency_metric=VECTOR_QUERY_LATENCY,
         index_size_metric=VECTOR_INDEX_SIZE,
         **kwargs,

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -20,6 +20,8 @@ from ume.cli.compose import (
     _compose_ps,
     _quickstart,
 )
+
+quickstart = _quickstart
 from ume.cli.prompt import UMEPrompt, create_graph_adapter
 
 # Detect if a lightweight stub was injected for testing.
@@ -149,6 +151,9 @@ def _setup_warnings(display: bool, log_file: str | None) -> None:
             )
 
     warnings.showwarning = custom_showwarning
+
+
+__all__ = ["quickstart", "main"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- declare optional `UMEClient` class in `angel_bridge`
- re-export `quickstart` in `ume_cli` and call it from `ume.__main__`
- refine vector backend types and read vector config from env vars
- fix dynamic import path for `UMEClient`
- import settings dynamically when creating a default store

## Testing
- `ruff check .`
- `mypy`
- `pytest tests/test_vector_store.py::test_create_default_store_dimension_mismatch -q`
- `pytest tests/integration/test_integration_clients.py tests/test_grpc_snapshot.py tests/test_vector_store.py tests/test_vector_store_unit.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687d3fdcf88c8326ab77b3067686096d