### PR TITLE
docs: add watcher hook overview

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -116,6 +116,7 @@ Valid values for `UME_GRAPH_BACKEND` are:
 `UME_RATE_LIMIT_REDIS` may be set to a Redis URL to enable shared rate limiting.
 If unset, the API uses an in-memory limiter.
 
+The dev-log watcher monitors the directories listed in `WATCH_PATHS`. Importing `ume.watchers` enables logging of file events to each dossier's `telemetry/activity.log`.
 ## Benchmark Hardware
 A single-node Dell PowerEdge R7625 with an EPYC 9254P CPU, 256 GB RAM and four NVMe drives was used when validating the Redpanda benchmark.
 

--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -64,3 +64,8 @@ with your `UME_ENCRYPTION_KEY`:
 UME_ENCRYPTION_ENABLED=true UME_ENCRYPTION_KEY=<key> \
   poetry run python scripts/migrate_dossier.py --encrypt ~/.ume_dossier
 ```
+
+## Watcher Hooks
+
+Importing `ume.watchers` automatically registers the `dossier_activity_hook`. When active, file events collected by watchers are appended to `telemetry/activity.log` inside the user's dossier.
+


### PR DESCRIPTION
## Summary
- document automatic dossier hook registration in DOSSIER_OVERVIEW
- note how WATCH_PATHS configures watcher logging in CONFIG_TEMPLATES

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688286f27c6c83268a28f66de3859dfb