### PR TITLE
Add IDs and linking to dossier entries

### DIFF
--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -15,6 +15,10 @@ A newly initialized dossier contains:
 
 You can create the folder manually or call `Dossier.init_dossier(path)` from Python to copy the template files.
 
+## Linking Entries
+
+Projects and reflections are stored as objects that include a generated `id` field using `uuid4`.  Entries may reference other items by listing their IDs in a `links` array.  Helper functions automatically create the IDs and accept lists of related entry IDs when adding new records.
+
 ## Security Practices
 
 Dossier API routes enforce role-based access. `ProjectManager` can add projects while `Viewer` may only read.

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -4,6 +4,7 @@ import os
 import shutil
 from dataclasses import dataclass, field
 from datetime import datetime
+from uuid import uuid4
 from pathlib import Path
 from typing import Any
 import json
@@ -92,6 +93,23 @@ class Dossier:
         self.preferences = self._read_yaml(self.root / "preferences.yaml") or {}
         self.reflections = self._read_yaml(self.root / "reflections.yaml") or []
 
+        normalized_projects = []
+        for p in self.projects:
+            if isinstance(p, str):
+                normalized_projects.append({"id": p, "name": p, "links": []})
+            else:
+                p.setdefault("id", str(uuid4()))
+                p.setdefault("links", [])
+                normalized_projects.append(p)
+        self.projects = normalized_projects
+
+        normalized_reflections = []
+        for r in self.reflections:
+            r.setdefault("id", str(uuid4()))
+            r.setdefault("links", [])
+            normalized_reflections.append(r)
+        self.reflections = normalized_reflections
+
     def add_activity(self, payload: dict[str, Any]) -> None:
         """Append ``payload`` to ``telemetry/activity.log`` if allowed."""
         if not self.preferences.get("record_activity", True):
@@ -137,9 +155,29 @@ class Dossier:
 
 # Helper functions
 
-def add_reflection(dossier: Dossier, text: str) -> None:
-    dossier.reflections.append({"text": text, "timestamp": datetime.utcnow().isoformat()})
+def add_project(dossier: Dossier, name: str, links: list[str] | None = None) -> str:
+    """Append a project entry and return its id."""
+    for p in dossier.projects:
+        if p.get("name") == name:
+            return str(p["id"])
+    entry_id = str(uuid4())
+    entry = {"id": entry_id, "name": name, "links": links or []}
+    dossier.projects.append(entry)
     dossier.save()
+    return entry_id
+
+
+def add_reflection(dossier: Dossier, text: str, links: list[str] | None = None) -> str:
+    entry_id = str(uuid4())
+    entry = {
+        "id": entry_id,
+        "text": text,
+        "timestamp": datetime.utcnow().isoformat(),
+        "links": links or [],
+    }
+    dossier.reflections.append(entry)
+    dossier.save()
+    return entry_id
 
 def list_projects(dossier: Dossier) -> list[str]:
     return [p.get("name", "") for p in dossier.projects]

--- a/src/ume/dossier/dossier_template/projects.yaml
+++ b/src/ume/dossier/dossier_template/projects.yaml
@@ -1,2 +1,2 @@
-# List your projects
+# List your projects. Each entry includes an id (uuid4), name and optional links
 projects: []

--- a/src/ume/dossier/dossier_template/reflections.yaml
+++ b/src/ume/dossier/dossier_template/reflections.yaml
@@ -1,1 +1,2 @@
+# Journal style reflections. Each entry has an id (uuid4), timestamp, text and optional links
 []

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -10,7 +10,13 @@ from pydantic import BaseModel
 from . import api_deps as deps
 from .policy import can_read_projects
 
-from .dossier import Dossier, add_reflection, update_preferences
+from .dossier import (
+    Dossier,
+    add_project as dossier_add_project,
+    add_reflection,
+    list_projects,
+    update_preferences,
+)
 
 router = APIRouter(prefix="/dossier")
 
@@ -29,6 +35,7 @@ class AddProjectRequest(BaseModel):
 class AddReflectionRequest(BaseModel):
     dossier_id: str
     text: str
+    links: list[str] | None = None
 
 
 class SetPreferenceRequest(BaseModel):
