### PR TITLE
Add locking for dossier activity logs

### DIFF
--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -137,26 +137,28 @@ class Dossier:
         entry = {"timestamp": now.isoformat(), "payload": payload}
         data = json.dumps(entry)
 
-        if ENCRYPTION_ENABLED:
-            token = _fernet.encrypt(data.encode()).decode()
-            with log_path.open("a", encoding="utf-8") as f:
-                f.write(token + "\n")
-        else:
-            with log_path.open("a", encoding="utf-8") as f:
-                f.write(data + "\n")
+        lock = FileLock(str(log_dir / ".activity.lock"))
+        with lock:
+            if ENCRYPTION_ENABLED:
+                token = _fernet.encrypt(data.encode()).decode()
+                with log_path.open("a", encoding="utf-8") as f:
+                    f.write(token + "\n")
+            else:
+                with log_path.open("a", encoding="utf-8") as f:
+                    f.write(data + "\n")
 
-        # Daily CSV log
-        csv_path = log_dir / f"{now.date().isoformat()}.csv"
-        if ENCRYPTION_ENABLED:
-            csv_token = _fernet.encrypt(data.encode()).decode()
-            with csv_path.open("a", encoding="utf-8") as f:
-                f.write(csv_token + "\n")
-        else:
-            if not csv_path.exists():
-                with csv_path.open("w", encoding="utf-8") as f:
-                    f.write("timestamp,payload\n")
-            with csv_path.open("a", encoding="utf-8") as f:
-                f.write(f"{now.isoformat()},{json.dumps(payload)}\n")
+            # Daily CSV log
+            csv_path = log_dir / f"{now.date().isoformat()}.csv"
+            if ENCRYPTION_ENABLED:
+                csv_token = _fernet.encrypt(data.encode()).decode()
+                with csv_path.open("a", encoding="utf-8") as f:
+                    f.write(csv_token + "\n")
+            else:
+                if not csv_path.exists():
+                    with csv_path.open("w", encoding="utf-8") as f:
+                        f.write("timestamp,payload\n")
+                with csv_path.open("a", encoding="utf-8") as f:
+                    f.write(f"{now.isoformat()},{json.dumps(payload)}\n")
 
         # Update meta information
         rel_log = log_path.relative_to(self.root).as_posix()

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -1,5 +1,5 @@
 import json
-import threading
+import multiprocessing as mp
 from datetime import datetime
 import yaml
 import pytest
@@ -14,6 +14,11 @@ from ume.dossier import (
     list_skills,
     update_preferences,
 )
+
+
+def _activity_worker(path: str, i: int) -> None:
+    dossier = Dossier.load(path)
+    dossier.add_activity({"n": i})
 
 
 def test_dossier_init_and_helpers(tmp_path):
@@ -86,14 +91,14 @@ def test_add_activity_thread_safety(tmp_path):
     dossier.preferences["record_activity"] = True
     dossier.save()
 
-    def worker(i: int) -> None:
-        dossier.add_activity({"n": i})
-
-    threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
+    procs = [
+        mp.Process(target=_activity_worker, args=(str(tmp_path), i))
+        for i in range(5)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join()
 
     log = tmp_path / "telemetry" / "activity.log"
     entries = [json.loads(line) for line in log.read_text().splitlines()]


### PR DESCRIPTION
## Summary
- ensure dossier activity writes use a lock
- test concurrent dossier logging across processes

## Testing
- `ruff check src/ume/dossier/__init__.py tests/test_dossier.py`
- `mypy --config-file mypy.ini --strict src/ume/dossier/__init__.py tests/test_dossier.py`
- `pytest tests/test_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c5d023e4832684df52025df06c2c