### PR TITLE
Add locking for dossier saves

### DIFF
--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any
 import json
 
+from filelock import FileLock
+
 import yaml
 
 
@@ -46,14 +48,25 @@ class Dossier:
     def save(self) -> None:
         """Persist current state to disk."""
         self.root.mkdir(parents=True, exist_ok=True)
-        yaml.safe_dump(
-            {"schema_version": self.schema_version, "shareable": self.shareable},
-            (self.root / "meta.yaml").open("w", encoding="utf-8"),
-        )
-        yaml.safe_dump(self.profile, (self.root / "profile.yaml").open("w", encoding="utf-8"))
-        yaml.safe_dump({"projects": self.projects}, (self.root / "projects.yaml").open("w", encoding="utf-8"))
-        yaml.safe_dump(self.preferences, (self.root / "preferences.yaml").open("w", encoding="utf-8"))
-        yaml.safe_dump(self.reflections, (self.root / "reflections.yaml").open("w", encoding="utf-8"))
+        lock = FileLock(str(self.root / ".dossier.lock"))
+        with lock:
+            yaml.safe_dump(
+                {"schema_version": self.schema_version, "shareable": self.shareable},
+                (self.root / "meta.yaml").open("w", encoding="utf-8"),
+            )
+            yaml.safe_dump(
+                self.profile, (self.root / "profile.yaml").open("w", encoding="utf-8")
+            )
+            yaml.safe_dump(
+                {"projects": self.projects},
+                (self.root / "projects.yaml").open("w", encoding="utf-8"),
+            )
+            yaml.safe_dump(
+                self.preferences, (self.root / "preferences.yaml").open("w", encoding="utf-8")
+            )
+            yaml.safe_dump(
+                self.reflections, (self.root / "reflections.yaml").open("w", encoding="utf-8")
+            )
 
     def _ensure_dirs(self) -> None:
         (self.root / "telemetry").mkdir(parents=True, exist_ok=True)

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from ume.dossier import (
     Dossier,
     add_reflection,
@@ -49,3 +50,22 @@ def test_add_activity_respects_preferences(tmp_path):
     dossier.add_activity({"b": 2})
     entries = [json.loads(line) for line in log.read_text().splitlines()]
     assert entries[-1]["payload"] == {"b": 2}
+
+
+def test_add_activity_thread_safety(tmp_path):
+    dossier = Dossier.init_dossier(tmp_path)
+    dossier.preferences["record_activity"] = True
+    dossier.save()
+
+    def worker(i: int) -> None:
+        dossier.add_activity({"n": i})
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    log = tmp_path / "telemetry" / "activity.log"
+    entries = [json.loads(line) for line in log.read_text().splitlines()]
+    assert len(entries) == 5


### PR DESCRIPTION
## Summary
- ensure concurrent saves use a lock file
- test that simultaneous calls to `add_activity` don't corrupt the log

## Testing
- `pre-commit run --files src/ume/dossier/__init__.py tests/test_dossier.py`
- `pytest tests/test_dossier.py::test_add_activity_thread_safety -q`

------
https://chatgpt.com/codex/tasks/task_e_688161e7732483268ba13ce42e85fbbc