### PR TITLE
Add knowledge section to dossier

### DIFF
--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -11,6 +11,7 @@ A newly initialized dossier contains:
 - `projects.yaml` – list of active projects
 - `preferences.yaml` – arbitrary key/value settings
 - `reflections.yaml` – journal style reflections
+- `knowledge.yaml` – saved knowledge or memories
 - `values.yaml` – list of personal values
 - `skills.yaml` – list of personal skills
 - `telemetry/` – directory for captured traces
@@ -43,6 +44,12 @@ ume dossier add-skill user123 python
 
 # List skills
 ume dossier list-skills user123
+
+# Add a memory
+ume dossier add-memory user123 "remember this"
+
+# List memories
+ume dossier list-memories user123
 ```
 
 ## API Examples
@@ -70,6 +77,15 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 # List skills
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:8000/dossier/skills/user123
+
+# Add a memory
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"dossier_id":"user123","text":"remember this"}' \
+  http://localhost:8000/dossier/add-memory
+
+# List memories
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/dossier/memories/user123
 ```
 
 ## Migrating Existing Dossiers

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -42,6 +42,7 @@ class Dossier:
     projects: list[dict[str, Any]] = field(default_factory=list)
     preferences: dict[str, Any] = field(default_factory=dict)
     reflections: list[dict[str, Any]] = field(default_factory=list)
+    knowledge: list[dict[str, Any]] = field(default_factory=list)
     values: list[str] = field(default_factory=list)
     skills: list[str] = field(default_factory=list)
     telemetry_files: list[str] = field(default_factory=list)
@@ -83,6 +84,7 @@ class Dossier:
             self._write_yaml(self.root / "projects.yaml", {"projects": self.projects})
             self._write_yaml(self.root / "preferences.yaml", self.preferences)
             self._write_yaml(self.root / "reflections.yaml", self.reflections)
+            self._write_yaml(self.root / "knowledge.yaml", self.knowledge)
             self._write_yaml(self.root / "values.yaml", self.values)
             self._write_yaml(self.root / "skills.yaml", self.skills)
 
@@ -102,6 +104,7 @@ class Dossier:
             self.projects = proj
         self.preferences = self._read_yaml(self.root / "preferences.yaml") or {}
         self.reflections = self._read_yaml(self.root / "reflections.yaml") or []
+        self.knowledge = self._read_yaml(self.root / "knowledge.yaml") or []
         self.values = self._read_yaml(self.root / "values.yaml") or []
         self.skills = self._read_yaml(self.root / "skills.yaml") or []
 
@@ -125,6 +128,14 @@ class Dossier:
             r.setdefault("attachments", [])
             normalized_reflections.append(r)
         self.reflections = normalized_reflections
+
+        normalized_knowledge = []
+        for k in self.knowledge:
+            k.setdefault("id", str(uuid4()))
+            k.setdefault("links", [])
+            k.setdefault("attachments", [])
+            normalized_knowledge.append(k)
+        self.knowledge = normalized_knowledge
 
     def add_activity(self, payload: dict[str, Any]) -> None:
         """Append ``payload`` to ``telemetry/activity.log`` if allowed."""
@@ -282,3 +293,27 @@ def add_skill(dossier: Dossier, skill: str) -> None:
 
 def list_skills(dossier: Dossier) -> list[str]:
     return list(dossier.skills)
+
+
+def add_memory(
+    dossier: Dossier,
+    text: str,
+    links: list[str] | None = None,
+    attachments: list[str] | None = None,
+) -> str:
+    """Append a knowledge entry and return its id."""
+    entry_id = str(uuid4())
+    entry = {
+        "id": entry_id,
+        "text": text,
+        "timestamp": datetime.utcnow().isoformat(),
+        "links": links or [],
+        "attachments": attachments or [],
+    }
+    dossier.knowledge.append(entry)
+    dossier.save()
+    return entry_id
+
+
+def list_memories(dossier: Dossier) -> list[str]:
+    return [m.get("text", "") for m in dossier.knowledge]

