### PR TITLE
Ensure early abort when docker/npm missing

### DIFF
--- a/src/ume/cli/compose.py
+++ b/src/ume/cli/compose.py
@@ -17,25 +17,31 @@ ROOT_DIR = Path(__file__).resolve().parents[3]
 COMPOSE_FILE = ROOT_DIR / "docker" / "docker-compose.yml"
 
 
-def _require_docker() -> None:
-    """Exit with a message if Docker is not available."""
+def _require_docker(abort: bool = True) -> bool:
+    """Return ``True`` if Docker is available, optionally exiting if not."""
     if os.getenv("UME_SKIP_DOCKER_CHECK") == "1":
-        return
+        return True
     if shutil.which("docker") is None:
         print(
             "Docker is required to run the UME stack. "
             "Please install Docker and ensure it is on your PATH."
         )
-        raise SystemExit(1)
+        if abort:
+            raise SystemExit(1)
+        return False
+    return True
 
 
-def _require_npm() -> None:
-    """Exit with a message if npm (Node.js) is not available."""
+def _require_npm(abort: bool = True) -> bool:
+    """Return ``True`` if npm is available, optionally exiting if not."""
     if os.getenv("UME_SKIP_NPM_CHECK") == "1":
-        return
+        return True
     if shutil.which("npm") is None:
         print("npm is required to build the dashboard. Please install Node.js.")
-        raise SystemExit(1)
+        if abort:
+            raise SystemExit(1)
+        return False
+    return True
 
 
 def _compose_up(compose_file: Path = COMPOSE_FILE, timeout: int = 120) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -658,6 +658,64 @@ def test_cli_up_missing_node(monkeypatch: pytest.MonkeyPatch, capsys: pytest.Cap
     assert "npm is required" in out
 
 
+def test_cli_missing_docker_does_not_create_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure .env is not created when Docker is missing."""
+    import importlib
+    import ume_cli as cli
+    from ume.cli import compose
+
+    importlib.reload(cli)
+    importlib.reload(compose)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        compose.shutil,
+        "which",
+        lambda name: None if name == "docker" else "/usr/bin/" + name,
+    )
+    monkeypatch.delenv("UME_SKIP_DOCKER_CHECK", raising=False)
+    monkeypatch.delenv("UME_SKIP_NPM_CHECK", raising=False)
+
+    argv = sys.argv[:]
+    sys.argv = ["ume-cli", "up", "--no-confirm"]
+    with pytest.raises(SystemExit):
+        cli.main()
+    sys.argv = argv
+
+    assert not (tmp_path / ".env").exists()
+
+
+def test_cli_missing_node_does_not_create_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ensure .env is not created when npm is missing."""
+    import importlib
+    import ume_cli as cli
+    from ume.cli import compose
+
+    importlib.reload(cli)
+    importlib.reload(compose)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        compose.shutil,
+        "which",
+        lambda name: None if name == "npm" else "/usr/bin/" + name,
+    )
+    monkeypatch.delenv("UME_SKIP_DOCKER_CHECK", raising=False)
+    monkeypatch.delenv("UME_SKIP_NPM_CHECK", raising=False)
+
+    argv = sys.argv[:]
+    sys.argv = ["ume-cli", "up", "--no-confirm"]
+    with pytest.raises(SystemExit):
+        cli.main()
+    sys.argv = argv
+
+    assert not (tmp_path / ".env").exists()
+
+
 def test_subprocess_up_creates_env_and_checks_health(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- allow `_require_docker()` and `_require_npm()` to optionally return False instead of exiting
- add smoke tests to verify `.env` is not created when docker or npm executables are absent

## Testing
- `ruff check src/ume/cli/compose.py tests/test_cli_smoke.py`
- `pytest tests/test_cli_smoke.py::test_cli_up_missing_docker tests/test_cli_smoke.py::test_cli_up_missing_node tests/test_cli_smoke.py::test_cli_missing_docker_does_not_create_env tests/test_cli_smoke.py::test_cli_missing_node_does_not_create_env -q`

------
https://chatgpt.com/codex/tasks/task_e_6880271f4fac832693c8777a40adf871