@@ -46,7 +53,7 @@ def view_dossier(dossier_id: str, role: str = Depends(deps.get_current_role)) ->
     dossier = Dossier.load(path)
     if not can_read_projects(role, dossier.shareable):
         raise HTTPException(status_code=403, detail="Not authorized")
-    return {"dossier_id": dossier_id, "projects": list(dossier.projects), "shareable": dossier.shareable}
+    return {"dossier_id": dossier_id, "projects": list_projects(dossier), "shareable": dossier.shareable}
 
 
 @router.post("/add-project")
@@ -59,10 +66,11 @@ def add_project(req: AddProjectRequest, role: str = Depends(deps.get_current_rol
         dossier = Dossier.load(path)
     else:
         dossier = Dossier.init_dossier(path)
-    if req.project_id not in dossier.projects:
-        dossier.projects.append(req.project_id)
-        dossier.save()
-    return cast(Dict[str, object], {"dossier_id": req.dossier_id, "projects": list(dossier.projects), "shareable": dossier.shareable})
+    dossier_add_project(dossier, req.project_id)
+    return cast(
+        Dict[str, object],
+        {"dossier_id": req.dossier_id, "projects": list_projects(dossier), "shareable": dossier.shareable},
+    )
 
 
 @router.post("/add-reflection")
@@ -74,7 +82,7 @@ def add_reflection_endpoint(
         raise HTTPException(status_code=403, detail="Not authorized")
     path = _dossier_path(req.dossier_id)
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
-    add_reflection(dossier, req.text)
+    add_reflection(dossier, req.text, req.links)
     return {"status": "ok"}
 
 

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 from ume.api import app
 from ume.config import settings
-from ume.dossier import Dossier
+from ume.dossier import Dossier, list_projects
 
 
 def _token(client: TestClient) -> str:
@@ -70,7 +70,7 @@ def test_dossier_persists_after_restart(tmp_path, monkeypatch):
     assert res.status_code == 200
 
     reloaded = Dossier.load(tmp_path / "d3")
-    assert "p3" in reloaded.projects
+    assert "p3" in list_projects(reloaded)
 
 
 def test_reflection_and_pref_endpoints(tmp_path, monkeypatch):
@@ -96,6 +96,7 @@ def test_reflection_and_pref_endpoints(tmp_path, monkeypatch):
 
     dossier = Dossier.load(tmp_path / "d4")
     assert dossier.reflections[0]["text"] == "thinking"
+    assert "id" in dossier.reflections[0]
     assert dossier.preferences["theme"] == "dark"
 
 

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -1,8 +1,10 @@
 import json
 import threading
 import pytest
+import uuid
 from ume.dossier import (
     Dossier,
+    add_project,
     add_reflection,
     list_projects,
     update_preferences,
@@ -14,10 +16,9 @@ def test_dossier_init_and_helpers(tmp_path):
     assert dossier.schema_version == Dossier.schema_version
     assert dossier.shareable is False
 
-    dossier.projects.append({"name": "demo"})
-    dossier.save()
+    pid = add_project(dossier, "demo")
 
-    add_reflection(dossier, "thinking")
+    rid = add_reflection(dossier, "thinking", links=[pid])
     update_preferences(dossier, theme="dark")
 
     dossier.shareable = True
@@ -27,6 +28,12 @@ def test_dossier_init_and_helpers(tmp_path):
     assert list_projects(reloaded) == ["demo"]
     assert reloaded.preferences["theme"] == "dark"
     assert reloaded.reflections[0]["text"] == "thinking"
+    assert reloaded.reflections[0]["id"] == rid
+    assert reloaded.reflections[0]["links"] == [pid]
+    assert reloaded.projects[0]["id"] == pid
+    assert reloaded.projects[0]["links"] == []
+    uuid.UUID(reloaded.projects[0]["id"])
+    uuid.UUID(reloaded.reflections[0]["id"])
     assert reloaded.shareable is True
 
 


### PR DESCRIPTION
## Summary
- add uuid IDs and optional links in dossier templates
- update helper functions `add_project` and `add_reflection` to include IDs
- document entry linking in Dossier overview
- ensure API uses helper functions and returns project names
- test ID creation and link persistence

## Testing
- `ruff check src tests`
- `mypy --config-file mypy.ini --strict`
- `pytest tests/test_dossier.py tests/test_api_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881765b296883269d8f3738a48cb461