### PR TITLE
Add Dossier overview docs and config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ The resulting `.env` will contain values similar to:
 UME_AUDIT_SIGNING_KEY=<randomly-generated-key>
 UME_OAUTH_PASSWORD=<randomly-generated-password>
 ```
+To encrypt the audit log and ledger files, set `UME_ENCRYPTION_ENABLED=true` and provide a base64 key via `UME_ENCRYPTION_KEY`.
+
 
 See [`docs/CONFIG_TEMPLATES.md`](docs/CONFIG_TEMPLATES.md) for the full list of
 environment variables.
@@ -882,6 +884,7 @@ Pass `--show-warnings` to display Python warnings or `--warnings-log <file>` to
 log them for debugging.
 
 You can set `UME_CLI_DB` to override where the CLI stores its SQLite database.
+You can set `UME_DOSSIER_PATH` to change where the YAML dossier files are stored (default `~/.ume_dossier`).
 If you define `UME_ROLE`, the CLI will run with that role's permissions and
 display an informational message at startup.
 

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -76,6 +76,7 @@ Valid values for `UME_GRAPH_BACKEND` are:
 | `UME_AGENT_ID` | `SYSTEM` | Identifier recorded in audit logs. |
 | `UME_EMBED_MODEL` | `all-MiniLM-L6-v2` | SentenceTransformer model name. |
 | `UME_CLI_DB` | `ume_graph.db` | Database path used by the CLI. |
+| `UME_DOSSIER_PATH` | `~/.ume_dossier` | Directory containing YAML files for the user dossier. |
 | `UME_ROLE` | *(unset)* | Optional role for the CLI. |
 | `UME_API_ROLE` | *(unset)* | Optional role applied by the API server. |
 | `UME_RATE_LIMIT_REDIS` | *(unset)* | Redis URL for API rate limiting. |

--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -1,0 +1,44 @@
+# Dossier Overview
+
+The user dossier is a lightweight collection of YAML files that track basic profile information and notes. UME loads the dossier from the directory specified by `UME_DOSSIER_PATH` (defaults to `~/.ume_dossier`). The directory is created automatically when missing.
+
+## File Structure
+
+A newly initialized dossier contains:
+
+- `meta.yaml` – schema version metadata
+- `profile.yaml` – basic user details (name, email)
+- `projects.yaml` – list of active projects
+- `preferences.yaml` – arbitrary key/value settings
+- `reflections.yaml` – journal style reflections
+- `telemetry/` – directory for captured traces
+
+You can create the folder manually or call `Dossier.init_dossier(path)` from Python to copy the template files.
+
+## Security Practices
+
+Dossier API routes enforce role-based access. `ProjectManager` can add projects while `Viewer` may only read.
+To secure audit logs and ledger files, enable encryption by setting `UME_ENCRYPTION_ENABLED=true` and defining a base64 key in `UME_ENCRYPTION_KEY`.
+
+## CLI Examples
+
+```bash
+# View a dossier using the running API
+ume dossier view user123
+
+# Attach a project to a dossier
+ume dossier add-project user123 projectA
+```
+
+## API Examples
+
+```bash
+# Fetch dossier details
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/dossier/user123
+
+# Add a project
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"dossier_id":"user123","project_id":"projectA"}' \
+  http://localhost:8000/dossier/add-project
+```


### PR DESCRIPTION
## Summary
- document dossier usage in `docs/DOSSIER_OVERVIEW.md`
- describe encryption settings in README
- add `UME_DOSSIER_PATH` to README and config templates

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6880f2313c2c8326a44d3e1c6d19f522