### PR TITLE
Add dossier encryption support

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -71,7 +71,7 @@ Valid values for `UME_GRAPH_BACKEND` are:
 | `UME_SNAPSHOT_DIR` | `.` | Directory that snapshot APIs will accept paths from. |
 | `UME_AUDIT_LOG_PATH` | `audit.log` | Location of the audit log. |
 | `UME_AUDIT_SIGNING_KEY` | `default-key` | Key used to sign audit entries. Must be changed from the default or startup will fail. |
-| `UME_ENCRYPTION_ENABLED` | `False` | If `True`, encrypt audit log and ledger files with `UME_ENCRYPTION_KEY`. |
+| `UME_ENCRYPTION_ENABLED` | `False` | If `True`, encrypt audit, ledger, and dossier files with `UME_ENCRYPTION_KEY`. |
 | `UME_ENCRYPTION_KEY` | *(unset)* | Base64 Fernet key used when encryption is enabled. |
 | `UME_AGENT_ID` | `SYSTEM` | Identifier recorded in audit logs. |
 | `UME_EMBED_MODEL` | `all-MiniLM-L6-v2` | SentenceTransformer model name. |

--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -18,7 +18,7 @@ You can create the folder manually or call `Dossier.init_dossier(path)` from Pyt
 ## Security Practices
 
 Dossier API routes enforce role-based access. `ProjectManager` can add projects while `Viewer` may only read.
-To secure audit logs and ledger files, enable encryption by setting `UME_ENCRYPTION_ENABLED=true` and defining a base64 key in `UME_ENCRYPTION_KEY`.
+To secure audit logs, ledger files, and the dossier itself, enable encryption by setting `UME_ENCRYPTION_ENABLED=true` and defining a base64 key in `UME_ENCRYPTION_KEY`. When enabled, the YAML files and telemetry logs in `UME_DOSSIER_PATH` are stored encrypted on disk.
 
 ## CLI Examples
 

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -12,6 +12,23 @@ from filelock import FileLock
 
 import yaml
 
+try:
+    from cryptography.fernet import Fernet
+except Exception:  # pragma: no cover - cryptography optional
+    Fernet = None
+
+from ..config import settings
+
+ENCRYPTION_ENABLED = settings.UME_ENCRYPTION_ENABLED
+if ENCRYPTION_ENABLED:
+    if not (Fernet and settings.UME_ENCRYPTION_KEY):
+        raise ValueError(
+            "Encryption enabled but cryptography not available or key not set"
+        )
+    _fernet = Fernet(settings.UME_ENCRYPTION_KEY.encode())
+else:
+    _fernet = None
+
 
 @dataclass
 class Dossier:
@@ -50,23 +67,14 @@ class Dossier:
         self.root.mkdir(parents=True, exist_ok=True)
         lock = FileLock(str(self.root / ".dossier.lock"))
         with lock:
-            yaml.safe_dump(
+            self._write_yaml(
+                self.root / "meta.yaml",
                 {"schema_version": self.schema_version, "shareable": self.shareable},
-                (self.root / "meta.yaml").open("w", encoding="utf-8"),
             )
-            yaml.safe_dump(
-                self.profile, (self.root / "profile.yaml").open("w", encoding="utf-8")
-            )
-            yaml.safe_dump(
-                {"projects": self.projects},
-                (self.root / "projects.yaml").open("w", encoding="utf-8"),
-            )
-            yaml.safe_dump(
-                self.preferences, (self.root / "preferences.yaml").open("w", encoding="utf-8")
-            )
-            yaml.safe_dump(
-                self.reflections, (self.root / "reflections.yaml").open("w", encoding="utf-8")
-            )
+            self._write_yaml(self.root / "profile.yaml", self.profile)
+            self._write_yaml(self.root / "projects.yaml", {"projects": self.projects})
+            self._write_yaml(self.root / "preferences.yaml", self.preferences)
+            self._write_yaml(self.root / "reflections.yaml", self.reflections)
 
     def _ensure_dirs(self) -> None:
         (self.root / "telemetry").mkdir(parents=True, exist_ok=True)
@@ -91,15 +99,40 @@ class Dossier:
         log_path = self.root / "telemetry" / "activity.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
         entry = {"timestamp": datetime.utcnow().isoformat(), "payload": payload}
-        with log_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(entry) + "\n")
+        data = json.dumps(entry)
+        if ENCRYPTION_ENABLED:
+            token = _fernet.encrypt(data.encode()).decode()
+            with log_path.open("a", encoding="utf-8") as f:
+                f.write(token + "\n")
+        else:
+            with log_path.open("a", encoding="utf-8") as f:
+                f.write(data + "\n")
 
     @staticmethod
     def _read_yaml(path: Path) -> Any:
         if not path.is_file():
             return None
