### PR TITLE
Add send_events demo notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,10 +479,14 @@ See [`examples/langgraph_example.py`](examples/langgraph_example.py) and
   `LangGraph.recall()`.
 - [LangGraph workflow](examples/langgraph_workflow.ipynb) – end-to-end example
   showing event creation and recall with `LangGraph`.
+- [LangGraph `send_events` demo](examples/langgraph_send_events.ipynb) – simple
+  example showing `send_events()` and `recall()`.
 - [Letta integration](examples/letta_integration.ipynb) – send Letta flow events
   with `Letta.send_events()` and recall results via `Letta.recall()`.
 - [Letta workflow](examples/letta_workflow.ipynb) – complete flow using
   `Letta` to store and recall nodes.
+- [Letta `send_events` demo](examples/letta_send_events.ipynb) – minimal
+  demonstration of `send_events()` and `recall()`.
 - [MemGPT integration](examples/memgpt_integration.ipynb) – write memory events
   through `MemGPT.send_events()` and access them with `MemGPT.recall()`.
 - [CrewAI integration](examples/crewai_integration.ipynb) – forward CrewAI

--- a/examples/langgraph_send_events.ipynb
+++ b/examples/langgraph_send_events.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dbb61b24",
+   "metadata": {},
+   "source": [
+    "# LangGraph send_events demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9f39465",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ume.integrations import LangGraph\n",
+    "client = LangGraph()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "99fb98d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.send_events([{\"event_type\": \"CREATE_NODE\", \"timestamp\": 1, \"node_id\": \"n1\"}])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cc59fcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.recall({\"node_id\": \"n1\"})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/letta_send_events.ipynb
+++ b/examples/letta_send_events.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3dda5360",
+   "metadata": {},
+   "source": [
+    "# Letta send_events demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbd26eb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ume.integrations import Letta\n",
+    "client = Letta()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2843721e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.send_events([{\"event_type\": \"CREATE_NODE\", \"timestamp\": 1, \"node_id\": \"n1\"}])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bdbabe5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.recall({\"node_id\": \"n1\"})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+import pytest
+
+nbformat = pytest.importorskip("nbformat")
+ExecutePreprocessor = pytest.importorskip(
+    "nbconvert.preprocessors"
+).ExecutePreprocessor
+
+NOTEBOOKS = [
+    Path('examples/langgraph_send_events.ipynb'),
+    Path('examples/letta_send_events.ipynb'),
+]
+
+@pytest.mark.parametrize('nb_path', NOTEBOOKS)
+def test_example_notebooks(nb_path):
+    with nb_path.open() as f:
+        nb = nbformat.read(f, as_version=4)
+    root = Path(__file__).resolve().parents[1]
+    setup = nbformat.v4.new_code_cell(
+        "import sys, pathlib\n"
+        "sys.path.insert(0, str(pathlib.Path('" + str(root / 'src') + "')))")
+    stub = nbformat.v4.new_code_cell(
+        "import types, sys\n"
+        "class _Resp:\n"
+        "    def raise_for_status(self):\n"
+        "        pass\n"
+        "    def json(self):\n"
+        "        return {}\n"
+        "    def iter_lines(self):\n"
+        "        return []\n"
+        "class _Client:\n"
+        "    def __init__(self, *a, **k):\n"
+        "        pass\n"
+        "    def post(self, *a, **k):\n"
+        "        return _Resp()\n"
+        "    def get(self, *a, **k):\n"
+        "        return _Resp()\n"
+        "sys.modules['httpx'] = types.SimpleNamespace(Client=_Client, HTTPError=Exception)\n"
+        "yaml_stub = types.ModuleType('yaml')\n"
+        "yaml_stub.safe_load = lambda _ : {}\n"
+        "sys.modules.setdefault('yaml', yaml_stub)\n"
+        "prom_stub = types.ModuleType('prometheus_client')\n"
+        "class _D:\n"
+        "    def __init__(self, *a, **k):\n"
+        "        self.v=0\n"
+        "    def inc(self, amount=1):\n"
+        "        self.v+=amount\n"
+        "    def labels(self, *a, **k):\n"
+        "        return self\n"
+        "prom_stub.Counter = _D\n"
+        "prom_stub.Histogram = _D\n"
+        "prom_stub.Gauge = _D\n"
+        "sys.modules.setdefault('prometheus_client', prom_stub)\n"
+        "numpy_stub = types.ModuleType('numpy')\n"
+        "numpy_stub.asarray = lambda x, dtype=None: list(x)\n"
+        "sys.modules.setdefault('numpy', numpy_stub)\n"
+        "numpy_typing = types.ModuleType('numpy.typing')\n"
+        "numpy_typing.NDArray = list\n"
+        "sys.modules.setdefault('numpy.typing', numpy_typing)\n"
+    )
+    nb.cells.insert(0, stub)
+    nb.cells.insert(0, setup)
+    ep = ExecutePreprocessor(timeout=600, kernel_name='python3')
+    ep.preprocess(nb, {'metadata': {'path': str(root)}})


### PR DESCRIPTION
## Summary
- add LangGraph and Letta send_events notebooks
- reference the new notebooks in the README
- test notebooks run with nbconvert

## Testing
- `ruff check tests/test_notebooks.py`
- `pytest tests/test_notebooks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688030e5bd2883269b96cb9ad8429e91