### PR TITLE
Fix bookmark validation

### DIFF
--- a/src/ume/event_ledger.py
+++ b/src/ume/event_ledger.py
@@ -88,6 +88,8 @@ class EventLedger:
         return self._last_processed_offset
 
     def update_bookmark(self, offset: int) -> None:
+        if offset < 0:
+            raise ValueError("offset must be non-negative")
         with self.conn:
             self.conn.execute(
                 "INSERT INTO bookmark(id, last_offset) VALUES(0, ?) "

--- a/src/ume/grpc_server/__init__.py
+++ b/src/ume/grpc_server/__init__.py
@@ -217,7 +217,10 @@ class UMEServicer(ume_pb2_grpc.UMEServicer):
         self, request: ume_pb2.Bookmark, context: grpc.aio.ServicerContext
     ) -> ume_pb2.Bookmark:
         await self._require_auth(context)
-        event_ledger.update_bookmark(request.offset)
+        try:
+            event_ledger.update_bookmark(request.offset)
+        except ValueError as exc:
+            await context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(exc))
         return ume_pb2.Bookmark(offset=request.offset)
 
 

--- a/src/ume/ledger_routes.py
+++ b/src/ume/ledger_routes.py
@@ -89,6 +89,8 @@ def set_bookmark(
     bookmark: Bookmark, _: str = Depends(deps.get_current_role)
 ) -> Bookmark:
     """Persist ``bookmark`` as the last processed offset."""
-
-    event_ledger.update_bookmark(bookmark.offset)
+    try:
+        event_ledger.update_bookmark(bookmark.offset)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return bookmark

--- a/tests/test_event_ledger.py
+++ b/tests/test_event_ledger.py
@@ -71,3 +71,9 @@ def test_replay_from_timestamp(tmp_path):
     assert set(g2.get_all_node_ids()) == {"n0", "n1", "n2", "n3", "n4"}
 
     ledger.close()
+
+
+def test_update_bookmark_invalid(tmp_path):
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    with pytest.raises(ValueError):
+        ledger.update_bookmark(-1)

--- a/tests/test_grpc_snapshot.py
+++ b/tests/test_grpc_snapshot.py
@@ -190,3 +190,37 @@ def test_grpc_bookmark_persistence(tmp_path: pathlib.Path, monkeypatch) -> None:
     replay_from_ledger(g, ledger2, start_offset=ledger2.last_processed_offset + 1)
     assert set(g.get_all_node_ids()) == {"n2"}
 
+
+def test_grpc_bookmark_invalid(tmp_path: pathlib.Path, monkeypatch) -> None:
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    monkeypatch.setattr("ume.grpc_server.event_ledger", ledger)
+
+    async def _run_server(port_holder: list[int]) -> None:
+        server = grpc.aio.server()
+        svc = UMEServicer(DummyQE(), DummyStore())
+        ume_pb2_grpc.add_UMEServicer_to_server(svc, server)
+        port_holder.append(server.add_insecure_port("localhost:0"))
+        await server.start()
+        await server.wait_for_termination()
+
+    async def _set_bad(port: int) -> None:
+        async with AsyncUMEClient(f"localhost:{port}") as client:
+            with pytest.raises(grpc.aio.AioRpcError) as exc:
+                await client.set_bookmark(-1)
+            assert exc.value.code() == grpc.StatusCode.INVALID_ARGUMENT
+
+    ports: list[int] = []
+
+    async def runner() -> None:
+        server_task = asyncio.create_task(_run_server(ports))
+        while not ports:
+            await asyncio.sleep(0.01)
+        await _set_bad(ports[0])
+        server_task.cancel()
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(runner())
+


### PR DESCRIPTION
## Summary
- validate offsets are non-negative when setting bookmarks
- handle invalid bookmark offsets in gRPC and HTTP APIs
- add regression tests for negative bookmark values

## Testing
- `poetry run ruff check .`
- `poetry run pytest tests/integration/test_integration_clients.py tests/test_grpc_snapshot.py tests/test_vector_store.py tests/test_event_ledger.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687e49df178c832685bfc0471eadbede