### PR TITLE
Add docs section on toggling activity logging

### DIFF
--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -94,3 +94,12 @@ UME_ENCRYPTION_ENABLED=true UME_ENCRYPTION_KEY=<key> \
 
 Importing `ume.watchers` automatically registers the `dossier_activity_hook`. When active, file events collected by watchers are appended to `telemetry/activity.log` inside the user's dossier.
 
+### Enabling and Disabling Activity Logging
+
+Activity logging is enabled by default. Set the environment variable
+`UME_ACTIVITY_LOG_ENABLED=false` to prevent the watcher from registering
+`dossier_activity_hook`. With the hook disabled, file events are ignored and no
+entries are written to `telemetry/activity.log`. Using any value other than
+`0`, `false`, or `no` re-enables the hook on the next import of
+`ume.watchers`.
+


### PR DESCRIPTION
## Summary
- mention `UME_ACTIVITY_LOG_ENABLED` in the dossier overview
- document how watcher hooks are affected when logging is disabled

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882c5d0c4f88326a7c702bc3ec2698f