### PR TITLE
Expand dossier telemetry

### DIFF
--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -41,6 +41,7 @@ class Dossier:
     projects: list[dict[str, Any]] = field(default_factory=list)
     preferences: dict[str, Any] = field(default_factory=dict)
     reflections: list[dict[str, Any]] = field(default_factory=list)
+    telemetry_files: list[str] = field(default_factory=list)
 
     @classmethod
     def load(cls, root: str | Path | None = None) -> "Dossier":
@@ -69,7 +70,11 @@ class Dossier:
         with lock:
             self._write_yaml(
                 self.root / "meta.yaml",
-                {"schema_version": self.schema_version, "shareable": self.shareable},
+                {
+                    "schema_version": self.schema_version,
+                    "shareable": self.shareable,
+                    "telemetry_files": self.telemetry_files,
+                },
             )
             self._write_yaml(self.root / "profile.yaml", self.profile)
             self._write_yaml(self.root / "projects.yaml", {"projects": self.projects})
@@ -83,6 +88,7 @@ class Dossier:
         meta = self._read_yaml(self.root / "meta.yaml") or {}
         self.schema_version = int(meta.get("schema_version", self.schema_version))
         self.shareable = bool(meta.get("shareable", self.shareable))
+        self.telemetry_files = meta.get("telemetry_files", [])
         self.profile = self._read_yaml(self.root / "profile.yaml") or {}
         proj = self._read_yaml(self.root / "projects.yaml") or {}
         if isinstance(proj, dict):
@@ -96,10 +102,13 @@ class Dossier:
         """Append ``payload`` to ``telemetry/activity.log`` if allowed."""
         if not self.preferences.get("record_activity", True):
             return
-        log_path = self.root / "telemetry" / "activity.log"
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        entry = {"timestamp": datetime.utcnow().isoformat(), "payload": payload}
+        log_dir = self.root / "telemetry"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        log_path = log_dir / "activity.log"
+        now = datetime.utcnow()
+        entry = {"timestamp": now.isoformat(), "payload": payload}
         data = json.dumps(entry)
+
         if ENCRYPTION_ENABLED:
             token = _fernet.encrypt(data.encode()).decode()
             with log_path.open("a", encoding="utf-8") as f:
@@ -107,6 +116,39 @@ class Dossier:
         else:
             with log_path.open("a", encoding="utf-8") as f:
                 f.write(data + "\n")
+
+        # Daily CSV log
+        csv_path = log_dir / f"{now.date().isoformat()}.csv"
+        if ENCRYPTION_ENABLED:
+            csv_token = _fernet.encrypt(data.encode()).decode()
+            with csv_path.open("a", encoding="utf-8") as f:
+                f.write(csv_token + "\n")
+        else:
+            if not csv_path.exists():
+                with csv_path.open("w", encoding="utf-8") as f:
+                    f.write("timestamp,payload\n")
+            with csv_path.open("a", encoding="utf-8") as f:
+                f.write(f"{now.isoformat()},{json.dumps(payload)}\n")
+
+        # Update meta information
+        rel_log = log_path.relative_to(self.root).as_posix()
+        rel_csv = csv_path.relative_to(self.root).as_posix()
+        updated = False
+        for rel in (rel_log, rel_csv):
+            if rel not in self.telemetry_files:
+                self.telemetry_files.append(rel)
+                updated = True
+        if updated:
+            lock = FileLock(str(self.root / ".dossier.lock"))
+            with lock:
+                self._write_yaml(
+                    self.root / "meta.yaml",
+                    {
+                        "schema_version": self.schema_version,
+                        "shareable": self.shareable,
+                        "telemetry_files": self.telemetry_files,
+                    },
+                )
 
     @staticmethod
     def _read_yaml(path: Path) -> Any:

--- a/src/ume/dossier/dossier_template/meta.yaml
+++ b/src/ume/dossier/dossier_template/meta.yaml
@@ -1,2 +1,3 @@
 schema_version: 1
 shareable: false
+telemetry_files: []

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -1,5 +1,7 @@
 import json
 import threading
+from datetime import datetime
+import yaml
 import pytest
 from ume.dossier import (
     Dossier,
@@ -44,13 +46,23 @@ def test_add_activity_respects_preferences(tmp_path):
 
     dossier.add_activity({"a": 1})
     log = tmp_path / "telemetry" / "activity.log"
+    csv = tmp_path / "telemetry" / f"{datetime.utcnow().date().isoformat()}.csv"
+    meta = yaml.safe_load((tmp_path / "meta.yaml").read_text())
     assert not log.exists() or log.read_text() == ""
+    assert not csv.exists()
+    assert meta.get("telemetry_files", []) == []
 
     dossier.preferences["record_activity"] = True
     dossier.save()
     dossier.add_activity({"b": 2})
     entries = [json.loads(line) for line in log.read_text().splitlines()]
     assert entries[-1]["payload"] == {"b": 2}
+    assert csv.exists()
+    meta = yaml.safe_load((tmp_path / "meta.yaml").read_text())
+    assert sorted(meta.get("telemetry_files", [])) == sorted([
+        "telemetry/activity.log",
+        f"telemetry/{datetime.utcnow().date().isoformat()}.csv",
+    ])
 
 
 def test_add_activity_thread_safety(tmp_path):
@@ -105,3 +117,33 @@ def test_dossier_encryption_roundtrip(tmp_path, monkeypatch):
     importlib.reload(dossier_mod)
     reloaded = dossier_mod.Dossier.load(tmp_path)
     assert reloaded.profile["name"] == "Alice"
+
+
+def test_add_activity_multiple_files(tmp_path, monkeypatch):
+    dossier = Dossier.init_dossier(tmp_path)
+    dossier.preferences["record_activity"] = True
+    dossier.save()
+
+    class D1:
+        @staticmethod
+        def utcnow():
+            return datetime(2023, 1, 1, 0, 0, 0)
+
+    class D2:
+        @staticmethod
+        def utcnow():
+            return datetime(2023, 1, 2, 0, 0, 0)
+
+    import ume.dossier as dossier_mod
+    monkeypatch.setattr(dossier_mod, "datetime", D1)
+    dossier.add_activity({"n": 1})
+    monkeypatch.setattr(dossier_mod, "datetime", D2)
+    dossier.add_activity({"n": 2})
+
+    meta = yaml.safe_load((tmp_path / "meta.yaml").read_text())
+    expected = {
+        "telemetry/activity.log",
+        "telemetry/2023-01-01.csv",
+        "telemetry/2023-01-02.csv",
+    }
+    assert set(meta.get("telemetry_files", [])) == expected


### PR DESCRIPTION
## Summary
- track telemetry files in dossier metadata
- log activity to daily CSV files
- record telemetry files in `meta.yaml`
- test new telemetry behavior

## Testing
- `ruff check .`
- `pytest tests/test_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881765ae6548326b2cbb25bdba2780c