### PR TITLE
Add ledger and snapshot tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,8 @@ source =
     ume.grpc_server
     ume.dag_executor
     ume.vector_store
+    ume.snapshot
+    ume.event_ledger
 omit =
     */proto/*
     */tests/*
@@ -13,6 +15,8 @@ include =
     ume.grpc_server
     ume.dag_executor
     ume.vector_store
+    ume.snapshot
+    ume.event_ledger
 
 [html]
 directory = coverage_html

--- a/tests/test_event_ledger.py
+++ b/tests/test_event_ledger.py
@@ -77,3 +77,29 @@ def test_update_bookmark_invalid(tmp_path):
     ledger = EventLedger(str(tmp_path / "ledger.db"))
     with pytest.raises(ValueError):
         ledger.update_bookmark(-1)
+
+
+def test_compact_removes_old_events(tmp_path):
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    for i in range(5):
+        ledger.append(i, {"val": i})
+
+    ledger.compact(3)
+
+    remaining = ledger.range()
+    assert [off for off, _ in remaining] == [3, 4]
+
+
+def test_bookmark_persists_between_instances(tmp_path):
+    path = str(tmp_path / "ledger.db")
+    ledger = EventLedger(path)
+    ledger.update_bookmark(2)
+    ledger.close()
+
+    ledger2 = EventLedger(path)
+    assert ledger2.last_processed_offset == 2
+    ledger2.update_bookmark(4)
+    ledger2.close()
+
+    ledger3 = EventLedger(path)
+    assert ledger3.last_processed_offset == 4

--- a/tests/test_snapshot_backends.py
+++ b/tests/test_snapshot_backends.py
@@ -1,0 +1,52 @@
+import pathlib
+from typing import Optional
+import pytest
+
+from ume.snapshot import snapshot_graph_to_file, load_graph_into_existing
+from ume.persistent_graph import PersistentGraph
+from ume.postgres_graph import PostgresGraph
+from ume.redis_graph_adapter import RedisGraphAdapter
+
+
+@pytest.mark.parametrize(
+    "backend,service",
+    [
+        ("sqlite", None),
+        ("postgres", "postgres_service"),
+        ("redis", "redis_service"),
+    ],
+)
+def test_snapshot_roundtrip_all_backends(
+    tmp_path: pathlib.Path,
+    backend: str,
+    service: Optional[str],
+    request: pytest.FixtureRequest,
+) -> None:
+    if service:
+        info = request.getfixturevalue(service)
+        db_path = info["dsn"] if backend == "postgres" else info["url"]
+    else:
+        db_path = str(tmp_path / "graph.db")
+
+    if backend == "sqlite":
+        graph = PersistentGraph(db_path, check_same_thread=False)
+    elif backend == "postgres":
+        graph = PostgresGraph(db_path)
+    else:
+        graph = RedisGraphAdapter(db_path)
+
+    graph.add_node("a", {"val": 1})
+    graph.add_node("b", {"val": 2})
+    graph.add_edge("a", "b", "L")
+
+    snap = tmp_path / "snap.json"
+    snapshot_graph_to_file(graph, snap)
+
+    graph.clear()
+    load_graph_into_existing(graph, snap)
+
+    assert set(graph.get_all_node_ids()) == {"a", "b"}
+    assert ("a", "b", "L") in graph.get_all_edges()
+
+    graph.clear()
+    graph.close()


### PR DESCRIPTION
## Summary
- add EventLedger compact and bookmark persistence tests
- exercise snapshot load/save roundtrip on sqlite, postgres and redis graphs
- include `ume.snapshot` and `ume.event_ledger` in coverage

## Testing
- `poetry run pre-commit run --files .coveragerc tests/test_event_ledger.py tests/test_snapshot_backends.py`
- `poetry run pytest tests/test_event_ledger.py tests/test_snapshot_backends.py -m "not integration" -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5913d6b0832685c7d67573b48a36