### PR TITLE
Add Grafana dashboard and validation test

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -50,7 +50,8 @@ Start the stack with `docker-compose up`. Prometheus will scrape
    credentials.
 2. Add a Prometheus data source pointing to `http://prometheus:9090`.
 3. Create a dashboard and add graphs using the `ume_http_requests_total` and
-   other metrics exposed by UME.
+   other metrics exposed by UME, or import the ready-made dashboard from
+   `docs/grafana/ume_dashboard.json`.
 
 ## Example Grafana Panels
 

--- a/docs/grafana/ume_dashboard.json
+++ b/docs/grafana/ume_dashboard.json
@@ -1,0 +1,29 @@
+{
+  "title": "UME Dashboard",
+  "uid": "ume-dashboard",
+  "schemaVersion": 37,
+  "version": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Request Rate",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "rate(ume_http_requests_total[1m])"}],
+      "id": 1
+    },
+    {
+      "type": "timeseries",
+      "title": "Recall Latency",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "rate(ume_recall_latency_ms_sum[5m]) / rate(ume_recall_latency_ms_count[5m])"}],
+      "id": 2
+    },
+    {
+      "type": "timeseries",
+      "title": "Compaction Bytes",
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [{"expr": "ume_ledger_compacted_bytes"}],
+      "id": 3
+    }
+  ]
+}

--- a/tests/test_dashboard_json.py
+++ b/tests/test_dashboard_json.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+from jsonschema import validate
+
+SCHEMA = {
+    "type": "object",
+    "properties": {
+        "title": {"type": "string"},
+        "panels": {"type": "array"},
+    },
+    "required": ["title", "panels"],
+}
+
+
+def test_dashboard_json_valid() -> None:
+    data = json.loads(Path("docs/grafana/ume_dashboard.json").read_text())
+    validate(data, SCHEMA)


### PR DESCRIPTION
## Summary
- add UME Grafana dashboard JSON
- document dashboard import steps
- add JSON validation test for the dashboard

## Testing
- `pre-commit run --files docs/grafana/ume_dashboard.json docs/MONITORING.md tests/test_dashboard_json.py`
- `PYTHONPATH=src pytest tests/test_dashboard_json.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb0dbfd148326b15df8ccd075c727