--- a/src/ume/dossier/dossier_template/knowledge.yaml
+++ b/src/ume/dossier/dossier_template/knowledge.yaml
@@ -1,0 +1,2 @@
+# General knowledge entries
+[]

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -14,10 +14,12 @@ from .dossier import (
     Dossier,
     add_project as dossier_add_project,
     add_reflection,
+    add_memory,
     add_value,
     add_skill,
     list_projects,
     list_skills,
+    list_memories,
     update_preferences,
 )
 
@@ -36,6 +38,12 @@ class AddProjectRequest(BaseModel):
 
 
 class AddReflectionRequest(BaseModel):
+    dossier_id: str
+    text: str
+    links: list[str] | None = None
+
+
+class AddMemoryRequest(BaseModel):
     dossier_id: str
     text: str
     links: list[str] | None = None
@@ -103,6 +111,19 @@ def add_reflection_endpoint(
     return {"status": "ok"}
 
 
+@router.post("/add-memory")
+def add_memory_endpoint(
+    req: AddMemoryRequest, role: str = Depends(deps.get_current_role)
+) -> Dict[str, str]:
+    """Append a knowledge entry to the dossier."""
+    if role != "ProjectManager":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    path = _dossier_path(req.dossier_id)
+    dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
+    add_memory(dossier, req.text, req.links)
+    return {"status": "ok"}
+
+
 @router.post("/set-pref")
 def set_preference(
     req: SetPreferenceRequest, role: str = Depends(deps.get_current_role)
@@ -151,6 +172,19 @@ def get_skills(
     if not can_read_projects(role, dossier.shareable):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "skills": list_skills(dossier)}
+
+
+@router.get("/memories/{dossier_id}")
+def get_memories(
+    dossier_id: str, role: str = Depends(deps.get_current_role)
+) -> Dict[str, object]:
+    path = _dossier_path(dossier_id)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Dossier not found")
+    dossier = Dossier.load(path)
+    if not can_read_projects(role, dossier.shareable):
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return {"dossier_id": dossier_id, "memories": list_memories(dossier)}
 
 
 @router.post("/snapshot")

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -2,7 +2,7 @@ from fastapi.testclient import TestClient
 
 from ume.api import app
 from ume.config import settings
-from ume.dossier import Dossier, list_projects, list_skills
+from ume.dossier import Dossier, list_projects, list_skills, list_memories
 
 
 def _token(client: TestClient) -> str:
@@ -88,6 +88,13 @@ def test_reflection_and_pref_endpoints(tmp_path, monkeypatch):
     assert res.status_code == 200
 
     res = client.post(
+        "/dossier/add-memory",
+        json={"dossier_id": "d4", "text": "fact"},
+        headers=headers,
+    )
+    assert res.status_code == 200
+
+    res = client.post(
         "/dossier/set-pref",
         json={"dossier_id": "d4", "key": "theme", "value": "dark"},
         headers=headers,
@@ -117,9 +124,14 @@ def test_reflection_and_pref_endpoints(tmp_path, monkeypatch):
     assert res.status_code == 200
     assert res.json()["skills"] == ["python"]
 
+    res = client.get("/dossier/memories/d4", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["memories"] == ["fact"]
+
     dossier = Dossier.load(tmp_path / "d4")
     assert dossier.values == ["honesty"]
     assert list_skills(dossier) == ["python"]
+    assert list_memories(dossier) == ["fact"]
 
 
 def test_reflection_and_pref_forbidden(tmp_path, monkeypatch):
@@ -153,6 +165,13 @@ def test_reflection_and_pref_forbidden(tmp_path, monkeypatch):
     res = client.post(
         "/dossier/add-skill",
         json={"dossier_id": "d5", "skill": "python"},
+        headers=headers,
+    )
+    assert res.status_code == 403
+
+    res = client.post(
+        "/dossier/add-memory",
+        json={"dossier_id": "d5", "text": "idea"},
         headers=headers,
     )
     assert res.status_code == 403

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -8,10 +8,12 @@ from ume.dossier import (
     Dossier,
     add_project,
     add_reflection,
+    add_memory,
     add_value,
     add_skill,
     list_projects,
     list_skills,
+    list_memories,
     update_preferences,
 )
 
@@ -29,6 +31,7 @@ def test_dossier_init_and_helpers(tmp_path):
     pid = add_project(dossier, "demo", attachments=["file.txt"])
 
     rid = add_reflection(dossier, "thinking", links=[pid], attachments=["img.png"])
+    mid = add_memory(dossier, "fact", links=[rid])
     add_value(dossier, "honesty")
     add_skill(dossier, "python")
     update_preferences(dossier, theme="dark")
@@ -43,7 +46,11 @@ def test_dossier_init_and_helpers(tmp_path):
     assert reloaded.reflections[0]["id"] == rid
     assert reloaded.reflections[0]["links"] == [pid]
     assert reloaded.reflections[0]["attachments"] == ["img.png"]
+    assert reloaded.knowledge[0]["text"] == "fact"
+    assert reloaded.knowledge[0]["links"] == [rid]
+    assert reloaded.knowledge[0]["id"] == mid
     assert reloaded.values == ["honesty"]
+    assert list_memories(reloaded) == ["fact"]
     assert list_skills(reloaded) == ["python"]
     assert reloaded.projects[0]["id"] == pid
     assert reloaded.projects[0]["links"] == []

--- a/tests/test_dossier_cli.py
+++ b/tests/test_dossier_cli.py
@@ -50,6 +50,10 @@ async def add_project(payload: dict):
 async def add_reflection(payload: dict):
     return {'dossier_id': payload['dossier_id'], 'reflection': payload['text']}
 
+@app.post('/dossier/add-memory')
+async def add_memory(payload: dict):
+    return {'dossier_id': payload['dossier_id'], 'memory': payload['text']}
+
 @app.post('/dossier/set-pref')
 async def set_pref(payload: dict):
     return {'dossier_id': payload['dossier_id'], 'key': payload['key'], 'value': payload['value']}
@@ -65,6 +69,10 @@ async def add_skill(payload: dict):
 @app.get('/dossier/skills/{dossier_id}')
 async def list_skills(dossier_id: str):
     return {'dossier_id': dossier_id, 'skills': ['s1']}
+
+@app.get('/dossier/memories/{dossier_id}')
+async def list_memories(dossier_id: str):
+    return {'dossier_id': dossier_id, 'memories': ['m1']}
 
 @app.post('/dossier/snapshot')
 async def snapshot(payload: dict):
@@ -148,6 +156,24 @@ def test_dossier_add_reflection(tmp_path: Path):
     ]
 
 
+def test_dossier_add_memory(tmp_path: Path):
+    proc, requests = _run_cli(
+        tmp_path, ["dossier", "add-memory", "d2", "fact"]
+    )
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {
+        "dossier_id": "d2",
+        "memory": "fact",
+    }
+    assert requests == [
+        {
+            "method": "POST",
+            "url": "http://localhost:8000/dossier/add-memory",
+            "json": {"dossier_id": "d2", "text": "fact"},
+        }
+    ]
+
+
 def test_dossier_set_pref(tmp_path: Path):
     proc, requests = _run_cli(
         tmp_path, ["dossier", "set-pref", "d3", "theme", "dark"]
@@ -201,6 +227,19 @@ def test_dossier_list_skills(tmp_path: Path):
         {
             "method": "GET",
             "url": "http://localhost:8000/dossier/skills/d6",
+            "json": None,
+        }
+    ]
+
+
+def test_dossier_list_memories(tmp_path: Path):
+    proc, requests = _run_cli(tmp_path, ["dossier", "list-memories", "d8"])
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {"dossier_id": "d8", "memories": ["m1"]}
+    assert requests == [
+        {
+            "method": "GET",
+            "url": "http://localhost:8000/dossier/memories/d8",
             "json": None,
         }
     ]

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -187,6 +187,44 @@ def _dossier_list_skills(dossier_id: str) -> None:
         print(f"Request failed: {exc}")
 
 
+def _dossier_add_memory(dossier_id: str, text: str) -> None:
+    """Send a request to append a memory entry."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    payload = {"dossier_id": dossier_id, "text": text}
+    try:
+        resp = httpx.post(
+            f"{base_url}/dossier/add-memory",
+            json=payload,
+            headers=headers,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
+def _dossier_list_memories(dossier_id: str) -> None:
+    """Fetch and print the memory list."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    try:
+        resp = httpx.get(
+            f"{base_url}/dossier/memories/{dossier_id}",
+            headers=headers,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
 def _dossier_snapshot(dossier_id: str) -> None:
     """Request a dossier snapshot from the API."""
     base_url = "http://localhost:8000"
@@ -247,6 +285,9 @@ def main() -> None:
     refl_p = dossier_sub.add_parser("add-reflection", help="Add a reflection entry")
     refl_p.add_argument("dossier_id")
     refl_p.add_argument("text")
+    mem_p = dossier_sub.add_parser("add-memory", help="Add a knowledge entry")
+    mem_p.add_argument("dossier_id")
+    mem_p.add_argument("text")
     pref_p = dossier_sub.add_parser("set-pref", help="Set a preference key")
     pref_p.add_argument("dossier_id")
     pref_p.add_argument("key")
@@ -257,6 +298,8 @@ def main() -> None:
     skill_p = dossier_sub.add_parser("add-skill", help="Add a skill entry")
     skill_p.add_argument("dossier_id")
     skill_p.add_argument("skill")
+    list_mem_p = dossier_sub.add_parser("list-memories", help="List knowledge entries")
+    list_mem_p.add_argument("dossier_id")
     list_skills_p = dossier_sub.add_parser("list-skills", help="List skills")
     list_skills_p.add_argument("dossier_id")
     snap_p = dossier_sub.add_parser("snapshot", help="Snapshot dossier")
@@ -298,12 +341,16 @@ def main() -> None:
                 _dossier_add_project(args.dossier_id, args.project_id)
             elif args.dossier_cmd == "add-reflection":
                 _dossier_add_reflection(args.dossier_id, args.text)
+            elif args.dossier_cmd == "add-memory":
+                _dossier_add_memory(args.dossier_id, args.text)
             elif args.dossier_cmd == "set-pref":
                 _dossier_set_pref(args.dossier_id, args.key, args.value)
             elif args.dossier_cmd == "add-value":
                 _dossier_add_value(args.dossier_id, args.value)
             elif args.dossier_cmd == "add-skill":
                 _dossier_add_skill(args.dossier_id, args.skill)
+            elif args.dossier_cmd == "list-memories":
+                _dossier_list_memories(args.dossier_id)
             elif args.dossier_cmd == "list-skills":
                 _dossier_list_skills(args.dossier_id)
             elif args.dossier_cmd == "snapshot":


### PR DESCRIPTION
## Summary
- extend Dossier with a new `knowledge` list backed by `knowledge.yaml`
- implement helpers `add_memory` and `list_memories`
- expose `/add-memory` and `/memories/{id}` API routes
- add corresponding CLI commands
- document the new section in DOSSIER_OVERVIEW
- include tests for knowledge features

## Testing
- `pre-commit run --files docs/DOSSIER_OVERVIEW.md src/ume/dossier/__init__.py src/ume/dossier_routes.py tests/test_api_dossier.py tests/test_dossier.py tests/test_dossier_cli.py ume_cli.py src/ume/dossier/dossier_template/knowledge.yaml`
- `pytest -q tests/test_dossier.py tests/test_dossier_cli.py tests/test_api_dossier.py`

------
https://chatgpt.com/codex/tasks/task_e_6882dbf130048326b4fd6bc16f6a795b