### PR TITLE
Add dossier snapshot scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,6 +969,12 @@ curl -X POST http://localhost:8000/snapshot/save \
   -d '{"path":"ume_backup.json"}'
 ```
 
+To archive the dossier at regular intervals:
+
+```bash
+ume dossier snapshot-schedule --interval 300
+```
+
 ## Graph Analytics with Neo4j GDS
 
 When using `Neo4jGraph` with the `use_gds=True` option, UME can delegate graph

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -98,6 +98,10 @@ from .resources import (
 from .dag_service import DAGService
 from .resource_scheduler import ResourceScheduler, ScheduledTask
 from .dossier import Dossier
+from .dossier.scheduler import (
+    start_dossier_snapshot_scheduler,
+    stop_dossier_snapshot_scheduler,
+)
 
 # Import the API lazily via __getattr__ to avoid circular imports during
 # initialization. The ``api`` module will be loaded on first attribute access.
@@ -139,6 +143,8 @@ __all__ = [
     "stop_vector_age_scheduler",
     "start_ledger_compaction_scheduler",
     "stop_ledger_compaction_scheduler",
+    "start_dossier_snapshot_scheduler",
+    "stop_dossier_snapshot_scheduler",
     "validate_event_dict",
     "GraphSchema",
     "load_default_schema",

--- a/src/ume/audit.py
+++ b/src/ume/audit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from .config import settings
 import json
 import time
@@ -5,12 +7,12 @@ import hmac
 import hashlib
 import logging
 import os
-from typing import List, Dict, cast
+from typing import Dict, List
 
 try:
     from cryptography.fernet import Fernet
 except Exception:  # pragma: no cover - cryptography optional
-    Fernet = None
+    Fernet = None  # type: ignore[misc, assignment]
 
 try:
     import boto3
@@ -24,8 +26,9 @@ logger = logging.getLogger(__name__)
 AUDIT_LOG_PATH = settings.UME_AUDIT_LOG_PATH
 SIGNING_KEY = settings.UME_AUDIT_SIGNING_KEY.encode()
 ENCRYPTION_ENABLED = settings.UME_ENCRYPTION_ENABLED
+_fernet: Fernet | None
 if ENCRYPTION_ENABLED:
-    if not (Fernet and settings.UME_ENCRYPTION_KEY):
+    if Fernet is None or not settings.UME_ENCRYPTION_KEY:
         raise ValueError("Encryption enabled but cryptography not available or key not set")
     _fernet = Fernet(settings.UME_ENCRYPTION_KEY.encode())
 else:
@@ -70,8 +73,9 @@ def _read_lines(path: str) -> List[str]:
             return []
 
         if ENCRYPTION_ENABLED:
+            assert _fernet is not None
             try:
-                text = cast(bytes, _fernet.decrypt(raw)).decode()
+                text = _fernet.decrypt(raw).decode()
             except Exception as exc:
                 logger.error("Failed to decrypt audit log from %s: %s", path, exc)
                 return []
@@ -89,8 +93,9 @@ def _read_lines(path: str) -> List[str]:
                     raw = f.read()
                 if not raw:
                     return []
+                assert _fernet is not None
                 try:
-                    text = cast(bytes, _fernet.decrypt(raw)).decode()
+                    text = _fernet.decrypt(raw).decode()
                 except Exception as exc:
                     logger.error("Failed to decrypt audit log from %s: %s", path, exc)
                     return []
@@ -109,6 +114,7 @@ def _write_lines(path: str, lines: List[str]) -> None:
     data = "\n".join(lines) + "\n"
     payload: bytes
     if ENCRYPTION_ENABLED:
+        assert _fernet is not None
         payload = _fernet.encrypt(data.encode())
     else:
         payload = data.encode()

--- a/src/ume/consent_ledger.py
+++ b/src/ume/consent_ledger.py
@@ -9,7 +9,7 @@ from typing import Optional
 try:
     from cryptography.fernet import Fernet
 except Exception:  # pragma: no cover - cryptography optional
-    Fernet = None
+    Fernet = None  # type: ignore[misc, assignment]
 
 from .config import settings
 
@@ -21,7 +21,7 @@ class ConsentLedger:
         self.db_path = db_path or settings.UME_CONSENT_LEDGER_PATH
         self.encryption_enabled = settings.UME_ENCRYPTION_ENABLED
         if self.encryption_enabled:
-            if not (Fernet and settings.UME_ENCRYPTION_KEY):
+            if Fernet is None or not settings.UME_ENCRYPTION_KEY:
                 raise ValueError("Encryption enabled but cryptography not available or key not set")
             self._fernet = Fernet(settings.UME_ENCRYPTION_KEY.encode())
             self._plain_path = self.db_path + ".dec"

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -11,18 +11,19 @@ import json
 
 from filelock import FileLock
 
-import yaml
+import yaml  # type: ignore
 
 try:
     from cryptography.fernet import Fernet
 except Exception:  # pragma: no cover - cryptography optional
-    Fernet = None
+    Fernet = None  # type: ignore[misc, assignment]
 
 from ..config import settings
 
 ENCRYPTION_ENABLED = settings.UME_ENCRYPTION_ENABLED
+_fernet: Fernet | None
 if ENCRYPTION_ENABLED:
-    if not (Fernet and settings.UME_ENCRYPTION_KEY):
+    if Fernet is None or not settings.UME_ENCRYPTION_KEY:
         raise ValueError(
             "Encryption enabled but cryptography not available or key not set"
         )
@@ -161,6 +162,7 @@ class Dossier:
         lock = FileLock(str(log_dir / ".activity.lock"))
         with lock:
             if ENCRYPTION_ENABLED:
+                assert _fernet is not None
                 token = _fernet.encrypt(data.encode()).decode()
                 with log_path.open("a", encoding="utf-8") as f:
                     f.write(token + "\n")
@@ -171,6 +173,7 @@ class Dossier:
             # Daily CSV log
             csv_path = log_dir / f"{now.date().isoformat()}.csv"
             if ENCRYPTION_ENABLED:
+                assert _fernet is not None
                 csv_token = _fernet.encrypt(data.encode()).decode()
                 with csv_path.open("a", encoding="utf-8") as f:
                     f.write(csv_token + "\n")
@@ -212,6 +215,7 @@ class Dossier:
                 raw = f.read()
             if not raw:
                 return None
+            assert _fernet is not None
             data = _fernet.decrypt(raw).decode()
             return yaml.safe_load(data) or None
         else:
@@ -222,6 +226,7 @@ class Dossier:
     def _write_yaml(path: Path, data: Any) -> None:
         text = yaml.safe_dump(data)
         if ENCRYPTION_ENABLED:
+            assert _fernet is not None
             payload = _fernet.encrypt(text.encode())
             with path.open("wb") as f:
                 f.write(payload)

--- a/src/ume/dossier/scheduler.py
+++ b/src/ume/dossier/scheduler.py
@@ -1,0 +1,73 @@
+import atexit
+import logging
+import threading
+from collections.abc import Callable
+
+from . import Dossier
+
+logger = logging.getLogger(__name__)
+
+_thread: threading.Thread | None = None
+_stop_event: threading.Event | None = None
+_atexit_handle: Callable[[], object] | None = None
+_thread_params: tuple[object, ...] | None = None
+
+def start_dossier_snapshot_scheduler(
+    dossier: Dossier,
+    *,
+    interval_seconds: float = 3600,
+) -> tuple[threading.Thread, Callable[[], None]]:
+    """Periodically call :meth:`Dossier.snapshot` in the background."""
+    global _thread, _stop_event, _atexit_handle, _thread_params
+
+    params = (dossier, interval_seconds)
+
+    if _thread and _thread.is_alive():
+        if params == _thread_params:
+            return _thread, lambda: None
+        stop_dossier_snapshot_scheduler()
+
+    stop_event = threading.Event()
+
+    def _snapshot() -> None:
+        try:
+            dossier.snapshot()
+        except Exception:
+            logger.exception("Failed to snapshot dossier at %s", dossier.root)
+
+    def _run() -> None:
+        while not stop_event.wait(interval_seconds):
+            _snapshot()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    _atexit_handle = atexit.register(_snapshot)
+
+    _thread = thread
+    _stop_event = stop_event
+    _thread_params = params
+
+    def stop() -> None:
+        stop_event.set()
+        thread.join()
+
+    return thread, stop
+
+
+def stop_dossier_snapshot_scheduler() -> None:
+    """Stop the dossier snapshot scheduler if running."""
+    global _thread, _stop_event, _atexit_handle, _thread_params
+
+    if _stop_event is not None:
+        _stop_event.set()
+    if _thread is not None and _thread.is_alive():
+        _thread.join()
+    if _atexit_handle is not None:
+        try:
+            atexit.unregister(_atexit_handle)
+        finally:
+            _atexit_handle = None
+    _thread = None
+    _stop_event = None
+    _thread_params = None

--- a/src/ume/event_ledger.py
+++ b/src/ume/event_ledger.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Tuple, Optional
 try:
     from cryptography.fernet import Fernet
 except Exception:  # pragma: no cover - cryptography optional
-    Fernet = None
+    Fernet = None  # type: ignore[misc, assignment]
 
 from .config import settings
 
@@ -21,7 +21,7 @@ class EventLedger:
         self.db_path = db_path or settings.UME_EVENT_LEDGER_PATH
         self.encryption_enabled = settings.UME_ENCRYPTION_ENABLED
         if self.encryption_enabled:
-            if not (Fernet and settings.UME_ENCRYPTION_KEY):
+            if Fernet is None or not settings.UME_ENCRYPTION_KEY:
                 raise ValueError("Encryption enabled but cryptography not available or key not set")
             self._fernet = Fernet(settings.UME_ENCRYPTION_KEY.encode())
             self._plain_path = self.db_path + ".dec"

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -566,6 +566,98 @@ def test_cli_snapshot_schedule(
         sys.modules.pop(mod, None)
 
 
+def test_cli_dossier_snapshot_schedule(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import importlib
+    import ume.dossier.scheduler as sched
+
+    stub = types.ModuleType("ume")
+    stub.PersistentGraph = object
+    stub.RoleBasedGraphAdapter = object
+    stub.enable_snapshot_autosave_and_restore = lambda *_, **__: None
+    stub.parse_event = lambda *_: None
+    stub.apply_event_to_graph = lambda *_: None
+    stub.load_graph_into_existing = lambda *_: None
+    stub.snapshot_graph_to_file = lambda *_: None
+    stub.ProcessingError = Exception
+    stub.EventError = Exception
+    stub.SnapshotError = Exception
+    stub.IGraphAdapter = object
+    stub.log_audit_entry = lambda *_: None
+    stub.get_audit_entries = lambda *_: []
+    stub.DEFAULT_SCHEMA_MANAGER = object()
+    bench = types.ModuleType("ume.benchmarks")
+    bench.benchmark_vector_store = lambda *_: None
+    feder = types.ModuleType("ume.federation")
+    feder.MirrorMakerDriver = object  # type: ignore[assignment]
+    cli_pkg = types.ModuleType("ume.cli")
+    compose_pkg = types.ModuleType("ume.cli.compose")
+    compose_pkg._compose_down = lambda *_, **__: None
+    compose_pkg._compose_ps = lambda *_, **__: None
+    compose_pkg._quickstart = lambda *_, **__: None
+    cli_pkg.compose = compose_pkg
+    prompt_pkg = types.ModuleType("ume.cli.prompt")
+    prompt_pkg.UMEPrompt = object
+    prompt_pkg.create_graph_adapter = lambda *_, **__: None
+    sys.modules["ume"] = stub
+    sys.modules["ume.benchmarks"] = bench
+    sys.modules["ume.federation"] = feder
+    dossier_mod = types.ModuleType("ume.dossier")
+    class DummyDossier:
+        root = Path("/tmp")
+
+        @classmethod
+        def load(cls):
+            return cls()
+
+    dossier_mod.Dossier = DummyDossier
+    dossier_mod.scheduler = sched
+    sys.modules["ume.dossier"] = dossier_mod
+    sys.modules["ume.dossier.scheduler"] = sched
+    sys.modules["ume.cli"] = cli_pkg
+    sys.modules["ume.cli.compose"] = compose_pkg
+    sys.modules["ume.cli.prompt"] = prompt_pkg
+
+    import ume_cli as cli
+    importlib.reload(cli)
+
+    called: dict[str, object] = {}
+
+    class DummyThread:
+        def is_alive(self) -> bool:
+            return False
+
+        def join(self, timeout: float | None = None) -> None:
+            pass
+
+    def fake_start(dossier: object, interval_seconds: int) -> tuple[DummyThread, callable]:
+        called["interval"] = interval_seconds
+        return DummyThread(), lambda: None
+
+    monkeypatch.setattr(sched, "start_dossier_snapshot_scheduler", fake_start)
+    monkeypatch.setattr(sched, "stop_dossier_snapshot_scheduler", lambda: None)
+
+    argv = sys.argv[:]
+    sys.argv = ["ume-cli", "dossier", "snapshot-schedule", "--interval", "1"]
+    cli.main()
+    out = capsys.readouterr().out
+    sys.argv = argv
+
+    assert called["interval"] == 1
+    assert "Snapshots will be written" in out
+
+    for mod in [
+        "ume.cli.compose",
+        "ume.cli",
+        "ume.dossier.scheduler",
+        "ume.federation",
+        "ume.benchmarks",
+        "ume",
+    ]:
+        sys.modules.pop(mod, None)
+
+
 def test_cli_env_file_warning(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_dossier_scheduler.py
+++ b/tests/test_dossier_scheduler.py
@@ -1,0 +1,49 @@
+from ume.dossier import Dossier
+
+
+def test_dossier_snapshot_scheduler_logs_error(tmp_path, monkeypatch, caplog):
+    from ume.dossier import scheduler
+
+    dossier = Dossier.init_dossier(tmp_path)
+
+    def raise_error() -> None:
+        raise ValueError("snap error")
+
+    monkeypatch.setattr(dossier, "snapshot", raise_error)
+
+    events: dict[str, bool] = {}
+
+    class DummyEvent:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def wait(self, timeout=None):
+            self.calls += 1
+            return self.calls > 1
+
+        def set(self):
+            events["set"] = True
+
+    class DummyThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+        def join(self):
+            events["joined"] = True
+
+        def is_alive(self):
+            return True
+
+    monkeypatch.setattr(scheduler.threading, "Event", DummyEvent)
+    monkeypatch.setattr(scheduler.threading, "Thread", DummyThread)
+
+    with caplog.at_level("ERROR", logger="ume.dossier.scheduler"):
+        scheduler.start_dossier_snapshot_scheduler(dossier, interval_seconds=1)
+
+    scheduler.stop_dossier_snapshot_scheduler()
+
+    assert any("Failed to snapshot dossier" in r.message for r in caplog.records)
+    assert events.get("set") and events.get("joined")

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -60,6 +60,32 @@ def _snapshot_schedule(interval: int) -> None:
         print("Snapshot scheduler stopped.")
 
 
+def _dossier_snapshot_schedule(interval: int) -> None:
+    """Run periodic dossier snapshotting until interrupted."""
+    from ume.dossier import Dossier
+    from ume.dossier.scheduler import (
+        start_dossier_snapshot_scheduler,
+        stop_dossier_snapshot_scheduler,
+    )
+
+    dossier = Dossier.load()
+    thread, stop = start_dossier_snapshot_scheduler(dossier, interval_seconds=interval)
+    history = dossier.root / "history"
+    print(
+        f"Snapshots will be written to {history} every {interval} seconds."
+    )
+    print("Press Ctrl+C to stop.")
+    try:
+        while thread.is_alive():
+            thread.join(timeout=1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        stop()
+        stop_dossier_snapshot_scheduler()
+        print("Dossier snapshot scheduler stopped.")
+
+
 def _dossier_view(dossier_id: str) -> None:
     """Fetch and display dossier details from the running API."""
     base_url = "http://localhost:8000"
@@ -348,6 +374,10 @@ def main() -> None:
     list_skills_p.add_argument("dossier_id")
     snap_p = dossier_sub.add_parser("snapshot", help="Snapshot dossier")
     snap_p.add_argument("dossier_id")
+    sched_p = dossier_sub.add_parser(
+        "snapshot-schedule", help="Periodically snapshot dossier"
+    )
+    sched_p.add_argument("--interval", type=int, default=60)
     for p in (up_parser, quick_parser):
         p.add_argument(
             "--no-confirm",
@@ -403,6 +433,8 @@ def main() -> None:
                 _dossier_list_reflections(args.dossier_id)
             elif args.dossier_cmd == "snapshot":
                 _dossier_snapshot(args.dossier_id)
+            elif args.dossier_cmd == "snapshot-schedule":
+                _dossier_snapshot_schedule(args.interval)
             return
 
         configure_logging()


### PR DESCRIPTION
## Summary
- add `start_dossier_snapshot_scheduler` to periodically archive the YAML dossier
- expose the scheduler in `ume.__init__`
- add CLI command `dossier snapshot-schedule` to run the scheduler
- document the new command in the README
- fix mypy errors around optional cryptography

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini`
- `pytest tests/test_dossier_scheduler.py tests/test_cli_smoke.py::test_cli_dossier_snapshot_schedule -q`


------
https://chatgpt.com/codex/tasks/task_e_6882ea2ba8c8832690c7ba19a6b4edd3