### PR TITLE
Add dossier listing commands

### DIFF
--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -45,6 +45,12 @@ ume dossier add-skill user123 python
 # List skills
 ume dossier list-skills user123
 
+# List projects
+ume dossier list-projects user123
+
+# List reflections
+ume dossier list-reflections user123
+
 # Add a memory
 ume dossier add-memory user123 "remember this"
 
@@ -77,6 +83,14 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 # List skills
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:8000/dossier/skills/user123
+
+# List projects
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/dossier/projects/user123
+
+# List reflections
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/dossier/reflections/user123
 
 # Add a memory
 curl -X POST -H "Authorization: Bearer $TOKEN" \

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -269,6 +269,11 @@ def add_reflection(
     dossier.save()
     return entry_id
 
+
+def list_reflections(dossier: Dossier) -> list[str]:
+    """Return a list of reflection texts."""
+    return [r.get("text", "") for r in dossier.reflections]
+
 def list_projects(dossier: Dossier) -> list[str]:
     return [p.get("name", "") for p in dossier.projects]
 

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -18,6 +18,7 @@ from .dossier import (
     add_value,
     add_skill,
     list_projects,
+    list_reflections,
     list_skills,
     list_memories,
     update_preferences,
@@ -159,6 +160,32 @@ def add_skill_endpoint(
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
     add_skill(dossier, req.skill)
     return {"status": "ok"}
+
+
+@router.get("/projects/{dossier_id}")
+def get_projects(
+    dossier_id: str, role: str = Depends(deps.get_current_role)
+) -> Dict[str, object]:
+    path = _dossier_path(dossier_id)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Dossier not found")
+    dossier = Dossier.load(path)
+    if not can_read_projects(role, dossier.shareable):
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return {"dossier_id": dossier_id, "projects": list_projects(dossier)}
+
+
+@router.get("/reflections/{dossier_id}")
+def get_reflections(
+    dossier_id: str, role: str = Depends(deps.get_current_role)
+) -> Dict[str, object]:
+    path = _dossier_path(dossier_id)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Dossier not found")
+    dossier = Dossier.load(path)
+    if not can_read_projects(role, dossier.shareable):
+        raise HTTPException(status_code=403, detail="Not authorized")
+    return {"dossier_id": dossier_id, "reflections": list_reflections(dossier)}
 
 
 @router.get("/skills/{dossier_id}")

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -101,6 +101,13 @@ def test_reflection_and_pref_endpoints(tmp_path, monkeypatch):
     )
     assert res.status_code == 200
 
+    res = client.post(
+        "/dossier/add-project",
+        json={"dossier_id": "d4", "project_id": "p4"},
+        headers=headers,
+    )
+    assert res.status_code == 200
+
     dossier = Dossier.load(tmp_path / "d4")
     assert dossier.reflections[0]["text"] == "thinking"
     assert "id" in dossier.reflections[0]
@@ -123,6 +130,14 @@ def test_reflection_and_pref_endpoints(tmp_path, monkeypatch):
     res = client.get("/dossier/skills/d4", headers=headers)
     assert res.status_code == 200
     assert res.json()["skills"] == ["python"]
+
+    res = client.get("/dossier/projects/d4", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["projects"] == ["p4"]
+
+    res = client.get("/dossier/reflections/d4", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["reflections"] == ["thinking"]
 
     res = client.get("/dossier/memories/d4", headers=headers)
     assert res.status_code == 200

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -11,6 +11,7 @@ from ume.dossier import (
     add_memory,
     add_value,
     add_skill,
+    list_reflections,
     list_projects,
     list_skills,
     list_memories,
@@ -50,6 +51,7 @@ def test_dossier_init_and_helpers(tmp_path):
     assert reloaded.knowledge[0]["links"] == [rid]
     assert reloaded.knowledge[0]["id"] == mid
     assert reloaded.values == ["honesty"]
+    assert list_reflections(reloaded) == ["thinking"]
     assert list_memories(reloaded) == ["fact"]
     assert list_skills(reloaded) == ["python"]
     assert reloaded.projects[0]["id"] == pid

--- a/tests/test_dossier_cli.py
+++ b/tests/test_dossier_cli.py
@@ -66,6 +66,14 @@ async def add_value(payload: dict):
 async def add_skill(payload: dict):
     return {'dossier_id': payload['dossier_id'], 'skill': payload['skill']}
 
+@app.get('/dossier/projects/{dossier_id}')
+async def list_projects(dossier_id: str):
+    return {'dossier_id': dossier_id, 'projects': ['p1']}
+
+@app.get('/dossier/reflections/{dossier_id}')
+async def list_reflections(dossier_id: str):
+    return {'dossier_id': dossier_id, 'reflections': ['r1']}
+
 @app.get('/dossier/skills/{dossier_id}')
 async def list_skills(dossier_id: str):
     return {'dossier_id': dossier_id, 'skills': ['s1']}
@@ -275,6 +283,34 @@ def test_dossier_add_skill_and_list(tmp_path: Path):
         {
             "method": "GET",
             "url": "http://localhost:8000/dossier/skills/d8",
+            "json": None,
+        }
+    ]
+
+
+def test_list_projects(tmp_path: Path):
+    proc, requests = _run_cli(tmp_path, ["dossier", "list-projects", "d9"])
+
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {"dossier_id": "d9", "projects": ["p1"]}
+    assert requests == [
+        {
+            "method": "GET",
+            "url": "http://localhost:8000/dossier/projects/d9",
+            "json": None,
+        }
+    ]
+
+
+def test_list_reflections(tmp_path: Path):
+    proc, requests = _run_cli(tmp_path, ["dossier", "list-reflections", "d10"])
+
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {"dossier_id": "d10", "reflections": ["r1"]}
+    assert requests == [
+        {
+            "method": "GET",
+            "url": "http://localhost:8000/dossier/reflections/d10",
             "json": None,
         }
     ]

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -187,6 +187,42 @@ def _dossier_list_skills(dossier_id: str) -> None:
         print(f"Request failed: {exc}")
 
 
+def _dossier_list_projects(dossier_id: str) -> None:
+    """Fetch and print the project list."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    try:
+        resp = httpx.get(
+            f"{base_url}/dossier/projects/{dossier_id}",
+            headers=headers,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
+def _dossier_list_reflections(dossier_id: str) -> None:
+    """Fetch and print the reflection list."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    try:
+        resp = httpx.get(
+            f"{base_url}/dossier/reflections/{dossier_id}",
+            headers=headers,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
 def _dossier_add_memory(dossier_id: str, text: str) -> None:
     """Send a request to append a memory entry."""
     base_url = "http://localhost:8000"
@@ -298,6 +334,14 @@ def main() -> None:
     skill_p = dossier_sub.add_parser("add-skill", help="Add a skill entry")
     skill_p.add_argument("dossier_id")
     skill_p.add_argument("skill")
+    list_proj_p = dossier_sub.add_parser(
+        "list-projects", help="List projects"
+    )
+    list_proj_p.add_argument("dossier_id")
+    list_refl_p = dossier_sub.add_parser(
+        "list-reflections", help="List reflections"
+    )
+    list_refl_p.add_argument("dossier_id")
     list_mem_p = dossier_sub.add_parser("list-memories", help="List knowledge entries")
     list_mem_p.add_argument("dossier_id")
     list_skills_p = dossier_sub.add_parser("list-skills", help="List skills")
@@ -353,6 +397,10 @@ def main() -> None:
                 _dossier_list_memories(args.dossier_id)
             elif args.dossier_cmd == "list-skills":
                 _dossier_list_skills(args.dossier_id)
+            elif args.dossier_cmd == "list-projects":
+                _dossier_list_projects(args.dossier_id)
+            elif args.dossier_cmd == "list-reflections":
+                _dossier_list_reflections(args.dossier_id)
             elif args.dossier_cmd == "snapshot":
                 _dossier_snapshot(args.dossier_id)
             return


### PR DESCRIPTION
## Summary
- add `list_reflections` helper
- implement listing routes for projects and reflections
- expose new list commands in CLI
- update docs
- test the new routes and CLI features

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini --strict src/ume`
- `pytest tests/test_dossier_cli.py tests/test_api_dossier.py tests/test_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882e192f350832698dcd6c5b7f2aa0a