### PR TITLE
Create async CRUD mixin

### DIFF
--- a/src/ume/async_graph_adapter.py
+++ b/src/ume/async_graph_adapter.py
@@ -4,20 +4,16 @@ from __future__ import annotations
 
 import asyncio
 
-import json
-import time
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, cast
 
-import aiosqlite
-
-from .config import settings
+from .persistent_graph import PersistentGraph
 from .processing import ProcessingError, DEFAULT_VERSION
 from .event import Event, EventType, parse_event
 from ._internal.listeners import get_registered_listeners
 from .plugins.alignment import get_plugins
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
-from .graph_adapter import IGraphAdapter
+from .graph_adapter import IGraphAdapter, AsyncAdapterMixin
 
 
 class IAsyncGraphAdapter(ABC):
@@ -88,69 +84,11 @@ class IAsyncGraphAdapter(ABC):
         pass
 
 
-class AsyncGraphAdapterWrapper(IAsyncGraphAdapter):
+class AsyncGraphAdapterWrapper(AsyncAdapterMixin, IAsyncGraphAdapter):
     """Wrap a synchronous :class:`IGraphAdapter` with async methods."""
 
     def __init__(self, adapter: "IGraphAdapter") -> None:
-        self._adapter = adapter
-
-    async def add_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
-        await asyncio.to_thread(self._adapter.add_node, node_id, attributes)
-
-    async def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
-        await asyncio.to_thread(self._adapter.update_node, node_id, attributes)
-
-    async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
-        return await asyncio.to_thread(self._adapter.get_node, node_id)
-
-    async def node_exists(self, node_id: str) -> bool:
-        return await asyncio.to_thread(self._adapter.node_exists, node_id)
-
-    async def dump(self) -> Dict[str, Any]:
-        return await asyncio.to_thread(self._adapter.dump)
-
-    async def clear(self) -> None:
-        await asyncio.to_thread(self._adapter.clear)
-
-    async def get_all_node_ids(self) -> List[str]:
-        return await asyncio.to_thread(self._adapter.get_all_node_ids)
-
-    async def find_connected_nodes(
-        self, node_id: str, edge_label: Optional[str] = None
-    ) -> List[str]:
-        return await asyncio.to_thread(
-            self._adapter.find_connected_nodes, node_id, edge_label
-        )
-
-    async def add_edge(
-        self, source_node_id: str, target_node_id: str, label: str
-    ) -> None:
-        await asyncio.to_thread(
-            self._adapter.add_edge, source_node_id, target_node_id, label
-        )
-
-    async def get_all_edges(self) -> List[Tuple[str, str, str]]:
-        return await asyncio.to_thread(self._adapter.get_all_edges)
-
-    async def delete_edge(
-        self, source_node_id: str, target_node_id: str, label: str
-    ) -> None:
-        await asyncio.to_thread(
-            self._adapter.delete_edge, source_node_id, target_node_id, label
-        )
-
-    async def redact_node(self, node_id: str) -> None:
-        await asyncio.to_thread(self._adapter.redact_node, node_id)
-
-    async def redact_edge(
-        self, source_node_id: str, target_node_id: str, label: str
-    ) -> None:
-        await asyncio.to_thread(
-            self._adapter.redact_edge, source_node_id, target_node_id, label
-        )
-
-    async def close(self) -> None:
-        await asyncio.to_thread(self._adapter.close)
+        super().__init__(adapter)
 
 
 
@@ -182,264 +120,28 @@ class AsyncGraphAlgorithmsMixin:
         return path
 
 
-class AsyncPersistentGraph(AsyncGraphAlgorithmsMixin, IAsyncGraphAdapter):
-    """SQLite-backed graph adapter using ``aiosqlite``."""
+class AsyncPersistentGraph(AsyncAdapterMixin, AsyncGraphAlgorithmsMixin, IAsyncGraphAdapter):
+    """Asynchronous wrapper around :class:`PersistentGraph`."""
 
-    def __init__(self, conn: aiosqlite.Connection) -> None:
-        self.conn = conn
+    def __init__(self, adapter: "PersistentGraph") -> None:
+        super().__init__(adapter)
+        self._adapter: PersistentGraph = adapter
 
     @classmethod
     async def create(cls, db_path: str | None = None) -> "AsyncPersistentGraph":
