### PR TITLE
Add dossier activity hook for watchers

### DIFF
--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+import json
 
 import yaml
 
@@ -64,6 +65,16 @@ class Dossier:
             self.projects = proj
         self.preferences = self._read_yaml(self.root / "preferences.yaml") or {}
         self.reflections = self._read_yaml(self.root / "reflections.yaml") or []
+
+    def add_activity(self, payload: dict[str, Any]) -> None:
+        """Append ``payload`` to ``telemetry/activity.log`` if allowed."""
+        if not self.preferences.get("record_activity", True):
+            return
+        log_path = self.root / "telemetry" / "activity.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        entry = {"timestamp": datetime.utcnow().isoformat(), "payload": payload}
+        with log_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
 
     @staticmethod
     def _read_yaml(path: Path) -> Any:

--- a/src/ume/watchers/__init__.py
+++ b/src/ume/watchers/__init__.py
@@ -1,2 +1,15 @@
 """Filesystem and configuration change watchers."""
 
+from .hooks import register_hook, unregister_hook, WatcherHook, notify_hooks
+from .dossier_hook import dossier_activity_hook
+
+# Automatically record watcher activity in the user's dossier
+register_hook(dossier_activity_hook)
+
+__all__ = [
+    "register_hook",
+    "unregister_hook",
+    "notify_hooks",
+    "WatcherHook",
+]
+

--- a/src/ume/watchers/dev_log_watcher.py
+++ b/src/ume/watchers/dev_log_watcher.py
@@ -15,6 +15,7 @@ from confluent_kafka import Producer, KafkaException
 
 from ume.config import settings
 from ume.event import Event, EventType
+from .hooks import notify_hooks
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,7 @@ class DevLogHandler(FileSystemEventHandler):  # type: ignore[misc]
                 settings.KAFKA_RAW_EVENTS_TOPIC,
                 json.dumps(data).encode("utf-8"),
             )
+            notify_hooks(payload)
         except KafkaException as exc:  # pragma: no cover - logging only
             logger.error("Failed to produce dev log event: %s", exc)
 

--- a/src/ume/watchers/dossier_hook.py
+++ b/src/ume/watchers/dossier_hook.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ume.dossier import Dossier
+
+
+def dossier_activity_hook(payload: dict[str, Any]) -> None:
+    """Write watcher payloads to the user's dossier."""
+    dossier = Dossier.load()
+    dossier.add_activity(payload)

--- a/src/ume/watchers/hooks.py
+++ b/src/ume/watchers/hooks.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+from threading import Lock
+from typing import Any, Protocol, List
+
+logger = logging.getLogger(__name__)
+
+class WatcherHook(Protocol):
+    """Callback invoked with watcher payloads."""
+
+    def __call__(self, payload: dict[str, Any]) -> None:
+        ...
+
+
+_hooks: List[WatcherHook] = []
+_lock = Lock()
+
+
+def register_hook(hook: WatcherHook) -> None:
+    """Register a watcher hook."""
+    with _lock:
+        _hooks.append(hook)
+
+
+def unregister_hook(hook: WatcherHook) -> None:
+    """Remove a previously registered hook."""
+    with _lock:
+        if hook in _hooks:
+            _hooks.remove(hook)
+
+
+def notify_hooks(payload: dict[str, Any]) -> None:
+    """Call all registered hooks with ``payload``."""
+    with _lock:
+        hooks = list(_hooks)
+    for hook in hooks:
+        try:
+            hook(payload)
+        except Exception:  # pragma: no cover - avoid failing on hook errors
+            logger.exception("Watcher hook failed")

--- a/tests/test_dev_log_watcher.py
+++ b/tests/test_dev_log_watcher.py
@@ -35,6 +35,20 @@ def load_dev_log_watcher(monkeypatch: MonkeyPatch):
     monkeypatch.setitem(sys.modules, "ume.event", event_module)
 
     watchers_pkg = types.ModuleType("ume.watchers")
+    watchers_pkg.__path__ = []  # make it a package
+
+    hooks_mod = types.ModuleType("ume.watchers.hooks")
+    hook_calls: list[dict[str, Any]] = []
+
+    def notify_hooks(payload: dict[str, Any]) -> None:
+        hook_calls.append(payload)
+
+    hooks_mod.notify_hooks = notify_hooks
+    hooks_mod.register_hook = lambda hook: None
+    hooks_mod.unregister_hook = lambda hook: None
+    watchers_pkg.hooks = hooks_mod
+    monkeypatch.setitem(sys.modules, "ume.watchers.hooks", hooks_mod)
+
     ume_pkg.watchers = watchers_pkg
     monkeypatch.setitem(sys.modules, "ume.watchers", watchers_pkg)
 
