### PR TITLE
Add values & skills to Dossier

### DIFF
--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -11,6 +11,8 @@ A newly initialized dossier contains:
 - `projects.yaml` – list of active projects
 - `preferences.yaml` – arbitrary key/value settings
 - `reflections.yaml` – journal style reflections
+- `values.yaml` – list of personal values
+- `skills.yaml` – list of personal skills
 - `telemetry/` – directory for captured traces
 
 You can create the folder manually or call `Dossier.init_dossier(path)` from Python to copy the template files.
@@ -32,6 +34,15 @@ ume dossier view user123
 
 # Attach a project to a dossier
 ume dossier add-project user123 projectA
+
+# Add a personal value
+ume dossier add-value user123 honesty
+
+# Add a skill
+ume dossier add-skill user123 python
+
+# List skills
+ume dossier list-skills user123
 ```
 
 ## API Examples
@@ -45,6 +56,20 @@ curl -H "Authorization: Bearer $TOKEN" \
 curl -X POST -H "Authorization: Bearer $TOKEN" \
   -d '{"dossier_id":"user123","project_id":"projectA"}' \
   http://localhost:8000/dossier/add-project
+
+# Add a value
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"dossier_id":"user123","value":"honesty"}' \
+  http://localhost:8000/dossier/add-value
+
+# Add a skill
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"dossier_id":"user123","skill":"python"}' \
+  http://localhost:8000/dossier/add-skill
+
+# List skills
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/dossier/skills/user123
 ```
 
 ## Migrating Existing Dossiers

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -42,6 +42,8 @@ class Dossier:
     projects: list[dict[str, Any]] = field(default_factory=list)
     preferences: dict[str, Any] = field(default_factory=dict)
     reflections: list[dict[str, Any]] = field(default_factory=list)
+    values: list[str] = field(default_factory=list)
+    skills: list[str] = field(default_factory=list)
     telemetry_files: list[str] = field(default_factory=list)
 
     @classmethod
@@ -81,6 +83,8 @@ class Dossier:
             self._write_yaml(self.root / "projects.yaml", {"projects": self.projects})
             self._write_yaml(self.root / "preferences.yaml", self.preferences)
             self._write_yaml(self.root / "reflections.yaml", self.reflections)
+            self._write_yaml(self.root / "values.yaml", self.values)
+            self._write_yaml(self.root / "skills.yaml", self.skills)
 
     def _ensure_dirs(self) -> None:
         (self.root / "telemetry").mkdir(parents=True, exist_ok=True)
@@ -98,6 +102,8 @@ class Dossier:
             self.projects = proj
         self.preferences = self._read_yaml(self.root / "preferences.yaml") or {}
         self.reflections = self._read_yaml(self.root / "reflections.yaml") or []
+        self.values = self._read_yaml(self.root / "values.yaml") or []
+        self.skills = self._read_yaml(self.root / "skills.yaml") or []
 
         normalized_projects = []
         for p in self.projects:
@@ -247,3 +253,21 @@ def list_projects(dossier: Dossier) -> list[str]:
 def update_preferences(dossier: Dossier, **prefs: Any) -> None:
     dossier.preferences.update(prefs)
     dossier.save()
+
+
+def add_value(dossier: Dossier, value: str) -> None:
+    """Append a value string if not present."""
+    if value not in dossier.values:
+        dossier.values.append(value)
+        dossier.save()
+
+
+def add_skill(dossier: Dossier, skill: str) -> None:
+    """Append a skill string if not present."""
+    if skill not in dossier.skills:
+        dossier.skills.append(skill)
+        dossier.save()
+
+
+def list_skills(dossier: Dossier) -> list[str]:
+    return list(dossier.skills)

--- a/src/ume/dossier/dossier_template/skills.yaml
+++ b/src/ume/dossier/dossier_template/skills.yaml
@@ -1,0 +1,2 @@
+# List of skills
+[]

--- a/src/ume/dossier/dossier_template/values.yaml
+++ b/src/ume/dossier/dossier_template/values.yaml
@@ -1,0 +1,2 @@
+# Personal values
+[]

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -14,7 +14,10 @@ from .dossier import (
     Dossier,
     add_project as dossier_add_project,
     add_reflection,
+    add_value,
+    add_skill,
     list_projects,
+    list_skills,
     update_preferences,
 )
 
@@ -42,6 +45,16 @@ class SetPreferenceRequest(BaseModel):
     dossier_id: str
     key: str
     value: Any
+
+
+class AddValueRequest(BaseModel):
+    dossier_id: str
+    value: str
+
+
+class AddSkillRequest(BaseModel):
+    dossier_id: str
+    skill: str
 
 
 @router.get("/{dossier_id}")
