### PR TITLE
Add builtin adapter registry

### DIFF
--- a/src/ume/integrations/__init__.py
+++ b/src/ume/integrations/__init__.py
@@ -7,7 +7,14 @@ from .memgpt import MemGPT, AsyncMemGPT
 from .supermemory import SuperMemory, AsyncSuperMemory
 from .crewai import CrewAI, AsyncCrewAI
 from .autogen import AutoGen, AsyncAutoGen
-from .registry import register_adapter, get_adapter, available_adapters
+from .registry import (
+    register_adapter,
+    get_adapter,
+    available_adapters,
+    register_builtin_adapters,
+)
+
+register_builtin_adapters()
 
 __all__ = [
     "LangGraph",
@@ -28,4 +35,5 @@ __all__ = [
     "register_adapter",
     "get_adapter",
     "available_adapters",
+    "register_builtin_adapters",
 ]

--- a/src/ume/integrations/autogen.py
+++ b/src/ume/integrations/autogen.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 
 from ume.integrations.base import BaseClient, AsyncBaseClient
-from .registry import register_adapter
 
 
 class AutoGen(BaseClient):
@@ -18,7 +17,4 @@ class AsyncAutoGen(AsyncBaseClient):
 
     def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
         super().__init__(base_url, api_key or os.getenv("AUTOGEN_UME_API_TOKEN"))
-
-
-register_adapter("autogen", AutoGen)
 

--- a/src/ume/integrations/crewai.py
+++ b/src/ume/integrations/crewai.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 
 from ume.integrations.base import BaseClient, AsyncBaseClient
-from .registry import register_adapter
 
 
 class CrewAI(BaseClient):
@@ -18,7 +17,4 @@ class AsyncCrewAI(AsyncBaseClient):
 
     def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
         super().__init__(base_url, api_key or os.getenv("CREWAI_UME_API_TOKEN"))
-
-
-register_adapter("crewai", CrewAI)
 

--- a/src/ume/integrations/langgraph.py
+++ b/src/ume/integrations/langgraph.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 
 from ume.integrations.base import BaseClient, AsyncBaseClient
-from .registry import register_adapter
 
 
 class LangGraph(BaseClient):
@@ -18,7 +17,4 @@ class AsyncLangGraph(AsyncBaseClient):
 
     def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
         super().__init__(base_url, api_key or os.getenv("LANGGRAPH_UME_API_TOKEN"))
-
-
-register_adapter("langgraph", LangGraph)
 

--- a/src/ume/integrations/letta.py
+++ b/src/ume/integrations/letta.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 
 from ume.integrations.base import BaseClient, AsyncBaseClient
-from .registry import register_adapter
 
 
 class Letta(BaseClient):
@@ -18,7 +17,4 @@ class AsyncLetta(AsyncBaseClient):
 
     def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
         super().__init__(base_url, api_key or os.getenv("LETTA_UME_API_TOKEN"))
-
-
-register_adapter("letta", Letta)
 

--- a/src/ume/integrations/memgpt.py
+++ b/src/ume/integrations/memgpt.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 
 from ume.integrations.base import BaseClient, AsyncBaseClient
-from .registry import register_adapter
 
 
 class MemGPT(BaseClient):
@@ -18,7 +17,4 @@ class AsyncMemGPT(AsyncBaseClient):
 
     def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
         super().__init__(base_url, api_key or os.getenv("MEMGPT_UME_API_TOKEN"))
-
-
-register_adapter("memgpt", MemGPT)
 

--- a/src/ume/integrations/registry.py
+++ b/src/ume/integrations/registry.py
@@ -21,3 +21,20 @@ def get_adapter(name: str) -> type:
 def available_adapters() -> Iterable[str]:
     """Return names of all registered adapters."""
     return list(_ADAPTERS.keys())
+
+
+def register_builtin_adapters() -> None:
+    """Register adapters for built-in integrations."""
+    from .langgraph import LangGraph
+    from .letta import Letta
+    from .memgpt import MemGPT
+    from .supermemory import SuperMemory
+    from .crewai import CrewAI
+    from .autogen import AutoGen
+
+    register_adapter("langgraph", LangGraph)
+    register_adapter("letta", Letta)
+    register_adapter("memgpt", MemGPT)
+    register_adapter("supermemory", SuperMemory)
+    register_adapter("crewai", CrewAI)
+    register_adapter("autogen", AutoGen)

--- a/src/ume/integrations/supermemory.py
+++ b/src/ume/integrations/supermemory.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 
 from ume.integrations.base import BaseClient, AsyncBaseClient
-from .registry import register_adapter
 
 
 class SuperMemory(BaseClient):
@@ -18,7 +17,4 @@ class AsyncSuperMemory(AsyncBaseClient):
 
     def __init__(self, base_url: str = "http://localhost:8000", api_key: str | None = None) -> None:
         super().__init__(base_url, api_key or os.getenv("SUPERMEMORY_UME_API_TOKEN"))
-
-
-register_adapter("supermemory", SuperMemory)
 

--- a/tests/test_integration_registry.py
+++ b/tests/test_integration_registry.py
@@ -1,4 +1,8 @@
-from ume.integrations.registry import register_adapter, get_adapter
+from ume.integrations.registry import (
+    register_adapter,
+    get_adapter,
+    register_builtin_adapters,
+)
 from ume.integrations.langgraph import LangGraph
 
 
@@ -12,4 +16,9 @@ def test_register_and_retrieve() -> None:
 
 
 def test_builtin_registered() -> None:
+    assert get_adapter("langgraph") is LangGraph
+
+
+def test_register_builtin_function() -> None:
+    register_builtin_adapters()
     assert get_adapter("langgraph") is LangGraph


### PR DESCRIPTION
## Summary
- centralize builtin adapter registration
- invoke builtin registration on package import
- adjust integration registry tests for new function

## Testing
- `ruff check src/ume/integrations/registry.py src/ume/integrations/__init__.py src/ume/integrations/langgraph.py src/ume/integrations/letta.py src/ume/integrations/memgpt.py src/ume/integrations/crewai.py src/ume/integrations/autogen.py src/ume/integrations/supermemory.py tests/test_integration_registry.py`
- `pytest tests/test_integration_registry.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68802cd19dd48326916a101790e56eb1