### PR TITLE
Implement dossier snapshots

### DIFF
--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -90,6 +90,20 @@ UME_ENCRYPTION_ENABLED=true UME_ENCRYPTION_KEY=<key> \
   poetry run python scripts/migrate_dossier.py --encrypt ~/.ume_dossier
 ```
 
+## Dossier Snapshots
+
+Use `Dossier.snapshot()` to archive the current YAML files. A folder named
+`history/<timestamp>` is created inside the dossier directory containing
+copies of all YAML files. Snapshots can also be created via the API or CLI:
+
+```bash
+curl -X POST -H "Authorization: Bearer <token>" \
+  -d '{"dossier_id":"example"}' \
+  http://localhost:8000/dossier/snapshot
+
+ume dossier snapshot example
+```
+
 ## Watcher Hooks
 
 Importing `ume.watchers` automatically registers the `dossier_activity_hook`. When active, file events collected by watchers are appended to `telemetry/activity.log` inside the user's dossier.

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -206,6 +206,15 @@ class Dossier:
             with path.open("w", encoding="utf-8") as f:
                 f.write(text)
 
+    def snapshot(self) -> Path:
+        """Copy all YAML files into a timestamped history folder."""
+        ts = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        dest = self.root / "history" / ts
+        dest.mkdir(parents=True, exist_ok=True)
+        for yaml_file in self.root.glob("*.yaml"):
+            shutil.copy2(yaml_file, dest / yaml_file.name)
+        return dest
+
 
 # Helper functions
 

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -57,6 +57,10 @@ class AddSkillRequest(BaseModel):
     skill: str
 
 
+class SnapshotRequest(BaseModel):
+    dossier_id: str
+
+
 @router.get("/{dossier_id}")
 def view_dossier(dossier_id: str, role: str = Depends(deps.get_current_role)) -> Dict[str, object]:
     """Return information about ``dossier_id`` if the user has access."""
@@ -147,4 +151,18 @@ def get_skills(
     if not can_read_projects(role, dossier.shareable):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "skills": list_skills(dossier)}
+
+
+@router.post("/snapshot")
+def snapshot_endpoint(
+    req: SnapshotRequest, role: str = Depends(deps.get_current_role)
+) -> Dict[str, str]:
+    if role != "ProjectManager":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    path = _dossier_path(req.dossier_id)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Dossier not found")
+    dossier = Dossier.load(path)
+    dest = dossier.snapshot()
+    return {"status": "ok", "path": str(dest)}
 

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -168,3 +168,12 @@ def test_add_activity_multiple_files(tmp_path, monkeypatch):
         "telemetry/2023-01-02.csv",
     }
     assert set(meta.get("telemetry_files", [])) == expected
+
+
+def test_dossier_snapshot(tmp_path):
+    dossier = Dossier.init_dossier(tmp_path)
+    snap_dir = dossier.snapshot()
+    assert snap_dir.parent == tmp_path / "history"
+    originals = {p.name for p in tmp_path.glob("*.yaml")}
+    copies = {p.name for p in snap_dir.glob("*.yaml")}
+    assert originals == copies

--- a/tests/test_dossier_cli.py
+++ b/tests/test_dossier_cli.py
@@ -66,6 +66,10 @@ async def add_skill(payload: dict):
 async def list_skills(dossier_id: str):
     return {'dossier_id': dossier_id, 'skills': ['s1']}
 
+@app.post('/dossier/snapshot')
+async def snapshot(payload: dict):
+    return {'dossier_id': payload['dossier_id'], 'path': '/d/h'}
+
 client = TestClient(app)
 
 def _wrap(method):
@@ -198,5 +202,18 @@ def test_dossier_list_skills(tmp_path: Path):
             "method": "GET",
             "url": "http://localhost:8000/dossier/skills/d6",
             "json": None,
+        }
+    ]
+
+
+def test_dossier_snapshot(tmp_path: Path):
+    proc, requests = _run_cli(tmp_path, ["dossier", "snapshot", "d7"])
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {"dossier_id": "d7", "path": "/d/h"}
+    assert requests == [
+        {
+            "method": "POST",
+            "url": "http://localhost:8000/dossier/snapshot",
+            "json": {"dossier_id": "d7"},
         }
     ]

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -187,6 +187,26 @@ def _dossier_list_skills(dossier_id: str) -> None:
         print(f"Request failed: {exc}")
 
 
+def _dossier_snapshot(dossier_id: str) -> None:
+    """Request a dossier snapshot from the API."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    payload = {"dossier_id": dossier_id}
+    try:
+        resp = httpx.post(
+            f"{base_url}/dossier/snapshot",
+            json=payload,
+            headers=headers,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
 def main() -> None:
     """Entry point for the ``ume-cli`` console script."""
     parser = argparse.ArgumentParser(description="UME CLI")
@@ -239,6 +259,8 @@ def main() -> None:
     skill_p.add_argument("skill")
     list_skills_p = dossier_sub.add_parser("list-skills", help="List skills")
     list_skills_p.add_argument("dossier_id")
+    snap_p = dossier_sub.add_parser("snapshot", help="Snapshot dossier")
+    snap_p.add_argument("dossier_id")
     for p in (up_parser, quick_parser):
         p.add_argument(
             "--no-confirm",
@@ -284,6 +306,8 @@ def main() -> None:
                 _dossier_add_skill(args.dossier_id, args.skill)
             elif args.dossier_cmd == "list-skills":
                 _dossier_list_skills(args.dossier_id)
+            elif args.dossier_cmd == "snapshot":
+                _dossier_snapshot(args.dossier_id)
             return
 
         configure_logging()


### PR DESCRIPTION
## Summary
- add Dossier.snapshot for archiving YAML files
- expose `/dossier/snapshot` API route and CLI command
- test snapshot functionality via API and CLI
- document snapshot usage

## Testing
- `ruff check .`
- `pytest tests/test_dossier.py tests/test_dossier_cli.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882c91eb21483269e437d17b0d0a4fa