@@ -97,4 +110,41 @@ def set_preference(
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
     update_preferences(dossier, **{req.key: req.value})
     return {"status": "ok"}
+
+
+@router.post("/add-value")
+def add_value_endpoint(
+    req: AddValueRequest, role: str = Depends(deps.get_current_role)
+) -> Dict[str, str]:
+    if role != "ProjectManager":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    path = _dossier_path(req.dossier_id)
+    dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
+    add_value(dossier, req.value)
+    return {"status": "ok"}
+
+
+@router.post("/add-skill")
+def add_skill_endpoint(
+    req: AddSkillRequest, role: str = Depends(deps.get_current_role)
+) -> Dict[str, str]:
+    if role != "ProjectManager":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    path = _dossier_path(req.dossier_id)
+    dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
+    add_skill(dossier, req.skill)
+    return {"status": "ok"}
+
+
+@router.get("/skills/{dossier_id}")
+def get_skills(
+    dossier_id: str, role: str = Depends(deps.get_current_role)
+) -> Dict[str, object]:
+    path = _dossier_path(dossier_id)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Dossier not found")
+    dossier = Dossier.load(path)
+    if not can_read_projects(role, dossier.shareable):
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return {"dossier_id": dossier_id, "skills": list_skills(dossier)}
 

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 from ume.api import app
 from ume.config import settings
-from ume.dossier import Dossier, list_projects
+from ume.dossier import Dossier, list_projects, list_skills
 
 
 def _token(client: TestClient) -> str:
@@ -99,6 +99,28 @@ def test_reflection_and_pref_endpoints(tmp_path, monkeypatch):
     assert "id" in dossier.reflections[0]
     assert dossier.preferences["theme"] == "dark"
 
+    res = client.post(
+        "/dossier/add-value",
+        json={"dossier_id": "d4", "value": "honesty"},
+        headers=headers,
+    )
+    assert res.status_code == 200
+
+    res = client.post(
+        "/dossier/add-skill",
+        json={"dossier_id": "d4", "skill": "python"},
+        headers=headers,
+    )
+    assert res.status_code == 200
+
+    res = client.get("/dossier/skills/d4", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["skills"] == ["python"]
+
+    dossier = Dossier.load(tmp_path / "d4")
+    assert dossier.values == ["honesty"]
+    assert list_skills(dossier) == ["python"]
+
 
 def test_reflection_and_pref_forbidden(tmp_path, monkeypatch):
     monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "Viewer", raising=False)
@@ -117,6 +139,20 @@ def test_reflection_and_pref_forbidden(tmp_path, monkeypatch):
     res = client.post(
         "/dossier/set-pref",
         json={"dossier_id": "d5", "key": "foo", "value": "bar"},
+        headers=headers,
+    )
+    assert res.status_code == 403
+
+    res = client.post(
+        "/dossier/add-value",
+        json={"dossier_id": "d5", "value": "honesty"},
+        headers=headers,
+    )
+    assert res.status_code == 403
+
+    res = client.post(
+        "/dossier/add-skill",
+        json={"dossier_id": "d5", "skill": "python"},
         headers=headers,
     )
     assert res.status_code == 403

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -8,7 +8,10 @@ from ume.dossier import (
     Dossier,
     add_project,
     add_reflection,
+    add_value,
+    add_skill,
     list_projects,
+    list_skills,
     update_preferences,
 )
 
@@ -21,6 +24,8 @@ def test_dossier_init_and_helpers(tmp_path):
     pid = add_project(dossier, "demo", attachments=["file.txt"])
 
     rid = add_reflection(dossier, "thinking", links=[pid], attachments=["img.png"])
+    add_value(dossier, "honesty")
+    add_skill(dossier, "python")
     update_preferences(dossier, theme="dark")
 
     dossier.shareable = True
@@ -33,6 +38,8 @@ def test_dossier_init_and_helpers(tmp_path):
     assert reloaded.reflections[0]["id"] == rid
     assert reloaded.reflections[0]["links"] == [pid]
     assert reloaded.reflections[0]["attachments"] == ["img.png"]
+    assert reloaded.values == ["honesty"]
+    assert list_skills(reloaded) == ["python"]
     assert reloaded.projects[0]["id"] == pid
     assert reloaded.projects[0]["links"] == []
     assert reloaded.projects[0]["attachments"] == ["file.txt"]

--- a/tests/test_dossier_cli.py
+++ b/tests/test_dossier_cli.py
@@ -54,6 +54,18 @@ async def add_reflection(payload: dict):
 async def set_pref(payload: dict):
     return {'dossier_id': payload['dossier_id'], 'key': payload['key'], 'value': payload['value']}
 
+@app.post('/dossier/add-value')
+async def add_value(payload: dict):
+    return {'dossier_id': payload['dossier_id'], 'value': payload['value']}
+
+@app.post('/dossier/add-skill')
+async def add_skill(payload: dict):
+    return {'dossier_id': payload['dossier_id'], 'skill': payload['skill']}
+
+@app.get('/dossier/skills/{dossier_id}')
+async def list_skills(dossier_id: str):
+    return {'dossier_id': dossier_id, 'skills': ['s1']}
+
 client = TestClient(app)
 
 def _wrap(method):
@@ -147,5 +159,44 @@ def test_dossier_set_pref(tmp_path: Path):
             "method": "POST",
             "url": "http://localhost:8000/dossier/set-pref",
             "json": {"dossier_id": "d3", "key": "theme", "value": "dark"},
+        }
+    ]
+
+
+def test_dossier_add_value(tmp_path: Path):
+    proc, requests = _run_cli(tmp_path, ["dossier", "add-value", "d4", "honesty"])
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {"dossier_id": "d4", "value": "honesty"}
+    assert requests == [
+        {
+            "method": "POST",
+            "url": "http://localhost:8000/dossier/add-value",
+            "json": {"dossier_id": "d4", "value": "honesty"},
+        }
+    ]
+
+
+def test_dossier_add_skill(tmp_path: Path):
+    proc, requests = _run_cli(tmp_path, ["dossier", "add-skill", "d5", "python"])
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {"dossier_id": "d5", "skill": "python"}
+    assert requests == [
+        {
+            "method": "POST",
+            "url": "http://localhost:8000/dossier/add-skill",
+            "json": {"dossier_id": "d5", "skill": "python"},
+        }
+    ]
+
+
+def test_dossier_list_skills(tmp_path: Path):
+    proc, requests = _run_cli(tmp_path, ["dossier", "list-skills", "d6"])
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {"dossier_id": "d6", "skills": ["s1"]}
+    assert requests == [
+        {
+            "method": "GET",
+            "url": "http://localhost:8000/dossier/skills/d6",
+            "json": None,
         }
     ]

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -129,6 +129,64 @@ def _dossier_set_pref(dossier_id: str, key: str, value: str) -> None:
         print(f"Request failed: {exc}")
 
 
