### PR TITLE
Add attachments field for dossier items

### DIFF
--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -102,10 +102,13 @@ class Dossier:
         normalized_projects = []
         for p in self.projects:
             if isinstance(p, str):
-                normalized_projects.append({"id": p, "name": p, "links": []})
+                normalized_projects.append(
+                    {"id": p, "name": p, "links": [], "attachments": []}
+                )
             else:
                 p.setdefault("id", str(uuid4()))
                 p.setdefault("links", [])
+                p.setdefault("attachments", [])
                 normalized_projects.append(p)
         self.projects = normalized_projects
 
@@ -113,6 +116,7 @@ class Dossier:
         for r in self.reflections:
             r.setdefault("id", str(uuid4()))
             r.setdefault("links", [])
+            r.setdefault("attachments", [])
             normalized_reflections.append(r)
         self.reflections = normalized_reflections
 
@@ -197,25 +201,41 @@ class Dossier:
 
 # Helper functions
 
-def add_project(dossier: Dossier, name: str, links: list[str] | None = None) -> str:
+def add_project(
+    dossier: Dossier,
+    name: str,
+    links: list[str] | None = None,
+    attachments: list[str] | None = None,
+) -> str:
     """Append a project entry and return its id."""
     for p in dossier.projects:
         if p.get("name") == name:
             return str(p["id"])
     entry_id = str(uuid4())
-    entry = {"id": entry_id, "name": name, "links": links or []}
+    entry = {
+        "id": entry_id,
+        "name": name,
+        "links": links or [],
+        "attachments": attachments or [],
+    }
     dossier.projects.append(entry)
     dossier.save()
     return entry_id
 
 
-def add_reflection(dossier: Dossier, text: str, links: list[str] | None = None) -> str:
+def add_reflection(
+    dossier: Dossier,
+    text: str,
+    links: list[str] | None = None,
+    attachments: list[str] | None = None,
+) -> str:
     entry_id = str(uuid4())
     entry = {
         "id": entry_id,
         "text": text,
         "timestamp": datetime.utcnow().isoformat(),
         "links": links or [],
+        "attachments": attachments or [],
     }
     dossier.reflections.append(entry)
     dossier.save()

--- a/src/ume/dossier/dossier_template/projects.yaml
+++ b/src/ume/dossier/dossier_template/projects.yaml
@@ -1,2 +1,3 @@
 # List your projects. Each entry includes an id (uuid4), name and optional links
+# and attachments
 projects: []

--- a/src/ume/dossier/dossier_template/reflections.yaml
+++ b/src/ume/dossier/dossier_template/reflections.yaml
@@ -1,2 +1,3 @@
 # Journal style reflections. Each entry has an id (uuid4), timestamp, text and optional links
+# and attachments
 []

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -18,9 +18,9 @@ def test_dossier_init_and_helpers(tmp_path):
     assert dossier.schema_version == Dossier.schema_version
     assert dossier.shareable is False
 
-    pid = add_project(dossier, "demo")
+    pid = add_project(dossier, "demo", attachments=["file.txt"])
 
-    rid = add_reflection(dossier, "thinking", links=[pid])
+    rid = add_reflection(dossier, "thinking", links=[pid], attachments=["img.png"])
     update_preferences(dossier, theme="dark")
 
     dossier.shareable = True
@@ -32,8 +32,10 @@ def test_dossier_init_and_helpers(tmp_path):
     assert reloaded.reflections[0]["text"] == "thinking"
     assert reloaded.reflections[0]["id"] == rid
     assert reloaded.reflections[0]["links"] == [pid]
+    assert reloaded.reflections[0]["attachments"] == ["img.png"]
     assert reloaded.projects[0]["id"] == pid
     assert reloaded.projects[0]["links"] == []
+    assert reloaded.projects[0]["attachments"] == ["file.txt"]
     uuid.UUID(reloaded.projects[0]["id"])
     uuid.UUID(reloaded.reflections[0]["id"])
     assert reloaded.shareable is True


### PR DESCRIPTION
## Summary
- support optional attachments for projects and reflections
- pass attachments into helper functions
- update template YAML docs
- test attachments persistence

## Testing
- `pre-commit run --files src/ume/dossier/__init__.py src/ume/dossier/dossier_template/projects.yaml src/ume/dossier/dossier_template/reflections.yaml tests/test_dossier.py`
- `pytest -q tests/test_dossier.py`

------
https://chatgpt.com/codex/tasks/task_e_68828fcdc6dc832695657f217386ae1a