### PR TITLE
Add optional activity log

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -104,6 +104,7 @@ Valid values for `UME_GRAPH_BACKEND` are:
 | `UME_LOG_JSON` | `False` | Output logs as JSON lines when set to `True`. |
 | `UME_GRAPH_RETENTION_DAYS` | `30` | Age in days before old nodes/edges are purged. |
 | `WATCH_PATHS` | `['.']` | Paths watched by the dev-log watcher. |
+| `UME_ACTIVITY_LOG_ENABLED` | `True` | Disable to skip registering `dossier_activity_hook`. |
 | `DAG_RESOURCES` | `{'cpu': 1, 'io': 1}` | Resource slots for the DAG service. |
 | `KAFKA_CA_CERT` | *(unset)* | CA certificate for Kafka TLS. |
 | `KAFKA_CLIENT_CERT` | *(unset)* | Client certificate for Kafka TLS. |

--- a/env.example
+++ b/env.example
@@ -32,3 +32,6 @@ UME_API_TOKEN=
 
 # Number of hours of events to include in Angel Bridge summaries
 ANGEL_BRIDGE_LOOKBACK_HOURS=24
+
+# Enable or disable logging of watcher activity to each dossier
+UME_ACTIVITY_LOG_ENABLED=true

--- a/src/ume/watchers/__init__.py
+++ b/src/ume/watchers/__init__.py
@@ -1,10 +1,13 @@
 """Filesystem and configuration change watchers."""
 
+import os
+
 from .hooks import register_hook, unregister_hook, WatcherHook, notify_hooks
 from .dossier_hook import dossier_activity_hook
 
-# Automatically record watcher activity in the user's dossier
-register_hook(dossier_activity_hook)
+# Automatically record watcher activity in the user's dossier when enabled
+if os.getenv("UME_ACTIVITY_LOG_ENABLED", "true").lower() not in {"0", "false", "no"}:
+    register_hook(dossier_activity_hook)
 
 __all__ = [
     "register_hook",

--- a/tests/test_dossier_activity_hook.py
+++ b/tests/test_dossier_activity_hook.py
@@ -1,15 +1,16 @@
+import importlib
 import json
 import threading
 
 import pytest
 
 from ume.dossier import Dossier
-from ume.watchers.dossier_hook import dossier_activity_hook
 
 
 def test_dossier_activity_hook_appends(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     Dossier.init_dossier(tmp_path)
     monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    from ume.watchers.dossier_hook import dossier_activity_hook
 
     dossier_activity_hook({"event": 1})
 
@@ -21,6 +22,7 @@ def test_dossier_activity_hook_appends(tmp_path, monkeypatch: pytest.MonkeyPatch
 def test_dossier_activity_hook_concurrent(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
     Dossier.init_dossier(tmp_path)
     monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    from ume.watchers.dossier_hook import dossier_activity_hook
 
     def worker(i: int) -> None:
         dossier_activity_hook({"n": i})
@@ -35,3 +37,16 @@ def test_dossier_activity_hook_concurrent(tmp_path, monkeypatch: pytest.MonkeyPa
     entries = [json.loads(line)["payload"] for line in log.read_text().splitlines()]
     values = sorted(e["n"] for e in entries)
     assert values == list(range(5))
+
+
+def test_watcher_registration_skipped_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    import ume.watchers
+    from ume.watchers import hooks
+
+    hooks._hooks.clear()
+    calls: list[object] = []
+    monkeypatch.setattr(hooks, "register_hook", lambda h: calls.append(h))
+    monkeypatch.setenv("UME_ACTIVITY_LOG_ENABLED", "false")
+    importlib.reload(ume.watchers)
+
+    assert not calls


### PR DESCRIPTION
## Summary
- guard dossier activity hook behind `UME_ACTIVITY_LOG_ENABLED`
- document `UME_ACTIVITY_LOG_ENABLED` and update example env
- test registration skip when `UME_ACTIVITY_LOG_ENABLED=false`

## Testing
- `ruff check src/ume/watchers/__init__.py tests/test_dossier_activity_hook.py`
- `mypy --config-file mypy.ini --strict src/ume/watchers/__init__.py tests/test_dossier_activity_hook.py`
- `pytest -q tests/test_dossier_activity_hook.py`

------
https://chatgpt.com/codex/tasks/task_e_6882c24771008326bb63af4e1bc61058