### PR TITLE
Add section-level shareable flags

### DIFF
--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -96,11 +96,11 @@ The following snippet demonstrates how dossier permissions could be expressed in
 ```rego
 package ume.dossier
 
-# Allow reading projects if the dossier is shareable or the caller has a valid role
+# Allow reading projects if that section is shareable or the caller has a valid role
 default can_read_projects = false
 
 can_read_projects {
-    input.metadata.shareable
+    input.metadata.shareable_projects
 }
 
 can_read_projects {
@@ -108,6 +108,21 @@ can_read_projects {
 }
 
 can_read_projects {
+    input.role == "Viewer"
+}
+
+# Allow reading reflections if that section is shareable or the caller has a valid role
+default can_read_reflections = false
+
+can_read_reflections {
+    input.metadata.shareable_reflections
+}
+
+can_read_reflections {
+    input.role == "ProjectManager"
+}
+
+can_read_reflections {
     input.role == "Viewer"
 }
 

--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -6,7 +6,7 @@ The user dossier is a lightweight collection of YAML files that track basic prof
 
 A newly initialized dossier contains:
 
-- `meta.yaml` – schema version metadata
+- `meta.yaml` – schema version metadata and shareable flags
 - `profile.yaml` – basic user details (name, email)
 - `projects.yaml` – list of active projects
 - `preferences.yaml` – arbitrary key/value settings

--- a/scripts/migrate_dossier.py
+++ b/scripts/migrate_dossier.py
@@ -33,6 +33,12 @@ def _load_plain(root: Path) -> dict[str, Any]:
     return {
         "schema_version": int(meta.get("schema_version", 1)),
         "shareable": bool(meta.get("shareable", False)),
+        "shareable_projects": bool(
+            meta.get("shareable_projects", meta.get("shareable", False))
+        ),
+        "shareable_reflections": bool(
+            meta.get("shareable_reflections", meta.get("shareable", False))
+        ),
         "telemetry_files": meta.get("telemetry_files", []),
         "profile": profile,
         "projects": projects,
@@ -60,6 +66,8 @@ def migrate_dossier(path: Path, *, encrypt: bool = False) -> None:
     dossier = dossier_mod.Dossier(path)
     dossier.schema_version = dossier_mod.Dossier.schema_version
     dossier.shareable = data["shareable"]
+    dossier.shareable_projects = data["shareable_projects"]
+    dossier.shareable_reflections = data["shareable_reflections"]
     dossier.profile = data["profile"]
     dossier.projects = data["projects"]
     dossier.preferences = data["preferences"]

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -38,6 +38,8 @@ class Dossier:
     root: Path
     schema_version: int = 1
     shareable: bool = False
+    shareable_projects: bool = False
+    shareable_reflections: bool = False
     profile: dict[str, Any] = field(default_factory=dict)
     projects: list[dict[str, Any]] = field(default_factory=list)
     preferences: dict[str, Any] = field(default_factory=dict)
@@ -77,6 +79,8 @@ class Dossier:
                 {
                     "schema_version": self.schema_version,
                     "shareable": self.shareable,
+                    "shareable_projects": self.shareable_projects,
+                    "shareable_reflections": self.shareable_reflections,
                     "telemetry_files": self.telemetry_files,
                 },
             )
@@ -95,6 +99,12 @@ class Dossier:
         meta = self._read_yaml(self.root / "meta.yaml") or {}
         self.schema_version = int(meta.get("schema_version", self.schema_version))
         self.shareable = bool(meta.get("shareable", self.shareable))
+        self.shareable_projects = bool(
+            meta.get("shareable_projects", meta.get("shareable", self.shareable))
+        )
+        self.shareable_reflections = bool(
+            meta.get("shareable_reflections", meta.get("shareable", self.shareable))
+        )
         self.telemetry_files = meta.get("telemetry_files", [])
         self.profile = self._read_yaml(self.root / "profile.yaml") or {}
         proj = self._read_yaml(self.root / "projects.yaml") or {}
@@ -187,6 +197,8 @@ class Dossier:
                     {
                         "schema_version": self.schema_version,
                         "shareable": self.shareable,
+                        "shareable_projects": self.shareable_projects,
+                        "shareable_reflections": self.shareable_reflections,
                         "telemetry_files": self.telemetry_files,
                     },
                 )

--- a/src/ume/dossier/dossier_template/meta.yaml
+++ b/src/ume/dossier/dossier_template/meta.yaml
@@ -1,3 +1,5 @@
 schema_version: 1
 shareable: false
+shareable_projects: false
+shareable_reflections: false
 telemetry_files: []

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -76,9 +76,14 @@ def view_dossier(dossier_id: str, role: str = Depends(deps.get_current_role)) ->
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_projects(role, dossier.shareable):
+    if not can_read_projects(role, dossier.shareable_projects):
         raise HTTPException(status_code=403, detail="Not authorized")
-    return {"dossier_id": dossier_id, "projects": list_projects(dossier), "shareable": dossier.shareable}
+    return {
+        "dossier_id": dossier_id,
+        "projects": list_projects(dossier),
+        "shareable_projects": dossier.shareable_projects,
+        "shareable_reflections": dossier.shareable_reflections,
+    }
 
 
 @router.post("/add-project")
@@ -94,7 +99,12 @@ def add_project(req: AddProjectRequest, role: str = Depends(deps.get_current_rol
     dossier_add_project(dossier, req.project_id)
     return cast(
         Dict[str, object],
-        {"dossier_id": req.dossier_id, "projects": list_projects(dossier), "shareable": dossier.shareable},
+        {
+            "dossier_id": req.dossier_id,
+            "projects": list_projects(dossier),
+            "shareable_projects": dossier.shareable_projects,
+            "shareable_reflections": dossier.shareable_reflections,
+        },
     )
 
 
@@ -169,7 +179,7 @@ def get_skills(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_projects(role, dossier.shareable):
+    if not can_read_projects(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "skills": list_skills(dossier)}
 
@@ -182,7 +192,7 @@ def get_memories(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_projects(role, dossier.shareable):
+    if not can_read_projects(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "memories": list_memories(dossier)}
 

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -27,6 +27,8 @@ def test_dossier_init_and_helpers(tmp_path):
     dossier = Dossier.init_dossier(tmp_path)
     assert dossier.schema_version == Dossier.schema_version
     assert dossier.shareable is False
+    assert dossier.shareable_projects is False
+    assert dossier.shareable_reflections is False
 
     pid = add_project(dossier, "demo", attachments=["file.txt"])
 
@@ -37,6 +39,8 @@ def test_dossier_init_and_helpers(tmp_path):
     update_preferences(dossier, theme="dark")
 
     dossier.shareable = True
+    dossier.shareable_projects = True
+    dossier.shareable_reflections = True
     dossier.save()
 
     reloaded = Dossier.load(tmp_path)
@@ -58,6 +62,8 @@ def test_dossier_init_and_helpers(tmp_path):
     uuid.UUID(reloaded.projects[0]["id"])
     uuid.UUID(reloaded.reflections[0]["id"])
     assert reloaded.shareable is True
+    assert reloaded.shareable_projects is True
+    assert reloaded.shareable_reflections is True
 
 
 def test_dossier_env_load(tmp_path, monkeypatch):

--- a/tests/test_dossier_rego_policy.py
+++ b/tests/test_dossier_rego_policy.py
@@ -24,10 +24,15 @@ def test_access_control_rego() -> None:
     interp = Interpreter()
     interp.add_module("dossier.rego", policy)
 
-    assert _eval(interp, "can_read_projects", role="ProjectManager", metadata={"shareable": False})
-    assert _eval(interp, "can_read_projects", role="Viewer", metadata={"shareable": False})
-    assert _eval(interp, "can_read_projects", role="Other", metadata={"shareable": True})
-    assert not _eval(interp, "can_read_projects", role="Other", metadata={"shareable": False})
+    assert _eval(interp, "can_read_projects", role="ProjectManager", metadata={"shareable_projects": False})
+    assert _eval(interp, "can_read_projects", role="Viewer", metadata={"shareable_projects": False})
+    assert _eval(interp, "can_read_projects", role="Other", metadata={"shareable_projects": True})
+    assert not _eval(interp, "can_read_projects", role="Other", metadata={"shareable_projects": False})
+
+    assert _eval(interp, "can_read_reflections", role="ProjectManager", metadata={"shareable_reflections": False})
+    assert _eval(interp, "can_read_reflections", role="Viewer", metadata={"shareable_reflections": False})
+    assert _eval(interp, "can_read_reflections", role="Other", metadata={"shareable_reflections": True})
+    assert not _eval(interp, "can_read_reflections", role="Other", metadata={"shareable_reflections": False})
 
     assert _eval(interp, "allow_add_project", role="ProjectManager")
     assert not _eval(interp, "allow_add_project", role="Viewer")


### PR DESCRIPTION
## Summary
- extend `meta.yaml` schema with `shareable_projects` and `shareable_reflections`
- load and save new shareable flags in `Dossier`
- enforce section flags in dossier endpoints
- update migration script and docs
- adjust dossier tests and policy snippet

## Testing
- `pre-commit run --files docs/ACCESS_CONTROL.md docs/DOSSIER_OVERVIEW.md scripts/migrate_dossier.py src/ume/dossier/__init__.py src/ume/dossier/dossier_template/meta.yaml src/ume/dossier_routes.py tests/test_dossier.py tests/test_dossier_rego_policy.py`
- `pytest tests/test_dossier.py tests/test_dossier_rego_policy.py tests/test_api_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e1936c908326a36203c9630efe27