### PR TITLE
Add recall latency and ledger compacted metrics

### DIFF
--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -62,7 +62,7 @@ Here are a few Prometheus queries you can use when building graphs:
 | `ume_vector_query_latency_seconds` | Latency of vector similarity search | `rate(ume_vector_query_latency_seconds_sum[5m]) / rate(ume_vector_query_latency_seconds_count[5m])` |
 | `ume_vector_index_size` | Number of vectors stored | `ume_vector_index_size` |
 | `ume_stale_vector_count` | Vectors older than the freshness limit | `ume_stale_vector_count` |
-| `ume_recall_latency_ms` | Latency of recall operations | `rate(ume_recall_latency_ms_sum[5m]) / rate(ume_recall_latency_ms_count[5m])` |
+| `ume_recall_latency_seconds` | Latency of recall operations | `rate(ume_recall_latency_seconds_sum[5m]) / rate(ume_recall_latency_seconds_count[5m])` |
 | `ume_ledger_compacted_bytes` | Bytes removed during the last ledger compaction | `ume_ledger_compacted_bytes` |
 
 You can combine these metrics in Grafana to visualize API performance and index

--- a/src/ume/metrics.py
+++ b/src/ume/metrics.py
@@ -47,6 +47,10 @@ FALSE_TEXT_RATE = Counter(
 )
 
 # Additional recall metrics
+RECALL_LATENCY = Histogram(
+    "ume_recall_latency_seconds",
+    "Latency of recall operations in seconds",
+)
 RECALL_LATENCY_MS = Histogram(
     "ume_recall_latency_ms",
     "Latency of recall operations in milliseconds",

--- a/src/ume/metrics_routes.py
+++ b/src/ume/metrics_routes.py
@@ -6,7 +6,13 @@ from fastapi import APIRouter, Depends, Response
 
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
-from .metrics import REQUEST_COUNT, REQUEST_LATENCY, RECALL_SCORE
+from .metrics import (
+    REQUEST_COUNT,
+    REQUEST_LATENCY,
+    RECALL_SCORE,
+    RECALL_LATENCY,
+    LEDGER_COMPACTED_BYTES,
+)
 from .api_deps import get_current_role, get_vector_store
 from .vector_store import VectorStore
 
@@ -53,6 +59,28 @@ def metrics_summary(
                 recall_count += s.value
     avg_recall = recall_sum / recall_count if recall_count else 0.0
 
+    recall_lat_sum = 0.0
+    recall_lat_count = 0.0
+    for metric in RECALL_LATENCY.collect():
+        for s in metric.samples:
+            if s.name.endswith("_sum"):
+                recall_lat_sum += s.value
+            elif s.name.endswith("_count"):
+                recall_lat_count += s.value
+    avg_recall_latency = (
+        recall_lat_sum / recall_lat_count if recall_lat_count else 0.0
+    )
+
+    compacted_bytes = 0.0
+    for metric in LEDGER_COMPACTED_BYTES.collect():
+        for s in metric.samples:
+            if (
+                s.name == "ume_ledger_compacted_bytes"
+                and s.labels == {}
+            ):
+                compacted_bytes = float(s.value)
+                break
+
     if hasattr(store, "get_index_size"):
         try:
             index_size = store.get_index_size()
@@ -71,4 +99,6 @@ def metrics_summary(
         "average_request_latency": avg_latency,
         "vector_index_size": index_size,
         "average_recall_score": avg_recall,
+        "average_recall_latency": avg_recall_latency,
+        "ledger_compacted_bytes": int(compacted_bytes),
     }

--- a/src/ume/vector_routes.py
+++ b/src/ume/vector_routes.py
@@ -14,7 +14,7 @@ from . import api_deps as deps
 from .vector_store import VectorStore
 from .graph_adapter import IGraphAdapter
 from .embedding import generate_embedding
-from .metrics import RECALL_SCORE, RECALL_LATENCY_MS
+from .metrics import RECALL_SCORE, RECALL_LATENCY, RECALL_LATENCY_MS
 
 router = APIRouter()
 
@@ -81,7 +81,9 @@ def api_recall(
                 except TypeError:
                     pass
             nodes.append({"id": node_id, "attributes": attrs})
-    RECALL_LATENCY_MS.observe((time.perf_counter() - start) * 1000)
+    duration = time.perf_counter() - start
+    RECALL_LATENCY.observe(duration)
+    RECALL_LATENCY_MS.observe(duration * 1000)
     return {"nodes": nodes}
 
 
@@ -118,7 +120,9 @@ async def api_recall_stream(
                 payload = {"id": node_id, "attributes": attrs}
                 yield f"data: {json.dumps(payload)}\n\n"
             await asyncio.sleep(0)
-        RECALL_LATENCY_MS.observe((time.perf_counter() - start) * 1000)
+        duration = time.perf_counter() - start
+        RECALL_LATENCY.observe(duration)
+        RECALL_LATENCY_MS.observe(duration * 1000)
 
     return StreamingResponse(_gen(), media_type="text/event-stream")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -164,6 +164,8 @@ def test_metrics_summary(monkeypatch: MonkeyPatch) -> None:
     assert "vector_index_size" in data
     assert "average_request_latency" in data
     assert "average_recall_score" in data
+    assert "average_recall_latency" in data
+    assert "ledger_compacted_bytes" in data
 
 
 def test_metrics_summary_with_rate_limit(monkeypatch: MonkeyPatch) -> None:
@@ -200,6 +202,8 @@ def test_metrics_summary_with_rate_limit(monkeypatch: MonkeyPatch) -> None:
         assert res.status_code == 200
         data = res.json()
         assert data["request_count_by_status"].get("429", 0) >= 1
+        assert "average_recall_latency" in data
+        assert "ledger_compacted_bytes" in data
 
 
 def test_dashboard_endpoints(monkeypatch: MonkeyPatch) -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -103,6 +103,7 @@ else:
     spec_metrics.loader.exec_module(metrics_module)
 REQUEST_COUNT = metrics_module.REQUEST_COUNT
 REQUEST_LATENCY = metrics_module.REQUEST_LATENCY
+RECALL_LATENCY = metrics_module.RECALL_LATENCY
 RECALL_LATENCY_MS = metrics_module.RECALL_LATENCY_MS
 LEDGER_COMPACTED_BYTES = metrics_module.LEDGER_COMPACTED_BYTES
 
@@ -193,7 +194,7 @@ def _latency_counts() -> List[float]:
 def _recall_latency_counts() -> List[float]:
     return [
         s.value
-        for m in RECALL_LATENCY_MS.collect()
+        for m in RECALL_LATENCY.collect()
         for s in m.samples
         if s.name.endswith("_count")
     ]


### PR DESCRIPTION
## Summary
- expose new RECALL_LATENCY metric
- observe RECALL_LATENCY in recall endpoints
- include recall latency and ledger compact stats in metrics summary
- document metrics in MONITORING guide
- update tests for new metrics

## Testing
- `pre-commit run --files docs/MONITORING.md src/ume/metrics.py src/ume/metrics_routes.py src/ume/vector_routes.py tests/test_api.py tests/test_metrics.py`
- `poetry run pytest tests/test_metrics.py tests/test_api.py::test_metrics_summary tests/test_api.py::test_metrics_summary_with_rate_limit -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb0cecd108326b26c04615480e591