### PR TITLE
Add scheduler and watcher runtime tests

### DIFF
--- a/tests/test_memory_aging.py
+++ b/tests/test_memory_aging.py
@@ -3,9 +3,15 @@ from ume.memory import EpisodicMemory, SemanticMemory, ColdMemory
 from ume.config import settings
 from ume.metrics import STALE_VECTOR_WARNINGS
 from ume.memory.tiered import TieredMemoryManager
-from ume.memory_aging import start_memory_aging_scheduler, stop_memory_aging_scheduler
+from ume.memory_aging import (
+    start_memory_aging_scheduler,
+    stop_memory_aging_scheduler,
+    start_vector_age_scheduler,
+    stop_vector_age_scheduler,
+)
 
 import itertools
+import types
 
 import threading
 
@@ -340,3 +346,49 @@ def test_aging_scheduler_prunes_and_audits_vectors(monkeypatch: pytest.MonkeyPat
     assert not episodic.graph.node_exists("old")
     assert semantic.get_fact("old") == {"text": "hi"}
     assert store.query([0.0, 1.0], k=1) == []
+
+
+def test_start_memory_aging_scheduler_moves_events() -> None:
+    """Scheduler migrates aged events and stops cleanly."""
+    episodic = EpisodicMemory(db_path=":memory:")
+    semantic = SemanticMemory(db_path=":memory:")
+    episodic.graph.add_node("e1", {"text": "hi"})
+    old_ts = int(time.time()) - 10
+    with episodic.graph.conn:
+        episodic.graph.conn.execute(
+            "UPDATE nodes SET created_at=? WHERE id='e1'", (old_ts,)
+        )
+
+    start_memory_aging_scheduler(
+        episodic,
+        semantic,
+        cold=None,
+        event_age_seconds=0,
+        cold_age_seconds=None,
+        vector_age_seconds=None,
+        interval_seconds=0.01,
+        vector_check_interval=0.01,
+    )
+
+    time.sleep(0.02)
+    stop_memory_aging_scheduler()
+
+    assert not episodic.graph.node_exists("e1")
+    assert semantic.get_fact("e1") == {"text": "hi"}
+
+
+def test_start_vector_age_scheduler_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Vector age scheduler updates metrics and stops."""
+    now = int(time.time())
+    store = types.SimpleNamespace(get_vector_timestamps=lambda: {"old": now - 100})
+
+    monkeypatch.setattr(settings, "UME_VECTOR_MAX_AGE_DAYS", 0)
+    STALE_VECTOR_WARNINGS._value.set(0)  # type: ignore[attr-defined]
+
+    thread, stop = start_vector_age_scheduler(store, interval_seconds=0.01)
+    threading.Event().wait(0.05)
+    stop()
+    stop_vector_age_scheduler()
+
+    assert not thread.is_alive()
+    assert STALE_VECTOR_WARNINGS._value.get() > 0  # type: ignore[attr-defined]

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -35,3 +35,48 @@ def test_on_modified_logs_error(tmp_path, monkeypatch: pytest.MonkeyPatch, caplo
     handler.on_modified(event)
 
     assert any("Failed to produce dev log event" in rec.message for rec in caplog.records)
+
+
+def test_run_watcher_runtime_cleanup(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Watcher stops and flushes after short runtime."""
+    dev_log_watcher = load_dev_log_watcher(monkeypatch)
+
+    class Producer:
+        def __init__(self) -> None:
+            self.flush_calls = 0
+
+        def produce(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def flush(self) -> None:
+            self.flush_calls += 1
+
+    class DummyObserver:
+        def __init__(self) -> None:
+            self.stop_calls = 0
+            self.join_calls = 0
+            self.scheduled: list[str] = []
+
+        def schedule(self, handler: dev_log_watcher.DevLogHandler, path: str, recursive: bool = True) -> None:
+            self.scheduled.append(path)
+
+        def start(self) -> None:  # pragma: no cover - not used
+            pass
+
+        def join(self) -> None:
+            self.join_calls += 1
+
+        def stop(self) -> None:
+            self.stop_calls += 1
+
+    producer = Producer()
+    observer = DummyObserver()
+    monkeypatch.setattr(dev_log_watcher, "Producer", lambda *_, **__: producer)
+    monkeypatch.setattr(dev_log_watcher, "Observer", lambda: observer)
+
+    dev_log_watcher.run_watcher([str(tmp_path)], runtime=0)
+
+    assert producer.flush_calls == 1
+    assert observer.stop_calls == 1
+    assert observer.join_calls >= 1
+    assert observer.scheduled == [str(tmp_path)]


### PR DESCRIPTION
## Summary
- test watcher cleanup when runtime expires
- cover memory and vector aging scheduler behaviour

## Testing
- `ruff check .`
- `pytest tests/test_watchers.py::test_run_watcher_runtime_cleanup tests/test_memory_aging.py::test_start_memory_aging_scheduler_moves_events tests/test_memory_aging.py::test_start_vector_age_scheduler_runs -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f22fa9308326867a7a8b9bd56735