+def _dossier_add_value(dossier_id: str, value: str) -> None:
+    """Send a request to append a value."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    payload = {"dossier_id": dossier_id, "value": value}
+    try:
+        resp = httpx.post(
+            f"{base_url}/dossier/add-value",
+            json=payload,
+            headers=headers,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
+def _dossier_add_skill(dossier_id: str, skill: str) -> None:
+    """Send a request to append a skill."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    payload = {"dossier_id": dossier_id, "skill": skill}
+    try:
+        resp = httpx.post(
+            f"{base_url}/dossier/add-skill",
+            json=payload,
+            headers=headers,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
+def _dossier_list_skills(dossier_id: str) -> None:
+    """Fetch and print the skill list."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    try:
+        resp = httpx.get(
+            f"{base_url}/dossier/skills/{dossier_id}",
+            headers=headers,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
 def main() -> None:
     """Entry point for the ``ume-cli`` console script."""
     parser = argparse.ArgumentParser(description="UME CLI")
@@ -173,6 +231,14 @@ def main() -> None:
     pref_p.add_argument("dossier_id")
     pref_p.add_argument("key")
     pref_p.add_argument("value")
+    val_p = dossier_sub.add_parser("add-value", help="Add a value entry")
+    val_p.add_argument("dossier_id")
+    val_p.add_argument("value")
+    skill_p = dossier_sub.add_parser("add-skill", help="Add a skill entry")
+    skill_p.add_argument("dossier_id")
+    skill_p.add_argument("skill")
+    list_skills_p = dossier_sub.add_parser("list-skills", help="List skills")
+    list_skills_p.add_argument("dossier_id")
     for p in (up_parser, quick_parser):
         p.add_argument(
             "--no-confirm",
@@ -212,6 +278,12 @@ def main() -> None:
                 _dossier_add_reflection(args.dossier_id, args.text)
             elif args.dossier_cmd == "set-pref":
                 _dossier_set_pref(args.dossier_id, args.key, args.value)
+            elif args.dossier_cmd == "add-value":
+                _dossier_add_value(args.dossier_id, args.value)
+            elif args.dossier_cmd == "add-skill":
+                _dossier_add_skill(args.dossier_id, args.skill)
+            elif args.dossier_cmd == "list-skills":
+                _dossier_list_skills(args.dossier_id)
             return
 
         configure_logging()


### PR DESCRIPTION
## Summary
- track `values` and `skills` in user dossiers
- expose helper functions and CLI commands for new fields
- extend dossier API routes for managing values and skills
- document new sections
- test dossier updates and CLI interactions

## Testing
- `pre-commit run --files docs/DOSSIER_OVERVIEW.md src/ume/dossier/__init__.py src/ume/dossier_routes.py tests/test_api_dossier.py tests/test_dossier.py tests/test_dossier_cli.py ume_cli.py src/ume/dossier/dossier_template/skills.yaml src/ume/dossier/dossier_template/values.yaml`
- `pytest tests/test_dossier.py tests/test_dossier_cli.py tests/test_api_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c2484d188326a860c78c526654bf