### PR TITLE
Graceful index size retrieval

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -68,6 +68,11 @@ Here are a few Prometheus queries you can use when building graphs:
 You can combine these metrics in Grafana to visualize API performance and index
 growth over time.
 
+The metrics summary endpoint expects the configured vector store to expose a
+`get_index_size()` method or `get_vector_timestamps()` mapping. If neither is
+implemented, it falls back to counting the legacy `idx_to_id` attribute when
+present.
+
 ## Distributed Tracing with OpenTelemetry
 
 Set the `UME_OTLP_ENDPOINT` environment variable to enable trace export via OTLP.

--- a/src/ume/metrics_routes.py
+++ b/src/ume/metrics_routes.py
@@ -53,7 +53,18 @@ def metrics_summary(
                 recall_count += s.value
     avg_recall = recall_sum / recall_count if recall_count else 0.0
 
-    index_size = len(getattr(store, "idx_to_id", []))
+    if hasattr(store, "get_index_size"):
+        try:
+            index_size = store.get_index_size()
+        except Exception:  # pragma: no cover - best effort
+            index_size = 0
+    elif hasattr(store, "get_vector_timestamps"):
+        try:
+            index_size = len(store.get_vector_timestamps())
+        except Exception:  # pragma: no cover - best effort
+            index_size = 0
+    else:
+        index_size = len(getattr(store, "idx_to_id", []))
     return {
         "total_requests": int(total_requests),
         "request_count_by_status": {k: int(v) for k, v in by_status.items()},

--- a/tests/test_vector_store_unit.py
+++ b/tests/test_vector_store_unit.py
@@ -190,3 +190,65 @@ def test_create_default_store_selects_backend(monkeypatch):
     store = vs.create_default_store()
     assert isinstance(store, vs.ChromaBackend)
 
+
+def test_metrics_summary_without_idx_to_id() -> None:
+    import importlib.util
+    import types
+    import sys
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+
+    orig_pkg = sys.modules.get("ume")
+    package = types.ModuleType("ume")
+    package.__path__ = [str(root / "src" / "ume")]
+    sys.modules["ume"] = package
+
+    metrics_module = types.ModuleType("ume.metrics")
+    class _DummyMetric:
+        def collect(self) -> list[object]:
+            return []
+
+    metrics_module.REQUEST_COUNT = _DummyMetric()
+    metrics_module.REQUEST_LATENCY = _DummyMetric()
+    metrics_module.RECALL_SCORE = _DummyMetric()
+    sys.modules["ume.metrics"] = metrics_module
+
+    api_deps = types.ModuleType("ume.api_deps")
+    api_deps.get_current_role = lambda token="": ""
+    api_deps.get_vector_store = lambda: None
+    sys.modules["ume.api_deps"] = api_deps
+
+    vector_store_mod = types.ModuleType("ume.vector_store")
+    class VectorStoreBase:  # minimal placeholder
+        pass
+    vector_store_mod.VectorStore = VectorStoreBase
+    sys.modules["ume.vector_store"] = vector_store_mod
+
+    spec_mr = importlib.util.spec_from_file_location(
+        "ume.metrics_routes", root / "src" / "ume" / "metrics_routes.py"
+    )
+    assert spec_mr and spec_mr.loader
+    mr_module = importlib.util.module_from_spec(spec_mr)
+    sys.modules["ume.metrics_routes"] = mr_module
+    spec_mr.loader.exec_module(mr_module)
+
+    class DummyStore:
+        def get_vector_timestamps(self) -> dict[str, int]:
+            return {"a": 0, "b": 0}
+
+    try:
+        result = mr_module.metrics_summary("", DummyStore())
+        assert result["vector_index_size"] == 2
+    finally:
+        for mod in [
+            "ume.metrics_routes",
+            "ume.metrics",
+            "ume.api_deps",
+            "ume.vector_store",
+            "ume",
+        ]:
+            sys.modules.pop(mod, None)
+        if orig_pkg is not None:
+            sys.modules["ume"] = orig_pkg
+


### PR DESCRIPTION
## Summary
- handle missing `idx_to_id` with `get_index_size` or `get_vector_timestamps`
- document index size expectations in monitoring docs
- test metrics summary with a backend missing `idx_to_id`

## Testing
- `pre-commit run --files src/ume/metrics_routes.py docs/MONITORING.md tests/test_vector_store_unit.py`
- `PYTHONPATH=src pytest tests/test_vector_store_unit.py::test_metrics_summary_without_idx_to_id -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9207f558832693ac530ae2daa7f6