### PR TITLE
Use persistent dossier backend

### DIFF
--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+from pathlib import Path
 from typing import Dict, cast
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -7,11 +9,15 @@ from pydantic import BaseModel
 
 from . import api_deps as deps
 from .policy import can_read_projects
+from .dossier import Dossier
 
 router = APIRouter(prefix="/dossier")
 
-# In-memory storage for dossier information
-_dossiers: Dict[str, Dict[str, object]] = {}
+
+def _dossier_path(dossier_id: str) -> Path:
+    """Return the filesystem path for ``dossier_id``."""
+    base = Path(os.environ.get("UME_DOSSIER_PATH", "~/.ume_dossier")).expanduser()
+    return base / dossier_id
 
 
 class AddProjectRequest(BaseModel):
@@ -22,12 +28,13 @@ class AddProjectRequest(BaseModel):
 @router.get("/{dossier_id}")
 def view_dossier(dossier_id: str, role: str = Depends(deps.get_current_role)) -> Dict[str, object]:
     """Return information about ``dossier_id`` if the user has access."""
-    dossier = _dossiers.get(dossier_id)
-    if dossier is None:
+    path = _dossier_path(dossier_id)
+    if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
-    if not can_read_projects(role, bool(dossier.get("shareable"))):
+    dossier = Dossier.load(path)
+    if not can_read_projects(role, dossier.shareable):
         raise HTTPException(status_code=403, detail="Not authorized")
-    return dossier
+    return {"dossier_id": dossier_id, "projects": list(dossier.projects), "shareable": dossier.shareable}
 
 
 @router.post("/add-project")
@@ -35,12 +42,13 @@ def add_project(req: AddProjectRequest, role: str = Depends(deps.get_current_rol
     """Attach ``project_id`` to the specified dossier."""
     if role != "ProjectManager":
         raise HTTPException(status_code=403, detail="Not authorized")
-    dossier = _dossiers.setdefault(
-        req.dossier_id,
-        {"dossier_id": req.dossier_id, "projects": [], "shareable": False},
-    )
-    projects = dossier.setdefault("projects", [])
-    if req.project_id not in projects:
-        projects.append(req.project_id)
-    return cast(Dict[str, object], dossier)
+    path = _dossier_path(req.dossier_id)
+    if path.exists():
+        dossier = Dossier.load(path)
+    else:
+        dossier = Dossier.init_dossier(path)
+    if req.project_id not in dossier.projects:
+        dossier.projects.append(req.project_id)
+        dossier.save()
+    return cast(Dict[str, object], {"dossier_id": req.dossier_id, "projects": list(dossier.projects), "shareable": dossier.shareable})
 

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -12,8 +12,9 @@ def _token(client: TestClient) -> str:
     return str(res.json()["access_token"])
 
 
-def test_add_and_view_dossier(monkeypatch):
+def test_add_and_view_dossier(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "ProjectManager", raising=False)
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
     client = TestClient(app)
     token = _token(client)
     headers = {"Authorization": f"Bearer {token}"}
@@ -30,8 +31,9 @@ def test_add_and_view_dossier(monkeypatch):
     assert res.json()["projects"] == ["p1"]
 
 
-def test_add_project_forbidden(monkeypatch):
+def test_add_project_forbidden(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "Viewer", raising=False)
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
     client = TestClient(app)
     token = _token(client)
     headers = {"Authorization": f"Bearer {token}"}
@@ -43,11 +45,38 @@ def test_add_project_forbidden(monkeypatch):
     assert res.status_code == 403
 
 
-def test_view_missing(monkeypatch):
+def test_view_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "ProjectManager", raising=False)
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
     client = TestClient(app)
     token = _token(client)
     headers = {"Authorization": f"Bearer {token}"}
     res = client.get("/dossier/unknown", headers=headers)
     assert res.status_code == 404
+
+
+def test_dossier_persists_after_restart(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "ProjectManager", raising=False)
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+    res = client.post(
+        "/dossier/add-project",
+        json={"dossier_id": "d3", "project_id": "p3"},
+        headers=headers,
+    )
+    assert res.status_code == 200
+
+    import importlib
+    import ume.api as api_mod
+
+    api_mod = importlib.reload(api_mod)
+    monkeypatch.setattr(api_mod.settings, "UME_OAUTH_ROLE", "ProjectManager", raising=False)
+    client2 = TestClient(api_mod.app)
+    token2 = _token(client2)
+    headers2 = {"Authorization": f"Bearer {token2}"}
+    res2 = client2.get("/dossier/d3", headers=headers2)
+    assert res2.status_code == 200
+    assert res2.json()["projects"] == ["p3"]
 


### PR DESCRIPTION
## Summary
- persist dossiers using the `Dossier` class
- respect `UME_DOSSIER_PATH` and initialise missing dossiers
- test dossier persistence across requests and restarts

## Testing
- `pre-commit run --files src/ume/dossier_routes.py tests/test_api_dossier.py`
- `pytest tests/test_api_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688161e76a9c832696db019334972b4d