-        conn = await aiosqlite.connect(db_path or settings.UME_DB_PATH)
-        conn.row_factory = aiosqlite.Row
-        self = cls(conn)
-        await self._create_tables()
-        return self
+        adapter = await asyncio.to_thread(PersistentGraph, db_path)
+        return cls(adapter)
 
-    async def _create_tables(self) -> None:
-        await self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS nodes (
-                id TEXT PRIMARY KEY,
-                attributes TEXT,
-                redacted INTEGER DEFAULT 0,
-                created_at INTEGER DEFAULT (strftime('%s','now'))
-            )
-            """
-        )
-        await self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS edges (
-                source TEXT,
-                target TEXT,
-                label TEXT,
-                redacted INTEGER DEFAULT 0,
-                created_at INTEGER DEFAULT (strftime('%s','now')),
-                PRIMARY KEY (source, target, label)
-            )
-            """
-        )
-        await self.conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS scores (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                task_id TEXT,
-                agent_id TEXT,
-                score REAL
-            )
-            """
-        )
-        await self.conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_edges_source ON edges (source)"
-        )
-        await self.conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_edges_target ON edges (target)"
-        )
-        await self.conn.commit()
-
-    async def close(self) -> None:
-        await self.conn.close()
-
-    async def add_node(
-        self, node_id: str, attributes: Dict[str, Any], *, created_at: int | None = None
+    async def add_score(
+        self, task_id: str | None, agent_id: str | None, score: float
     ) -> None:
-        try:
-            await self.conn.execute(
-                "INSERT INTO nodes(id, attributes, created_at) VALUES(?, ?, ?)",
-                (node_id, json.dumps(attributes), created_at or int(time.time())),
-            )
-            await self.conn.commit()
-        except aiosqlite.IntegrityError:
-            raise ProcessingError(f"Node '{node_id}' already exists.")
-
-    async def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
-        cur = await self.conn.execute(
-            "SELECT attributes FROM nodes WHERE id=? AND redacted=0", (node_id,)
-        )
-        row = await cur.fetchone()
-        await cur.close()
-        if row is None:
-            raise ProcessingError(f"Node '{node_id}' not found for update.")
-        data = json.loads(row["attributes"])
-        data.update(attributes)
-        await self.conn.execute(
-            "UPDATE nodes SET attributes=? WHERE id=?",
-            (json.dumps(data), node_id),
-        )
-        await self.conn.commit()
-
-    async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
-        cur = await self.conn.execute(
-            "SELECT attributes FROM nodes WHERE id=? AND redacted=0",
-            (node_id,),
-        )
-        row = await cur.fetchone()
-        await cur.close()
-        if row is None:
-            return None
-        return cast(Dict[str, Any], json.loads(row["attributes"]))
-
-    async def node_exists(self, node_id: str) -> bool:
-        cur = await self.conn.execute(
-            "SELECT 1 FROM nodes WHERE id=? AND redacted=0",
-            (node_id,),
-        )
-        row = await cur.fetchone()
-        await cur.close()
-        return row is not None
-
-    async def get_all_node_ids(self) -> List[str]:
-        cur = await self.conn.execute("SELECT id FROM nodes WHERE redacted=0")
-        rows = await cur.fetchall()
-        await cur.close()
-        return [row["id"] for row in rows]
-
-    async def add_edge(
-        self,
-        source_node_id: str,
-        target_node_id: str,
-        label: str,
-        *,
-        created_at: int | None = None,
-    ) -> None:
-        if not await self.node_exists(source_node_id) or not await self.node_exists(
-            target_node_id
-        ):
-            raise ProcessingError(
-                f"Both source node '{source_node_id}' and target node '{target_node_id}' must exist to add an edge."
-            )
-        try:
-            await self.conn.execute(
-                "INSERT INTO edges(source, target, label, created_at) VALUES(?, ?, ?, ?)",
-                (
-                    source_node_id,
-                    target_node_id,
-                    label,
-                    created_at or int(time.time()),
-                ),
-            )
-            await self.conn.commit()
-        except aiosqlite.IntegrityError:
-            raise ProcessingError(
-                f"Edge ({source_node_id}, {target_node_id}, {label}) already exists."
-            )
-
-    async def get_all_edges(self) -> List[Tuple[str, str, str]]:
-        cur = await self.conn.execute(
-            """
-            SELECT e.source, e.target, e.label
-            FROM edges e
-            JOIN nodes s ON e.source = s.id
-            JOIN nodes t ON e.target = t.id
-            WHERE e.redacted=0 AND s.redacted=0 AND t.redacted=0
-            """
-        )
-        rows = await cur.fetchall()
-        await cur.close()
-        return [(row["source"], row["target"], row["label"]) for row in rows]
-
-    async def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
-        cur = await self.conn.execute(
-            "DELETE FROM edges WHERE source=? AND target=? AND label=?",
-            (source_node_id, target_node_id, label),
-        )
-        await self.conn.commit()
-        if cur.rowcount == 0:
-            raise ProcessingError(
-                f"Edge {(source_node_id, target_node_id, label)} does not exist and cannot be deleted."
-            )
-
-    async def find_connected_nodes(
-        self, node_id: str, edge_label: Optional[str] = None
-    ) -> List[str]:
-        if not await self.node_exists(node_id):
-            raise ProcessingError(f"Node '{node_id}' not found.")
-        if edge_label:
-            cur = await self.conn.execute(
-                """
-                SELECT e.target FROM edges e
-                JOIN nodes s ON e.source = s.id
-                JOIN nodes t ON e.target = t.id
-                WHERE e.source=? AND e.label=?
-                  AND e.redacted=0 AND s.redacted=0 AND t.redacted=0
-                """,
-                (node_id, edge_label),
-            )
-        else:
-            cur = await self.conn.execute(
-                """
-                SELECT e.target FROM edges e
-                JOIN nodes s ON e.source = s.id
-                JOIN nodes t ON e.target = t.id
-                WHERE e.source=? AND e.redacted=0 AND s.redacted=0 AND t.redacted=0
-                """,
-                (node_id,),
-            )
-        rows = await cur.fetchall()
-        await cur.close()
-        return [row["target"] for row in rows]
-
-    async def add_score(self, task_id: str | None, agent_id: str | None, score: float) -> None:
-        await self.conn.execute(
-            "INSERT INTO scores(task_id, agent_id, score) VALUES(?, ?, ?)",
-            (task_id, agent_id, score),
-        )
-        await self.conn.commit()
+        await asyncio.to_thread(self._adapter.add_score, task_id, agent_id, score)
 
     async def get_scores(self) -> List[Tuple[str | None, str | None, float]]:
-        cur = await self.conn.execute(
-            "SELECT task_id, agent_id, score FROM scores"
-        )
-        rows = await cur.fetchall()
-        await cur.close()
-        return [
-            (row["task_id"], row["agent_id"], float(row["score"])) for row in rows
-        ]
-
-    async def clear(self) -> None:
-        await self.conn.execute("DELETE FROM edges")
-        await self.conn.execute("DELETE FROM nodes")
-        await self.conn.execute("DELETE FROM scores")
-        await self.conn.commit()
+        return await asyncio.to_thread(self._adapter.get_scores)
 
     async def node_count(self) -> int:
-        cur = await self.conn.execute(
-            "SELECT COUNT(*) AS cnt FROM nodes WHERE redacted=0"
-        )
-        row = await cur.fetchone()
-        await cur.close()
-        return int(row["cnt"]) if row else 0
-
-    async def dump(self) -> Dict[str, Any]:
-        nodes: Dict[str, Any] = {}
-        async with self.conn.execute(
-            "SELECT id, attributes FROM nodes WHERE redacted=0"
-        ) as cursor:
-            rows = await cursor.fetchall()
-            for row in rows:
-                nodes[row["id"]] = json.loads(row["attributes"])
-        edges = await self.get_all_edges()
-        return {"nodes": nodes, "edges": edges}
-
-    async def redact_node(self, node_id: str) -> None:
-        cur = await self.conn.execute(
-            "UPDATE nodes SET redacted=1 WHERE id=?",
-            (node_id,),
-        )
-        await self.conn.commit()
-        if cur.rowcount == 0:
-            raise ProcessingError(f"Node '{node_id}' not found to redact.")
-
-    async def redact_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
-        cur = await self.conn.execute(
-            "UPDATE edges SET redacted=1 WHERE source=? AND target=? AND label=?",
-            (source_node_id, target_node_id, label),
-        )
-        await self.conn.commit()
-        if cur.rowcount == 0:
-            raise ProcessingError(
-                f"Edge {(source_node_id, target_node_id, label)} does not exist and cannot be redacted."
-            )
+        return await asyncio.to_thread(lambda: self._adapter.node_count)
 
 
 async def apply_event_to_async_graph(

--- a/src/ume/graph_adapter.py
+++ b/src/ume/graph_adapter.py
@@ -1,6 +1,8 @@
 # src/ume/graph_adapter.py
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional, List, Tuple
+
+import asyncio
 
 # To avoid circular dependency if ProcessingError is defined in processing.py
 # and processing.py imports IGraphAdapter.
@@ -260,3 +262,70 @@ class IGraphAdapter(ABC):
         must return an empty list when no path satisfies the constraints.
         """
         pass
