### PR TITLE
Add TelemetryAdmin role with RBAC checks

### DIFF
--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -54,14 +54,14 @@ Without the `UserService` role the command raises `AccessDeniedError`.
 
 ## Dossier Endpoint RBAC
 
-API routes under `/dossier` use their own role checks. Two roles are
+API routes under `/dossier` use their own role checks. Three roles are
 implemented today:
 
 - **ProjectManager** – allowed to view any dossier and attach new projects.
 - **Viewer** – allowed to view dossier information but not modify it.
+- **TelemetryAdmin** – allowed to create snapshots and update activity logs.
 
-A future **TelemetryAdmin** role will enable privileged updates to telemetry
-files stored in each dossier. The HTTP server reads the current role from the
+The HTTP server reads the current role from the
 OAuth token via `UME_OAUTH_ROLE`. Command line tools can specify `UME_ROLE` to
 emulate the same restrictions.
 

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from . import api_deps as deps
-from .policy import can_read_projects
+from .policy import can_read_projects, can_modify_telemetry
 
 from .dossier import (
     Dossier,
@@ -68,6 +68,11 @@ class AddSkillRequest(BaseModel):
 
 class SnapshotRequest(BaseModel):
     dossier_id: str
+
+
+class AddActivityRequest(BaseModel):
+    dossier_id: str
+    payload: Dict[str, Any]
 
 
 @router.get("/{dossier_id}")
@@ -228,7 +233,7 @@ def get_memories(
 def snapshot_endpoint(
     req: SnapshotRequest, role: str = Depends(deps.get_current_role)
 ) -> Dict[str, str]:
-    if role != "ProjectManager":
+    if not can_modify_telemetry(role):
         raise HTTPException(status_code=403, detail="Not authorized")
     path = _dossier_path(req.dossier_id)
     if not path.exists():
@@ -236,4 +241,19 @@ def snapshot_endpoint(
     dossier = Dossier.load(path)
     dest = dossier.snapshot()
     return {"status": "ok", "path": str(dest)}
+
+
+@router.post("/add-activity")
+def add_activity_endpoint(
+    req: AddActivityRequest, role: str = Depends(deps.get_current_role)
+) -> Dict[str, str]:
+    """Append an activity entry to the dossier telemetry log."""
+    if not can_modify_telemetry(role):
+        raise HTTPException(status_code=403, detail="Not authorized")
+    path = _dossier_path(req.dossier_id)
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Dossier not found")
+    dossier = Dossier.load(path)
+    dossier.add_activity(req.payload)
+    return {"status": "ok"}
 

--- a/tests/test_dossier_telemetry_rbac.py
+++ b/tests/test_dossier_telemetry_rbac.py
@@ -1,0 +1,46 @@
+from fastapi.testclient import TestClient
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+from ume.dossier import Dossier
+
+
+def _client(role: str):
+    configure_graph(MockGraph())
+    object.__setattr__(settings, "UME_API_TOKEN", "tkn")
+    object.__setattr__(settings, "UME_API_ROLE", role)
+    return TestClient(app)
+
+
+def test_snapshot_permission(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    Dossier.init_dossier(tmp_path / "d1")
+
+    client = _client("ProjectManager")
+    res = client.post("/dossier/snapshot", json={"dossier_id": "d1"}, headers={"Authorization": "Bearer tkn"})
+    assert res.status_code == 403
+
+    client = _client("TelemetryAdmin")
+    res = client.post("/dossier/snapshot", json={"dossier_id": "d1"}, headers={"Authorization": "Bearer tkn"})
+    assert res.status_code == 200
+
+
+def test_add_activity_permission(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    Dossier.init_dossier(tmp_path / "d2")
+
+    client = _client("Viewer")
+    res = client.post(
+        "/dossier/add-activity",
+        json={"dossier_id": "d2", "payload": {"a": 1}},
+        headers={"Authorization": "Bearer tkn"},
+    )
+    assert res.status_code == 403
+
+    client = _client("TelemetryAdmin")
+    res = client.post(
+        "/dossier/add-activity",
+        json={"dossier_id": "d2", "payload": {"a": 1}},
+        headers={"Authorization": "Bearer tkn"},
+    )
+    assert res.status_code == 200


### PR DESCRIPTION
## Summary
- document TelemetryAdmin role
- require TelemetryAdmin role to snapshot or log activity
- add `/dossier/add-activity` endpoint
- test telemetry permissions

## Testing
- `pre-commit run --files docs/ACCESS_CONTROL.md src/ume/dossier_routes.py tests/test_dossier_telemetry_rbac.py`
- `pytest -q tests/test_dossier_telemetry_rbac.py`

------
https://chatgpt.com/codex/tasks/task_e_6882ea2abf788326851994892cf483ac