### PR TITLE
Add dossier knowledge tests

### DIFF
--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -157,3 +157,23 @@ def test_reflection_and_pref_forbidden(tmp_path, monkeypatch):
     )
     assert res.status_code == 403
 
+
+def test_skill_listing_no_duplicates(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "ProjectManager", raising=False)
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    for _ in range(2):
+        res = client.post(
+            "/dossier/add-skill",
+            json={"dossier_id": "d6", "skill": "python"},
+            headers=headers,
+        )
+        assert res.status_code == 200
+
+    res = client.get("/dossier/skills/d6", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["skills"] == ["python"]
+

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -177,3 +177,53 @@ def test_dossier_snapshot(tmp_path):
     originals = {p.name for p in tmp_path.glob("*.yaml")}
     copies = {p.name for p in snap_dir.glob("*.yaml")}
     assert originals == copies
+
+
+def test_add_knowledge_and_listing(tmp_path):
+    dossier = Dossier.init_dossier(tmp_path)
+    add_value(dossier, "integrity")
+    add_value(dossier, "integrity")
+    add_skill(dossier, "rust")
+    add_skill(dossier, "rust")
+
+    assert dossier.values == ["integrity"]
+    assert list_skills(dossier) == ["rust"]
+
+    loaded = Dossier.load(tmp_path)
+    assert loaded.values == ["integrity"]
+    assert list_skills(loaded) == ["rust"]
+
+
+def test_encrypted_knowledge_roundtrip(tmp_path, monkeypatch):
+    import importlib
+
+    try:
+        from cryptography.fernet import Fernet
+    except Exception:
+        pytest.skip("cryptography not available")
+
+    from ume.config.loader import load_settings
+
+    key = Fernet.generate_key().decode()
+    monkeypatch.setenv("UME_ENCRYPTION_ENABLED", "true")
+    monkeypatch.setenv("UME_ENCRYPTION_KEY", key)
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+
+    import ume.config as cfg
+    load_settings.cache_clear()
+    importlib.reload(cfg)
+    import ume.dossier as dossier_mod
+    importlib.reload(dossier_mod)
+
+    dossier = dossier_mod.Dossier.init_dossier(tmp_path)
+    dossier_mod.add_value(dossier, "transparency")
+    dossier_mod.add_skill(dossier, "go")
+
+    raw_v = (tmp_path / "values.yaml").read_bytes()
+    raw_s = (tmp_path / "skills.yaml").read_bytes()
+    assert b"transparency" not in raw_v
+    assert b"go" not in raw_s
+
+    reloaded = dossier_mod.Dossier.load(tmp_path)
+    assert "transparency" in reloaded.values
+    assert "go" in reloaded.skills

--- a/tests/test_dossier_cli.py
+++ b/tests/test_dossier_cli.py
@@ -217,3 +217,25 @@ def test_dossier_snapshot(tmp_path: Path):
             "json": {"dossier_id": "d7"},
         }
     ]
+
+
+def test_dossier_add_skill_and_list(tmp_path: Path):
+    proc1, req1 = _run_cli(tmp_path, ["dossier", "add-skill", "d8", "go"])
+    proc2, req2 = _run_cli(tmp_path, ["dossier", "list-skills", "d8"])
+
+    assert proc1.returncode == 0
+    assert proc2.returncode == 0
+    assert req1 == [
+        {
+            "method": "POST",
+            "url": "http://localhost:8000/dossier/add-skill",
+            "json": {"dossier_id": "d8", "skill": "go"},
+        }
+    ]
+    assert req2 == [
+        {
+            "method": "GET",
+            "url": "http://localhost:8000/dossier/skills/d8",
+            "json": None,
+        }
+    ]


### PR DESCRIPTION
## Summary
- cover dossier knowledge helpers
- test API skills listing
- test CLI add/list skills

## Testing
- `pre-commit run --files tests/test_dossier.py tests/test_api_dossier.py tests/test_dossier_cli.py`
- `pytest tests/test_dossier.py tests/test_api_dossier.py tests/test_dossier_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_6882dbf17908832689b0bef6b2c1f8ca