### PR TITLE
Add security notes documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,9 @@ See [`env.example`](env.example) for a minimal `.env` template.
 
 Always generate a unique `UME_AUDIT_SIGNING_KEY` for every deployment. Avoid
 reusing the example OAuth credentials or API keys in production. Tokens and
-signing keys should be treated as secrets and rotated periodically.
+signing keys should be treated as secrets and rotated periodically. Additional
+guidance on encryption and ledger storage is available in
+[docs/SECURITY_NOTES.md](docs/SECURITY_NOTES.md).
 
 ## Federated Deployments
 

--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -22,7 +22,7 @@ Projects and reflections are stored as objects that include a generated `id` fie
 ## Security Practices
 
 Dossier API routes enforce role-based access. `ProjectManager` can add projects while `Viewer` may only read.
-To secure audit logs, ledger files, and the dossier itself, enable encryption by setting `UME_ENCRYPTION_ENABLED=true` and defining a base64 key in `UME_ENCRYPTION_KEY`. When enabled, the YAML files and telemetry logs in `UME_DOSSIER_PATH` are stored encrypted on disk.
+To secure audit logs, ledger files, and the dossier itself, enable encryption by setting `UME_ENCRYPTION_ENABLED=true` and defining a base64 key in `UME_ENCRYPTION_KEY`. When enabled, the YAML files and telemetry logs in `UME_DOSSIER_PATH` are stored encrypted on disk. Additional notes on key management can be found in [SECURITY_NOTES.md](SECURITY_NOTES.md).
 
 ## CLI Examples
 

--- a/docs/SECURITY_NOTES.md
+++ b/docs/SECURITY_NOTES.md
@@ -1,0 +1,21 @@
+# Security Notes
+
+This document summarizes how to secure on-disk data for UME deployments.
+
+## Encryption Options
+
+Set `UME_ENCRYPTION_ENABLED=true` and define a base64 Fernet key in `UME_ENCRYPTION_KEY` to encrypt the SQLite ledgers and the audit log. When enabled, new ledger and log files are written in encrypted form. Archive or migrate any existing plaintext files.
+
+## Recommended Storage Locations
+
+By default the audit log and ledgers are created in the current working directory. In production these files should reside on a persistent volume with restricted permissions, e.g. `/var/lib/ume/`. Keep the directories readable only by the service account.
+
+Relevant settings:
+
+- `UME_AUDIT_LOG_PATH` – path to the audit log
+- `UME_EVENT_LEDGER_PATH` – path to the event ledger
+- `UME_CONSENT_LEDGER_PATH` – path to the consent ledger
+
+## Ledger and Audit Key Management
+
+Audit entries are signed with `UME_AUDIT_SIGNING_KEY`. Generate a unique key for every deployment and rotate it periodically. Store both the signing key and the encryption key securely outside of version control, such as in an environment file managed by a secrets vault.


### PR DESCRIPTION
## Summary
- document encryption settings and key management in `docs/SECURITY_NOTES.md`
- link security notes from README
- reference the security notes from dossier overview

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68829a604e288326950987deed44b160