@@ -85,6 +99,7 @@ def load_dev_log_watcher(monkeypatch: MonkeyPatch):
     dev_log_watcher = importlib.util.module_from_spec(devlog_spec)
     assert devlog_spec.loader is not None
     devlog_spec.loader.exec_module(dev_log_watcher)
+    dev_log_watcher.hook_calls = hook_calls
     watchers_pkg.dev_log_watcher = dev_log_watcher
     monkeypatch.setitem(sys.modules, "ume.watchers.dev_log_watcher", dev_log_watcher)
 
@@ -108,6 +123,7 @@ def test_handler_produces_event(tmp_path: Path, monkeypatch: MonkeyPatch) -> Non
     assert messages
     evt = parse_event(json.loads(messages[0].decode()))
     assert evt.payload["node_id"] == str(tmp_path / "file.txt")
+    assert dev_log_watcher.hook_calls == [{"path": str(tmp_path / "file.txt")}]
 
 
 def test_run_watcher_produces_event(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -159,6 +175,7 @@ def test_run_watcher_produces_event(tmp_path: Path, monkeypatch: MonkeyPatch) ->
     assert messages
     evt = parse_event(json.loads(messages[0].decode()))
     assert evt.payload["node_id"].endswith("watched.txt")
+    assert dev_log_watcher.hook_calls == [{"path": str(tmp_path / "watched.txt")}]
 
 
 def test_run_watcher_interrupt_stops_and_flushes(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
@@ -205,6 +222,7 @@ def test_run_watcher_interrupt_stops_and_flushes(tmp_path: Path, monkeypatch: Mo
     assert producer.flush_calls == 1
     assert observer.stop_calls == 1
     assert observer.join_calls == 2
+    assert dev_log_watcher.hook_calls == []
 
 
 def test_run_watcher_skips_missing_path(tmp_path: Path, monkeypatch: MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -246,6 +264,7 @@ def test_run_watcher_skips_missing_path(tmp_path: Path, monkeypatch: MonkeyPatch
 
     assert observer.scheduled == [str(tmp_path)]
     assert any("does not exist" in rec.message for rec in caplog.records)
+    assert dev_log_watcher.hook_calls == []
 
 
 def test_run_watcher_no_valid_paths(tmp_path: Path, monkeypatch: MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -287,3 +306,4 @@ def test_run_watcher_no_valid_paths(tmp_path: Path, monkeypatch: MonkeyPatch, ca
 
     assert not observer.started
     assert any("No existing paths" in rec.message for rec in caplog.records)
+    assert dev_log_watcher.hook_calls == []

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -1,3 +1,4 @@
+import json
 from ume.dossier import (
     Dossier,
     add_reflection,
@@ -27,3 +28,19 @@ def test_dossier_env_load(tmp_path, monkeypatch):
     monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
     dossier = Dossier.load()
     assert dossier.root == tmp_path
+
+
+def test_add_activity_respects_preferences(tmp_path):
+    dossier = Dossier.init_dossier(tmp_path)
+    dossier.preferences["record_activity"] = False
+    dossier.save()
+
+    dossier.add_activity({"a": 1})
+    log = tmp_path / "telemetry" / "activity.log"
+    assert not log.exists() or log.read_text() == ""
+
+    dossier.preferences["record_activity"] = True
+    dossier.save()
+    dossier.add_activity({"b": 2})
+    entries = [json.loads(line) for line in log.read_text().splitlines()]
+    assert entries[-1]["payload"] == {"b": 2}

--- a/tests/test_watchers.py
+++ b/tests/test_watchers.py
@@ -20,6 +20,7 @@ def test_on_modified_ignores_directory(tmp_path, monkeypatch: pytest.MonkeyPatch
     handler.on_modified(event)
 
     assert messages == []
+    assert dev_log_watcher.hook_calls == []
 
 
 def test_on_modified_logs_error(tmp_path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -35,3 +36,4 @@ def test_on_modified_logs_error(tmp_path, monkeypatch: pytest.MonkeyPatch, caplo
     handler.on_modified(event)
 
     assert any("Failed to produce dev log event" in rec.message for rec in caplog.records)
+    assert dev_log_watcher.hook_calls == []


### PR DESCRIPTION
## Summary
- allow watchers to register hooks and call them from the dev log watcher
- default watcher hook records activities in the dossier
- implement `Dossier.add_activity` respecting preferences
- test dossier activity logging and watcher hooks

## Testing
- `pre-commit run --files src/ume/watchers/hooks.py src/ume/watchers/dossier_hook.py src/ume/watchers/__init__.py src/ume/watchers/dev_log_watcher.py src/ume/dossier/__init__.py tests/test_dev_log_watcher.py tests/test_watchers.py tests/test_dossier.py`
- `pytest -q tests/test_dev_log_watcher.py tests/test_watchers.py tests/test_dossier.py`

------
https://chatgpt.com/codex/tasks/task_e_6880f22c217c8326a504775598ae6333