-        with path.open("r", encoding="utf-8") as f:
-            return yaml.safe_load(f) or None
+        if ENCRYPTION_ENABLED:
+            with path.open("rb") as f:
+                raw = f.read()
+            if not raw:
+                return None
+            data = _fernet.decrypt(raw).decode()
+            return yaml.safe_load(data) or None
+        else:
+            with path.open("r", encoding="utf-8") as f:
+                return yaml.safe_load(f) or None
+
+    @staticmethod
+    def _write_yaml(path: Path, data: Any) -> None:
+        text = yaml.safe_dump(data)
+        if ENCRYPTION_ENABLED:
+            payload = _fernet.encrypt(text.encode())
+            with path.open("wb") as f:
+                f.write(payload)
+        else:
+            with path.open("w", encoding="utf-8") as f:
+                f.write(text)
 
 
 # Helper functions

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -1,5 +1,6 @@
 import json
 import threading
+import pytest
 from ume.dossier import (
     Dossier,
     add_reflection,
@@ -69,3 +70,38 @@ def test_add_activity_thread_safety(tmp_path):
     log = tmp_path / "telemetry" / "activity.log"
     entries = [json.loads(line) for line in log.read_text().splitlines()]
     assert len(entries) == 5
+
+
+def test_dossier_encryption_roundtrip(tmp_path, monkeypatch):
+    import importlib
+    try:
+        from cryptography.fernet import Fernet
+    except Exception:
+        pytest.skip("cryptography not available")
+    from ume.config.loader import load_settings
+
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("UME_ENCRYPTION_ENABLED", "true")
+    monkeypatch.setenv("UME_ENCRYPTION_KEY", key)
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+
+    import ume.config as cfg
+    load_settings.cache_clear()
+    importlib.reload(cfg)
+    import ume.dossier as dossier_mod
+    importlib.reload(dossier_mod)
+
+    dossier = dossier_mod.Dossier.init_dossier(tmp_path)
+    dossier.profile["name"] = "Alice"
+    dossier.preferences["record_activity"] = True
+    dossier.save()
+    dossier.add_activity({"act": 1})
+
+    raw = (tmp_path / "profile.yaml").read_bytes()
+    assert b"Alice" not in raw
+    log_raw = (tmp_path / "telemetry" / "activity.log").read_bytes()
+    assert b"act" not in log_raw
+
+    importlib.reload(dossier_mod)
+    reloaded = dossier_mod.Dossier.load(tmp_path)
+    assert reloaded.profile["name"] == "Alice"


### PR DESCRIPTION
## Summary
- encrypt dossier YAML and telemetry when UME_ENCRYPTION_ENABLED is set
- document dossier encryption settings
- test encrypted dossier roundtrip

## Testing
- `pre-commit run --files src/ume/dossier/__init__.py tests/test_dossier.py docs/DOSSIER_OVERVIEW.md docs/CONFIG_TEMPLATES.md`
- `pytest tests/test_dossier.py::test_dossier_encryption_roundtrip tests/test_dossier.py::test_dossier_init_and_helpers tests/test_dossier.py::test_dossier_env_load tests/test_dossier.py::test_add_activity_respects_preferences tests/test_dossier.py::test_add_activity_thread_safety`

------
https://chatgpt.com/codex/tasks/task_e_688168eb44e08326ba583aa3e8dca57a