### PR TITLE
Add metrics and integration tests

### DIFF
--- a/tests/integration/test_integration_clients.py
+++ b/tests/integration/test_integration_clients.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 # ruff: noqa: E402
 
+import pytest
+
 import sys
 import importlib.util
 from pathlib import Path
@@ -20,7 +22,16 @@ import httpx
 from fastapi.testclient import TestClient
 from ume.api import app, configure_graph, configure_vector_store
 from ume.persistent_graph import PersistentGraph
-from ume.integrations import LangGraph, Letta, MemGPT, SuperMemory, BaseClient
+from ume.integrations import (
+    LangGraph,
+    Letta,
+    MemGPT,
+    SuperMemory,
+    BaseClient,
+    AsyncLangGraph,
+    AsyncLetta,
+    AsyncBaseClient,
+)
 from ume.config import settings
 
 class DummyVectorStore:
@@ -82,6 +93,40 @@ def test_integration_clients(tmp_path) -> None:
                 result = c.recall({"vector": vec, "k": 1})
             assert app.state.graph.get_node(nid) == {"text": nid}
             assert result == {"nodes": [{"id": nid, "attributes": {"text": nid}}]}
+
+
+@pytest.mark.asyncio
+async def test_async_langgraph_and_letta(tmp_path) -> None:
+    db_path = tmp_path / "db_async.sqlite"
+    configure_graph(PersistentGraph(str(db_path), check_same_thread=False))
+    configure_vector_store(DummyVectorStore(dim=2))
+
+    with TestClient(app) as client:
+        token = _token(client)
+        store = app.state.vector_store
+        store.add("n1", [1.0, 0.0])
+        store.add("n2", [0.0, 1.0])
+
+        async with AsyncLangGraph(base_url=str(client.base_url), api_key=token) as lg:
+            assert isinstance(lg, AsyncBaseClient)
+            lg._client = httpx.AsyncClient(transport=httpx.ASGITransport(app), base_url=str(client.base_url))
+            await lg.send_events([
+                {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {"node_id": "n1", "attributes": {"text": "n1"}}}
+            ])
+            result1 = await lg.recall({"vector": [1.0, 0.0], "k": 1})
+
+        async with AsyncLetta(base_url=str(client.base_url), api_key=token) as lt:
+            assert isinstance(lt, AsyncBaseClient)
+            lt._client = httpx.AsyncClient(transport=httpx.ASGITransport(app), base_url=str(client.base_url))
+            await lt.send_events([
+                {"event_type": "CREATE_NODE", "timestamp": 2, "node_id": "n2", "payload": {"node_id": "n2", "attributes": {"text": "n2"}}}
+            ])
+            result2 = await lt.recall({"vector": [0.0, 1.0], "k": 1})
+
+        assert app.state.graph.get_node("n1") == {"text": "n1"}
+        assert app.state.graph.get_node("n2") == {"text": "n2"}
+        assert result1 == {"nodes": [{"id": "n1", "attributes": {"text": "n1"}}]}
+        assert result2 == {"nodes": [{"id": "n2", "attributes": {"text": "n2"}}]}
 
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -61,6 +61,25 @@ class DummyVS:
 def dummy_create() -> DummyVS:
     return DummyVS()
 
+
+class DummyVectorStore:
+    def __init__(self, dim: int) -> None:
+        self.dim = dim
+        self.vectors: dict[str, list[float]] = {}
+
+    def add(self, vid: str, vector: list[float]) -> None:
+        assert len(vector) == self.dim
+        self.vectors[vid] = vector
+
+    def query(self, vector: list[float], k: int = 5) -> list[str]:
+        def dist(v: list[float]) -> float:
+            return sum((a - b) ** 2 for a, b in zip(v, vector))
+
+        return [vid for vid, v in sorted(self.vectors.items(), key=lambda kv: dist(kv[1]))][:k]
+
+    def close(self) -> None:  # pragma: no cover - no cleanup needed
+        pass
+
 package.VectorStore = DummyVS  # type: ignore[attr-defined]
 package.create_vector_store = dummy_create  # type: ignore[attr-defined]
 package.create_default_store = dummy_create  # type: ignore[attr-defined]
@@ -72,6 +91,7 @@ sys.modules["ume.api"] = api_module
 spec_api.loader.exec_module(api_module)
 app = api_module.app
 configure_graph = api_module.configure_graph
+configure_vector_store = api_module.configure_vector_store
 
 if "ume.metrics" in sys.modules:
     metrics_module = sys.modules["ume.metrics"]
@@ -83,6 +103,8 @@ else:
     spec_metrics.loader.exec_module(metrics_module)
 REQUEST_COUNT = metrics_module.REQUEST_COUNT
 REQUEST_LATENCY = metrics_module.REQUEST_LATENCY
+RECALL_LATENCY_MS = metrics_module.RECALL_LATENCY_MS
+LEDGER_COMPACTED_BYTES = metrics_module.LEDGER_COMPACTED_BYTES
 
 spec_graph = importlib.util.spec_from_file_location("ume.graph", root / "src" / "ume" / "graph.py")
 assert spec_graph and spec_graph.loader
@@ -168,6 +190,23 @@ def _latency_counts() -> List[float]:
     ]
 
 
+def _recall_latency_counts() -> List[float]:
+    return [
+        s.value
+        for m in RECALL_LATENCY_MS.collect()
+        for s in m.samples
+        if s.name.endswith("_count")
+    ]
+
+
+def _ledger_compacted_bytes() -> float:
+    for m in LEDGER_COMPACTED_BYTES.collect():
+        for s in m.samples:
+            if s.name == "ume_ledger_compacted_bytes" and s.labels == {}:
+                return float(s.value)
+    return 0.0
+
+
 def test_http_metrics_recorded():
     client = TestClient(app)
     tok = _token(client)
@@ -182,3 +221,29 @@ def test_http_metrics_recorded():
 def test_metrics_reset_between_tests():
     assert _count_samples() == []
     assert sum(_latency_counts()) == 0
+
+
+def test_recall_latency_metric_recorded(tmp_path) -> None:
+    configure_graph(MockGraph())
+    configure_vector_store(DummyVectorStore(dim=2))
+    app.state.vector_store = DummyVectorStore(dim=2)
+    app.state.graph = MockGraph()
+    client = TestClient(app)
+    tok = _token(client)
+    store = app.state.vector_store
+    store.add("n1", [0.0, 1.0])
+    app.state.graph.get_node = lambda _id: {"embedding": [0.0, 1.0]}
+    client.get(
+        "/recall",
+        params=[("vector", 0.0), ("vector", 1.0)],
+        headers={"Authorization": f"Bearer {tok}"},
+    )
+    assert sum(_recall_latency_counts()) > 0
+
+
+def test_ledger_compacted_bytes_metric_recorded() -> None:
+    LEDGER_COMPACTED_BYTES.set(123)
+    client = TestClient(app)
+    tok = _token(client)
+    client.get("/metrics", headers={"Authorization": f"Bearer {tok}"})
+    assert _ledger_compacted_bytes() == 123


### PR DESCRIPTION
## Summary
- extend metrics tests to cover `ume_recall_latency_ms` and `ume_ledger_compacted_bytes`
- run LangGraph and Letta async clients against the API

## Testing
- `pytest tests/test_metrics.py tests/integration/test_integration_clients.py::test_integration_clients tests/integration/test_integration_clients.py::test_async_langgraph_and_letta -q`
- `ruff check tests/test_metrics.py tests/integration/test_integration_clients.py`

------
https://chatgpt.com/codex/tasks/task_e_687ece7756bc8326842f5ff7f3f106e7