### PR TITLE
Add monitoring services to compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -86,6 +86,24 @@ services:
       timeout: 5s
       retries: 5
 
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana
+    depends_on:
+      prometheus:
+        condition: service_started
+    volumes:
+      - ./grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ../docs/grafana/ume_dashboard.json:/var/lib/grafana/dashboards/ume_dashboard.json:ro
+    ports:
+      - "3000:3000"
+
 volumes:
   ume-db:
   neo4j-data:

--- a/docker/grafana/dashboards.yml
+++ b/docker/grafana/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: 'ume'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'ume'
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['ume-api:8000']

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -20,7 +20,10 @@ scrape_configs:
 
 ## Docker Compose Example
 
-The following compose file runs UME, Prometheus and Grafana:
+The repository `docker/docker-compose.yml` now includes optional Prometheus and
+Grafana services. The Grafana service mounts
+`docs/grafana/ume_dashboard.json` so the default dashboard is available out of
+the box. An abbreviated example stack looks like:
 
 ```yaml
 version: '3'
@@ -37,6 +40,9 @@ services:
       - "9090:9090"
   grafana:
     image: grafana/grafana
+    volumes:
+      - ./grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+      - ../docs/grafana/ume_dashboard.json:/var/lib/grafana/dashboards/ume_dashboard.json:ro
     ports:
       - "3000:3000"
 ```

--- a/tests/compose/test_monitoring_services.py
+++ b/tests/compose/test_monitoring_services.py
@@ -1,0 +1,14 @@
+import subprocess
+from pathlib import Path
+
+
+def test_compose_includes_monitoring_services() -> None:
+    compose_file = Path("docker/docker-compose.yml")
+    out = subprocess.check_output([
+        "docker-compose",
+        "-f",
+        str(compose_file),
+        "config",
+    ], text=True)
+    assert "prometheus:" in out
+    assert "grafana:" in out


### PR DESCRIPTION
## Summary
- add prometheus and grafana containers to docker compose
- auto-provision dashboard for grafana
- document monitoring stack
- check monitoring services via docker compose config

## Testing
- `pre-commit run --files docker/docker-compose.yml docker/grafana/dashboards.yml docker/prometheus.yml docs/MONITORING.md tests/compose/test_monitoring_services.py`
- `pytest tests/compose/test_monitoring_services.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68802cd2fba48326b0b199b36f68e91e