### PR TITLE
Update docs with dossier examples and snapshot curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -951,6 +951,24 @@ ume> exit
 Goodbye!
 ```
 
+### Working with the Dossier
+
+The dossier directory (default `~/.ume_dossier`) is seeded from the YAML files in
+`src/ume/dossier/dossier_template/` such as `skills.yaml` and `values.yaml`.
+Use the CLI or API to add entries and snapshot the graph when needed.
+
+```bash
+# Add a value and a skill via the CLI
+ume dossier add-value user123 curiosity
+ume dossier add-skill user123 python
+
+# Trigger a snapshot through the API
+curl -X POST http://localhost:8000/snapshot/save \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"path":"ume_backup.json"}'
+```
+
 ## Graph Analytics with Neo4j GDS
 
 When using `Neo4jGraph` with the `use_gds=True` option, UME can delegate graph

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -60,10 +60,26 @@ Delete an edge.
 ### POST `/snapshot/save`
 Write the entire graph state to a JSON file.
 - **Body**: `{"path": "file.json"}`
+Example request:
+
+```bash
+curl -X POST http://localhost:8000/snapshot/save \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"path":"backup.json"}'
+```
 
 ### POST `/snapshot/load`
 Replace the current graph with the contents of a snapshot file.
 - **Body**: `{"path": "file.json"}`
+Example request:
+
+```bash
+curl -X POST http://localhost:8000/snapshot/load \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"path":"backup.json"}'
+```
 
 ### GET `/ledger/events`
 List entries in the event ledger.
@@ -184,6 +200,30 @@ curl -X POST http://localhost:8000/dossier/add-project \
   -H "Content-Type: application/json" \
   -d '{"dossier_id":"example","project_id":"p1"}'
 ```
+
+### POST `/dossier/add-value`
+Add a personal value entry to the dossier.
+
+```bash
+curl -X POST http://localhost:8000/dossier/add-value \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"dossier_id":"example","value":"curiosity"}'
+```
+
+### POST `/dossier/add-skill`
+Add a skill entry to the dossier.
+
+```bash
+curl -X POST http://localhost:8000/dossier/add-skill \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"dossier_id":"example","skill":"python"}'
+```
+
+The dossier directory is initialized from template files located under
+`src/ume/dossier/dossier_template/` which include `skills.yaml` and
+`values.yaml`.
 
 ## API Documentation
 


### PR DESCRIPTION
## Summary
- document snapshot API usage and dossier endpoints in API reference
- mention dossier YAML templates and show how to add values/skills in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882c91f9378832686f14b8a6ffac716