### PR TITLE
Add can_read_reflections policy helper

### DIFF
--- a/src/ume/policy/__init__.py
+++ b/src/ume/policy/__init__.py
@@ -1,11 +1,16 @@
 """Policy definitions and utilities for UME access control."""
 
 from .api_client import PolicyAPI
-from .rules import can_modify_telemetry, can_read_projects
+from .rules import (
+    can_modify_telemetry,
+    can_read_projects,
+    can_read_reflections,
+)
 
 __all__ = [
     "PolicyAPI",
     "can_read_projects",
+    "can_read_reflections",
     "can_modify_telemetry",
 ]
 

--- a/src/ume/policy/rules.py
+++ b/src/ume/policy/rules.py
@@ -10,6 +10,13 @@ def can_read_projects(role: str, shareable: bool = False) -> bool:
     return role in {"ProjectManager", "Viewer"}
 
 
+def can_read_reflections(role: str, shareable: bool = False) -> bool:
+    """Return ``True`` if ``role`` may view dossier reflections."""
+    if shareable:
+        return True
+    return role in {"ProjectManager", "Viewer"}
+
+
 def can_modify_telemetry(role: str) -> bool:
     """Return ``True`` if ``role`` may update telemetry data."""
     return role == "TelemetryAdmin"

--- a/tests/test_policy_rules.py
+++ b/tests/test_policy_rules.py
@@ -1,0 +1,14 @@
+from ume.policy import can_read_reflections
+
+
+def test_can_read_reflections_valid_role() -> None:
+    assert can_read_reflections("ProjectManager")
+    assert can_read_reflections("Viewer")
+
+
+def test_can_read_reflections_shareable() -> None:
+    assert can_read_reflections("Other", shareable=True)
+
+
+def test_can_read_reflections_forbidden() -> None:
+    assert not can_read_reflections("Other")


### PR DESCRIPTION
## Summary
- support reflection access checks in policy helpers
- expose `can_read_reflections` at package level
- test helper behavior

## Testing
- `ruff check src/ume/policy/rules.py src/ume/policy/__init__.py tests/test_policy_rules.py`
- `pytest tests/test_policy_rules.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d21f88d483269cba7dafb38e3cd5