### PR TITLE
Expose latency and compaction metrics

### DIFF
--- a/docs/grafana/ume_dashboard.json
+++ b/docs/grafana/ume_dashboard.json
@@ -13,14 +13,14 @@
     },
     {
       "type": "timeseries",
-      "title": "Recall Latency",
+      "title": "Recall Latency (ms)",
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [{"expr": "rate(ume_recall_latency_ms_sum[5m]) / rate(ume_recall_latency_ms_count[5m])"}],
       "id": 2
     },
     {
       "type": "timeseries",
-      "title": "Compaction Bytes",
+      "title": "Ledger Compacted Bytes",
       "datasource": {"type": "prometheus", "uid": "prometheus"},
       "targets": [{"expr": "ume_ledger_compacted_bytes"}],
       "id": 3

--- a/src/ume/metrics.py
+++ b/src/ume/metrics.py
@@ -61,3 +61,18 @@ LEDGER_COMPACTED_BYTES = Gauge(
     "ume_ledger_compacted_bytes",
     "Bytes removed during the most recent ledger compaction",
 )
+
+__all__ = [
+    "REQUEST_COUNT",
+    "REQUEST_LATENCY",
+    "VECTOR_QUERY_LATENCY",
+    "VECTOR_INDEX_SIZE",
+    "STALE_VECTOR_WARNINGS",
+    "STALE_VECTOR_COUNT",
+    "RECALL_SCORE",
+    "RESPONSE_CONFIDENCE",
+    "FALSE_TEXT_RATE",
+    "RECALL_LATENCY",
+    "RECALL_LATENCY_MS",
+    "LEDGER_COMPACTED_BYTES",
+]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -200,6 +200,15 @@ def _recall_latency_counts() -> List[float]:
     ]
 
 
+def _recall_latency_ms_counts() -> List[float]:
+    return [
+        s.value
+        for m in RECALL_LATENCY_MS.collect()
+        for s in m.samples
+        if s.name.endswith("_count")
+    ]
+
+
 def _ledger_compacted_bytes() -> float:
     for m in LEDGER_COMPACTED_BYTES.collect():
         for s in m.samples:
@@ -240,6 +249,28 @@ def test_recall_latency_metric_recorded(tmp_path) -> None:
         headers={"Authorization": f"Bearer {tok}"},
     )
     assert sum(_recall_latency_counts()) > 0
+
+
+def test_recall_metrics_exposed_via_endpoint(tmp_path) -> None:
+    configure_graph(MockGraph())
+    configure_vector_store(DummyVectorStore(dim=2))
+    app.state.vector_store = DummyVectorStore(dim=2)
+    app.state.graph = MockGraph()
+    client = TestClient(app)
+    tok = _token(client)
+    store = app.state.vector_store
+    store.add("n1", [0.0, 1.0])
+    app.state.graph.get_node = lambda _id: {"embedding": [0.0, 1.0]}
+    before_sec = sum(_recall_latency_counts())
+    before_ms = sum(_recall_latency_ms_counts())
+    client.get(
+        "/recall",
+        params=[("vector", 0.0), ("vector", 1.0)],
+        headers={"Authorization": f"Bearer {tok}"},
+    )
+    client.get("/metrics", headers={"Authorization": f"Bearer {tok}"})
+    assert sum(_recall_latency_counts()) > before_sec
+    assert sum(_recall_latency_ms_counts()) > before_ms
 
 
 def test_ledger_compacted_bytes_metric_recorded() -> None:


### PR DESCRIPTION
## Summary
- export RECALL_LATENCY_MS and LEDGER_COMPACTED_BYTES
- surface panels for the new metrics in Grafana dashboard
- check recall metrics via `/metrics` in tests

## Testing
- `pre-commit run --files src/ume/metrics.py tests/test_metrics.py docs/grafana/ume_dashboard.json`
- `pytest tests/test_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688030e6f620832684dcd447a07feef8