### PR TITLE
Add conditional frontend build

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,10 @@ Stack running. API docs: http://localhost:8000/docs
 Recall endpoint: http://localhost:8000/recall
 ```
 
+Frontend dependencies are installed and the dashboard is built only if the
+`node_modules` or `frontend/dist` directories are missing. Use the
+`--force-build` flag to rebuild these assets.
+
 The resulting `.env` will contain values similar to:
 
 ```bash
@@ -375,8 +379,9 @@ poetry run ume up --no-confirm
 ```
 
 The command generates TLS certificates if needed, installs frontend dependencies
-on the first run, builds the React dashboard and waits until the services become
-healthy before printing the main URLs:
+and builds the React dashboard when required. Pass ``--force-build`` to reinstall
+Node modules and rebuild the dashboard. The command waits until the services
+become healthy before printing the main URLs:
 
 ```
 http://localhost:8000/docs

--- a/src/ume/cli/compose.py
+++ b/src/ume/cli/compose.py
@@ -179,7 +179,7 @@ def _ensure_env_file(env_file: Path = Path(".env")) -> None:
         print("Updated secrets in .env with secure values")
 
 
-def _quickstart(no_confirm: bool = False) -> None:
+def _quickstart(no_confirm: bool = False, force_build: bool = False) -> None:
     """Prepare environment and start the Docker Compose stack."""
     _require_docker()
     _require_npm()
@@ -207,12 +207,15 @@ def _quickstart(no_confirm: bool = False) -> None:
     subprocess.run(["bash", str(cert_script)], check=True)
 
     frontend_dir = ROOT_DIR / "frontend"
+    need_install = force_build or not (frontend_dir / "node_modules").exists()
+    need_build = force_build or not (frontend_dir / "dist").exists()
     try:
-        if not (frontend_dir / "node_modules").exists():
+        if need_install:
             print("Installing frontend dependencies...")
             subprocess.run(["npm", "install"], cwd=frontend_dir, check=True)
-        print("Building frontend dashboard...")
-        subprocess.run(["npm", "run", "build"], cwd=frontend_dir, check=True)
+        if need_build:
+            print("Building frontend dashboard...")
+            subprocess.run(["npm", "run", "build"], cwd=frontend_dir, check=True)
     except FileNotFoundError:
         print("npm is required to build the dashboard. Please install Node.js.")
 

--- a/tests/test_api_scheduler.py
+++ b/tests/test_api_scheduler.py
@@ -8,6 +8,7 @@ import types
 import pytest
 
 root = Path(__file__).resolve().parents[1]
+_orig_ume = sys.modules.get("ume")
 package = types.ModuleType("ume")
 package.__path__ = [str(root / "src" / "ume")]
 sys.modules["ume"] = package
