### PR TITLE
Add dossier CLI and endpoints

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -167,6 +167,24 @@ curl -X GET -H "Authorization: Bearer <token>" \
   'http://localhost:8000/recall?vector=0.1&vector=0.2&k=2'
 ```
 
+### GET `/dossier/{dossier_id}`
+View details for a dossier.
+
+```bash
+curl -X GET -H "Authorization: Bearer <token>" \
+  http://localhost:8000/dossier/example
+```
+
+### POST `/dossier/add-project`
+Attach a project to a dossier.
+
+```bash
+curl -X POST http://localhost:8000/dossier/add-project \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"dossier_id":"example","project_id":"p1"}'
+```
+
 ## API Documentation
 
 To explore the API interactively, run the FastAPI server and open the Swagger UI:

--- a/mypy.ini
+++ b/mypy.ini
@@ -52,6 +52,9 @@ ignore_errors = True
 [mypy-ume.snapshot_routes]
 ignore_errors = True
 
+[mypy-ume.dossier_routes]
+ignore_errors = True
+
 [mypy-ume.ledger_routes]
 ignore_errors = True
 

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -48,6 +48,7 @@ from .recommendations_routes import router as recommendations_router
 from .feedback_routes import router as feedback_router
 from .snapshot_routes import router as snapshot_router
 from .ledger_routes import router as ledger_router
+from .dossier_routes import router as dossier_router
 from .consent_ledger import consent_ledger  # noqa: F401
 
 from . import api_deps
@@ -91,6 +92,7 @@ app.include_router(recommendations_router)
 app.include_router(feedback_router)
 app.include_router(snapshot_router)
 app.include_router(ledger_router)
+app.include_router(dossier_router)
 
 
 

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Dict, cast
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from . import api_deps as deps
+
+router = APIRouter(prefix="/dossier")
+
+# In-memory storage for dossier information
+_dossiers: Dict[str, Dict[str, object]] = {}
+
+
+class AddProjectRequest(BaseModel):
+    dossier_id: str
+    project_id: str
+
+
+@router.get("/{dossier_id}")
+def view_dossier(dossier_id: str, role: str = Depends(deps.get_current_role)) -> Dict[str, object]:
+    """Return information about ``dossier_id`` if the user has access."""
+    if role not in {"ProjectManager", "Viewer"}:
+        raise HTTPException(status_code=403, detail="Not authorized")
+    dossier = _dossiers.get(dossier_id)
+    if dossier is None:
+        raise HTTPException(status_code=404, detail="Dossier not found")
+    return dossier
+
+
+@router.post("/add-project")
+def add_project(req: AddProjectRequest, role: str = Depends(deps.get_current_role)) -> Dict[str, object]:
+    """Attach ``project_id`` to the specified dossier."""
+    if role != "ProjectManager":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    dossier = _dossiers.setdefault(req.dossier_id, {"dossier_id": req.dossier_id, "projects": []})
+    projects = dossier.setdefault("projects", [])
+    if req.project_id not in projects:
+        projects.append(req.project_id)
+    return cast(Dict[str, object], dossier)
+

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -1,0 +1,53 @@
+from fastapi.testclient import TestClient
+
+from ume.api import app
+from ume.config import settings
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return str(res.json()["access_token"])
+
+
+def test_add_and_view_dossier(monkeypatch):
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "ProjectManager", raising=False)
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    res = client.post(
+        "/dossier/add-project",
+        json={"dossier_id": "d1", "project_id": "p1"},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    assert "p1" in res.json()["projects"]
+
+    res = client.get("/dossier/d1", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["projects"] == ["p1"]
+
+
+def test_add_project_forbidden(monkeypatch):
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "Viewer", raising=False)
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    res = client.post(
+        "/dossier/add-project",
+        json={"dossier_id": "d2", "project_id": "p2"},
+        headers=headers,
+    )
+    assert res.status_code == 403
+
+
+def test_view_missing(monkeypatch):
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "ProjectManager", raising=False)
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    res = client.get("/dossier/unknown", headers=headers)
+    assert res.status_code == 404
+

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -6,6 +6,8 @@ import os
 import sys
 import warnings
 from pathlib import Path
+import json
+import httpx
 
 # Ensure local package import when run directly without installation
 _src_path = Path(__file__).resolve().parent / "src"
@@ -58,6 +60,35 @@ def _snapshot_schedule(interval: int) -> None:
         print("Snapshot scheduler stopped.")
 
 
+def _dossier_view(dossier_id: str) -> None:
+    """Fetch and display dossier details from the running API."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    try:
+        resp = httpx.get(f"{base_url}/dossier/{dossier_id}", headers=headers, timeout=5)
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
+def _dossier_add_project(dossier_id: str, project_id: str) -> None:
+    """Send a request to add a project to a dossier."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    payload = {"dossier_id": dossier_id, "project_id": project_id}
+    try:
+        resp = httpx.post(f"{base_url}/dossier/add-project", json=payload, headers=headers, timeout=5)
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
 def main() -> None:
     """Entry point for the ``ume-cli`` console script."""
     parser = argparse.ArgumentParser(description="UME CLI")
@@ -87,6 +118,14 @@ def main() -> None:
         help="Periodically snapshot the graph",
     )
     snap_parser.add_argument("--interval", type=int, default=60)
+
+    dossier_parser = sub.add_parser("dossier", help="Manage dossiers")
+    dossier_sub = dossier_parser.add_subparsers(dest="dossier_cmd")
+    view_p = dossier_sub.add_parser("view", help="View a dossier")
+    view_p.add_argument("dossier_id")
+    add_p = dossier_sub.add_parser("add-project", help="Add a project to a dossier")
+    add_p.add_argument("dossier_id")
+    add_p.add_argument("project_id")
     for p in (up_parser, quick_parser):
         p.add_argument(
             "--no-confirm",
@@ -116,6 +155,12 @@ def main() -> None:
             return
         if args.command == "snapshot-schedule":
             _snapshot_schedule(args.interval)
+            return
+        if args.command == "dossier":
+            if args.dossier_cmd == "view":
+                _dossier_view(args.dossier_id)
+            elif args.dossier_cmd == "add-project":
+                _dossier_add_project(args.dossier_id, args.project_id)
             return
 
         configure_logging()


### PR DESCRIPTION
## Summary
- add `/dossier` router with RBAC checks
- integrate dossier router into API app
- add CLI helpers `dossier view` and `dossier add-project`
- document new endpoints
- include tests and mypy config

## Testing
- `pre-commit run --files ume_cli.py src/ume/dossier_routes.py src/ume/api.py docs/API_REFERENCE.md tests/test_api_dossier.py mypy.ini`
- `pytest tests/test_api_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e2e2a62c83269e7c54ff96dc5a35