### PR TITLE
Improve compose dependency checks

### DIFF
--- a/src/ume/cli/compose.py
+++ b/src/ume/cli/compose.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+import shutil
 
 # Ensure local package import when run directly without installation
 _src_path = Path(__file__).resolve().parents[3] / "src"
@@ -15,8 +16,26 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 COMPOSE_FILE = ROOT_DIR / "docker" / "docker-compose.yml"
 
 
+def _require_docker() -> None:
+    """Exit with a message if Docker is not available."""
+    if shutil.which("docker") is None:
+        print(
+            "Docker is required to run the UME stack. "
+            "Please install Docker and ensure it is on your PATH."
+        )
+        raise SystemExit(1)
+
+
+def _require_npm() -> None:
+    """Exit with a message if npm (Node.js) is not available."""
+    if shutil.which("npm") is None:
+        print("npm is required to build the dashboard. Please install Node.js.")
+        raise SystemExit(1)
+
+
 def _compose_up(compose_file: Path = COMPOSE_FILE, timeout: int = 120) -> None:
     """Start Docker Compose services and wait until healthy."""
+    _require_docker()
     try:
         subprocess.run(
             ["docker", "compose", "-f", str(compose_file), "up", "-d"],
@@ -65,6 +84,7 @@ def _compose_up(compose_file: Path = COMPOSE_FILE, timeout: int = 120) -> None:
 
 def _compose_down(compose_file: Path = COMPOSE_FILE) -> None:
     """Stop Docker Compose services."""
+    _require_docker()
     try:
         subprocess.run(
             ["docker", "compose", "-f", str(compose_file), "down"],
@@ -78,6 +98,7 @@ def _compose_down(compose_file: Path = COMPOSE_FILE) -> None:
 
 def _compose_ps(compose_file: Path = COMPOSE_FILE) -> None:
     """Print Docker Compose service health info."""
+    _require_docker()
     try:
         out = subprocess.check_output(
             [
@@ -155,6 +176,8 @@ def _ensure_env_file(env_file: Path = Path(".env")) -> None:
 
 def _quickstart(no_confirm: bool = False) -> None:
     """Prepare environment and start the Docker Compose stack."""
+    _require_docker()
+    _require_npm()
     env_file = Path(".env")
     if not no_confirm and not sys.stdin.isatty():
         no_confirm = True

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -319,6 +319,8 @@ def test_cli_up_and_down(monkeypatch: pytest.MonkeyPatch, capsys: pytest.Capture
 
         return ""
 
+    monkeypatch.setattr(compose.shutil, "which", lambda name: "/usr/bin/" + name)
+
     monkeypatch.setattr(compose.subprocess, "run", fake_run)
     monkeypatch.setattr(compose.subprocess, "check_output", fake_check_output)
     monkeypatch.setattr(compose.time, "sleep", lambda *_: None)
@@ -570,3 +572,49 @@ def test_cli_env_file_no_warning(
 
     out = capsys.readouterr().out
     assert "insecure default key" not in out
+
+
+def test_cli_up_missing_docker(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI should exit with message when Docker is absent."""
+    import importlib
+    import ume_cli as cli
+    from ume.cli import compose
+
+    importlib.reload(cli)
+    importlib.reload(compose)
+
+    monkeypatch.setattr(compose.shutil, "which", lambda name: None if name == "docker" else "/usr/bin/" + name)
+    monkeypatch.setattr(compose, "_compose_up", lambda *_: None)
+    monkeypatch.setattr(compose.subprocess, "run", lambda *_, **__: None)
+
+    argv = sys.argv[:]
+    sys.argv = ["ume-cli", "up", "--no-confirm"]
+    with pytest.raises(SystemExit):
+        cli.main()
+    out = capsys.readouterr().out
+    sys.argv = argv
+
+    assert "Docker is required" in out
+
+
+def test_cli_up_missing_node(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI should exit with message when Node/npm is absent."""
+    import importlib
+    import ume_cli as cli
+    from ume.cli import compose
+
+    importlib.reload(cli)
+    importlib.reload(compose)
+
+    monkeypatch.setattr(compose.shutil, "which", lambda name: None if name == "npm" else "/usr/bin/" + name)
+    monkeypatch.setattr(compose, "_compose_up", lambda *_: None)
+    monkeypatch.setattr(compose.subprocess, "run", lambda *_, **__: None)
+
+    argv = sys.argv[:]
+    sys.argv = ["ume-cli", "up", "--no-confirm"]
+    with pytest.raises(SystemExit):
+        cli.main()
+    out = capsys.readouterr().out
+    sys.argv = argv
+
+    assert "npm is required" in out


### PR DESCRIPTION
## Summary
- ensure Docker and Node are installed before running compose helpers
- test quickstart behaviour when Docker or Node are missing
- adjust existing smoke test to handle new checks

## Testing
- `ruff check . --line-length 88`
- `mypy --config-file mypy.ini`
- `pytest tests/test_cli_smoke.py::test_cli_up_and_down tests/test_cli_smoke.py::test_cli_up_missing_docker tests/test_cli_smoke.py::test_cli_up_missing_node -q`

------
https://chatgpt.com/codex/tasks/task_e_687e9ee8b3788326881af8e3fac8cd8e