@@ -144,3 +145,8 @@ async def test_api_compaction_thread_stops(tmp_path, monkeypatch: pytest.MonkeyP
     assert thread.is_alive() is False
     retention.stop_ledger_compaction_scheduler()
     ledger.close()
+
+if _orig_ume is None:
+    sys.modules.pop("ume", None)
+else:
+    sys.modules["ume"] = _orig_ume

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -356,17 +356,21 @@ def test_top_level_ume_up(monkeypatch: pytest.MonkeyPatch) -> None:
 
     called: dict[str, bool] = {}
 
-    def fake_quickstart(no_confirm: bool = False) -> None:
-        called["flag"] = no_confirm
+    def fake_quickstart(
+        no_confirm: bool = False, force_build: bool = False
+    ) -> None:
+        called["no_confirm"] = no_confirm
+        called["force_build"] = force_build
 
     monkeypatch.setattr(main, "_quickstart", fake_quickstart)
 
     argv = sys.argv[:]
-    sys.argv = ["ume", "up", "--no-confirm"]
+    sys.argv = ["ume", "up", "--no-confirm", "--force-build"]
     main.main()
     sys.argv = argv
 
-    assert called.get("flag") is True
+    assert called.get("no_confirm") is True
+    assert called.get("force_build") is True
 
 
 def test_cli_up_custom_compose(
@@ -504,10 +508,22 @@ def test_cli_snapshot_schedule(
     bench.benchmark_vector_store = lambda *_: None
     feder = types.ModuleType("ume.federation")
     feder.MirrorMakerDriver = object  # type: ignore[assignment]
+    cli_pkg = types.ModuleType("ume.cli")
+    compose_pkg = types.ModuleType("ume.cli.compose")
+    compose_pkg._compose_down = lambda *_, **__: None
+    compose_pkg._compose_ps = lambda *_, **__: None
+    compose_pkg._quickstart = lambda *_, **__: None
+    cli_pkg.compose = compose_pkg
+    prompt_pkg = types.ModuleType("ume.cli.prompt")
+    prompt_pkg.UMEPrompt = object
+    prompt_pkg.create_graph_adapter = lambda *_, **__: None
     sys.modules["ume"] = stub
     sys.modules["ume.benchmarks"] = bench
     sys.modules["ume.federation"] = feder
     sys.modules["ume.auto_snapshot"] = auto_snapshot
+    sys.modules["ume.cli"] = cli_pkg
+    sys.modules["ume.cli.compose"] = compose_pkg
+    sys.modules["ume.cli.prompt"] = prompt_pkg
 
     import ume_cli as cli
     importlib.reload(cli)
@@ -538,6 +554,16 @@ def test_cli_snapshot_schedule(
 
     assert called["interval"] == 1
     assert "Snapshots will be written" in out
+
+    for mod in [
+        "ume.cli.compose",
+        "ume.cli",
+        "ume.auto_snapshot",
+        "ume.federation",
+        "ume.benchmarks",
+        "ume",
+    ]:
+        sys.modules.pop(mod, None)
 
 
 def test_cli_env_file_warning(
@@ -711,7 +737,7 @@ sys.modules['ume.config'] = conf
                 "    env_file.write_text('UME_AUDIT_SIGNING_KEY=test\\nUME_OAUTH_PASSWORD=test\\n')",
                 "    print('Created .env from env.example with random UME_AUDIT_SIGNING_KEY and UME_OAUTH_PASSWORD')",
                 "",
-                "def _quickstart(no_confirm: bool = False) -> None:",
+                "def _quickstart(no_confirm: bool = False, force_build: bool = False) -> None:",
                 "    _ensure_env_file(Path('.env'))",
                 "    _compose_up()",
             ]

--- a/tests/test_dag_service.py
+++ b/tests/test_dag_service.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 # Avoid executing ume/__init__.py which imports optional dependencies.
 pkg_root = Path(__file__).resolve().parents[1] / "src" / "ume"
-if "ume" not in sys.modules:
+_orig_ume = sys.modules.get("ume")
+if _orig_ume is None:
     stub = types.ModuleType("ume")
     stub.__path__ = [str(pkg_root)]
     sys.modules["ume"] = stub
@@ -87,3 +88,8 @@ def test_dag_service_task_exception(monkeypatch: pytest.MonkeyPatch) -> None:
     service._thread.join()
     assert not service._thread.is_alive()
     service.stop()
+
+if _orig_ume is None:
+    sys.modules.pop("ume", None)
+else:
+    sys.modules["ume"] = _orig_ume

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -15,7 +15,8 @@ from typing import Callable
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 pkg_root = Path(__file__).resolve().parents[1] / "src" / "ume"
-if "ume" not in sys.modules:
+_orig_ume = sys.modules.get("ume")
+if _orig_ume is None:
     stub = types.ModuleType("ume")
     stub.__path__ = [str(pkg_root)]
     sys.modules["ume"] = stub
@@ -223,3 +224,8 @@ def test_ledger_compaction_scheduler(tmp_path: Path, monkeypatch: pytest.MonkeyP
     stop_ledger_compaction_scheduler()
 
     assert [o for o, _ in ledger.range()] == [2, 3, 4]
+
+if _orig_ume is None:
+    sys.modules.pop("ume", None)
+else:
+    sys.modules["ume"] = _orig_ume

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -93,12 +93,20 @@ def main() -> None:
             action="store_true",
             help="Create .env and certs without prompting",
         )
+        p.add_argument(
+            "--force-build",
+            action="store_true",
+            help="Reinstall and rebuild frontend assets",
+        )
 
     args = parser.parse_args()
 
     try:
         if args.command in {"up", "quickstart"}:
-            _quickstart(getattr(args, "no_confirm", False))
+            _quickstart(
+                getattr(args, "no_confirm", False),
+                getattr(args, "force_build", False),
+            )
             return
         if args.command == "down":
             _compose_down()


### PR DESCRIPTION
## Summary
- rebuild frontend only if modules or build output is missing
- add `--force-build` argument to `ume up` and `ume quickstart`
- document new behaviour in the Quickstart section
- update CLI tests for new flag
- restore `ume` module after stubbing in several tests

## Testing
- `poetry run pre-commit run --files tests/test_cli_smoke.py tests/test_api_scheduler.py tests/test_dag_service.py tests/test_retention.py`
- `poetry run pytest tests/test_api_scheduler.py tests/test_dag_service.py tests/test_retention.py tests/test_cli_smoke.py::test_cli_snapshot_schedule -q`

------
https://chatgpt.com/codex/tasks/task_e_687f9bf5f24c83269dc4fea4db47cb8b