### PR TITLE
Add policy helpers and dossier metadata

### DIFF
--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -74,3 +74,26 @@ setting `UME_ENCRYPTION_ENABLED` to `True` and provide a base64 encoded key via
 `UME_ENCRYPTION_KEY`. Existing plaintext files must be re-encrypted or replaced.
 The simplest migration is to archive the old files and let UME create new,
 encrypted ones on startup.
+
+## Sample Rego Rules
+
+The following snippet demonstrates how dossier permissions could be expressed in Rego.
+
+```rego
+package ume.dossier
+
+# Allow reading projects if the dossier is shareable or the caller has a valid role
+default can_read_projects = false
+
+can_read_projects {
+    input.metadata.shareable
+}
+
+can_read_projects {
+    input.role == "ProjectManager"
+}
+
+can_modify_telemetry {
+    input.role == "TelemetryAdmin"
+}
+```

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -16,6 +16,7 @@ class Dossier:
 
     root: Path
     schema_version: int = 1
+    shareable: bool = False
     profile: dict[str, Any] = field(default_factory=dict)
     projects: list[dict[str, Any]] = field(default_factory=list)
     preferences: dict[str, Any] = field(default_factory=dict)
@@ -44,7 +45,10 @@ class Dossier:
     def save(self) -> None:
         """Persist current state to disk."""
         self.root.mkdir(parents=True, exist_ok=True)
-        yaml.safe_dump({"schema_version": self.schema_version}, (self.root / "meta.yaml").open("w", encoding="utf-8"))
+        yaml.safe_dump(
+            {"schema_version": self.schema_version, "shareable": self.shareable},
+            (self.root / "meta.yaml").open("w", encoding="utf-8"),
+        )
         yaml.safe_dump(self.profile, (self.root / "profile.yaml").open("w", encoding="utf-8"))
         yaml.safe_dump({"projects": self.projects}, (self.root / "projects.yaml").open("w", encoding="utf-8"))
         yaml.safe_dump(self.preferences, (self.root / "preferences.yaml").open("w", encoding="utf-8"))
@@ -56,6 +60,7 @@ class Dossier:
     def _load_files(self) -> None:
         meta = self._read_yaml(self.root / "meta.yaml") or {}
         self.schema_version = int(meta.get("schema_version", self.schema_version))
+        self.shareable = bool(meta.get("shareable", self.shareable))
         self.profile = self._read_yaml(self.root / "profile.yaml") or {}
         proj = self._read_yaml(self.root / "projects.yaml") or {}
         if isinstance(proj, dict):

--- a/src/ume/dossier/dossier_template/meta.yaml
+++ b/src/ume/dossier/dossier_template/meta.yaml
@@ -1,1 +1,2 @@
 schema_version: 1
+shareable: false

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from . import api_deps as deps
+from .policy import can_read_projects
 
 router = APIRouter(prefix="/dossier")
 
@@ -21,11 +22,11 @@ class AddProjectRequest(BaseModel):
 @router.get("/{dossier_id}")
 def view_dossier(dossier_id: str, role: str = Depends(deps.get_current_role)) -> Dict[str, object]:
     """Return information about ``dossier_id`` if the user has access."""
-    if role not in {"ProjectManager", "Viewer"}:
-        raise HTTPException(status_code=403, detail="Not authorized")
     dossier = _dossiers.get(dossier_id)
     if dossier is None:
         raise HTTPException(status_code=404, detail="Dossier not found")
+    if not can_read_projects(role, bool(dossier.get("shareable"))):
+        raise HTTPException(status_code=403, detail="Not authorized")
     return dossier
 
 
@@ -34,7 +35,10 @@ def add_project(req: AddProjectRequest, role: str = Depends(deps.get_current_rol
     """Attach ``project_id`` to the specified dossier."""
     if role != "ProjectManager":
         raise HTTPException(status_code=403, detail="Not authorized")
-    dossier = _dossiers.setdefault(req.dossier_id, {"dossier_id": req.dossier_id, "projects": []})
+    dossier = _dossiers.setdefault(
+        req.dossier_id,
+        {"dossier_id": req.dossier_id, "projects": [], "shareable": False},
+    )
     projects = dossier.setdefault("projects", [])
     if req.project_id not in projects:
         projects.append(req.project_id)

--- a/src/ume/policy/__init__.py
+++ b/src/ume/policy/__init__.py
@@ -1,6 +1,11 @@
 """Policy definitions and utilities for UME access control."""
 
 from .api_client import PolicyAPI
+from .rules import can_modify_telemetry, can_read_projects
 
-__all__ = ["PolicyAPI"]
+__all__ = [
+    "PolicyAPI",
+    "can_read_projects",
+    "can_modify_telemetry",
+]
 

--- a/src/ume/policy/rules.py
+++ b/src/ume/policy/rules.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+"""Simple role-based policy helpers."""
+
+
+def can_read_projects(role: str, shareable: bool = False) -> bool:
+    """Return ``True`` if ``role`` may view dossier projects."""
+    if shareable:
+        return True
+    return role in {"ProjectManager", "Viewer"}
+
+
+def can_modify_telemetry(role: str) -> bool:
+    """Return ``True`` if ``role`` may update telemetry data."""
+    return role == "TelemetryAdmin"

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -9,6 +9,7 @@ from ume.dossier import (
 def test_dossier_init_and_helpers(tmp_path):
     dossier = Dossier.init_dossier(tmp_path)
     assert dossier.schema_version == Dossier.schema_version
+    assert dossier.shareable is False
 
     dossier.projects.append({"name": "demo"})
     dossier.save()
@@ -16,10 +17,14 @@ def test_dossier_init_and_helpers(tmp_path):
     add_reflection(dossier, "thinking")
     update_preferences(dossier, theme="dark")
 
+    dossier.shareable = True
+    dossier.save()
+
     reloaded = Dossier.load(tmp_path)
     assert list_projects(reloaded) == ["demo"]
     assert reloaded.preferences["theme"] == "dark"
     assert reloaded.reflections[0]["text"] == "thinking"
+    assert reloaded.shareable is True
 
 
 def test_dossier_env_load(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `can_read_projects` and `can_modify_telemetry` helpers
- store policy metadata like `shareable` in dossier
- enforce project viewing permissions in dossier API
- document sample Rego rules
- update dossier tests

## Testing
- `ruff check .`
- `pytest tests/test_dossier.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6880f22b00e0832691983b54a22cf1cb