+
+
+class AsyncAdapterMixin:
+    """Async wrappers for CRUD operations on a synchronous :class:`IGraphAdapter`."""
+
+    _adapter: IGraphAdapter
+
+    def __init__(self, adapter: IGraphAdapter) -> None:
+        self._adapter = adapter
+
+    async def add_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        await asyncio.to_thread(self._adapter.add_node, node_id, attributes)
+
+    async def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        await asyncio.to_thread(self._adapter.update_node, node_id, attributes)
+
+    async def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        return await asyncio.to_thread(self._adapter.get_node, node_id)
+
+    async def node_exists(self, node_id: str) -> bool:
+        return await asyncio.to_thread(self._adapter.node_exists, node_id)
+
+    async def dump(self) -> Dict[str, Any]:
+        return await asyncio.to_thread(self._adapter.dump)
+
+    async def clear(self) -> None:
+        await asyncio.to_thread(self._adapter.clear)
+
+    async def get_all_node_ids(self) -> List[str]:
+        return await asyncio.to_thread(self._adapter.get_all_node_ids)
+
+    async def find_connected_nodes(
+        self, node_id: str, edge_label: Optional[str] = None
+    ) -> List[str]:
+        return await asyncio.to_thread(
+            self._adapter.find_connected_nodes, node_id, edge_label
+        )
+
+    async def add_edge(
+        self, source_node_id: str, target_node_id: str, label: str
+    ) -> None:
+        await asyncio.to_thread(
+            self._adapter.add_edge, source_node_id, target_node_id, label
+        )
+
+    async def get_all_edges(self) -> List[Tuple[str, str, str]]:
+        return await asyncio.to_thread(self._adapter.get_all_edges)
+
+    async def delete_edge(
+        self, source_node_id: str, target_node_id: str, label: str
+    ) -> None:
+        await asyncio.to_thread(
+            self._adapter.delete_edge, source_node_id, target_node_id, label
+        )
+
+    async def redact_node(self, node_id: str) -> None:
+        await asyncio.to_thread(self._adapter.redact_node, node_id)
+
+    async def redact_edge(
+        self, source_node_id: str, target_node_id: str, label: str
+    ) -> None:
+        await asyncio.to_thread(
+            self._adapter.redact_edge, source_node_id, target_node_id, label
+        )
+
+    async def close(self) -> None:
+        await asyncio.to_thread(self._adapter.close)


### PR DESCRIPTION
## Summary
- add `AsyncAdapterMixin` with common CRUD logic
- simplify `AsyncGraphAdapterWrapper` to use the mixin
- implement `AsyncPersistentGraph` as a thin wrapper around `PersistentGraph`

## Testing
- `ruff check src/ume/graph_adapter.py src/ume/async_graph_adapter.py`
- `mypy --config-file mypy.ini src/ume/graph_adapter.py src/ume/async_graph_adapter.py`
- `pytest tests/test_async_graph_adapter.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9bf509548326b4f89ee60033396d