### PR TITLE
Add dossier shareable permission tests

### DIFF
--- a/src/ume/audit.py
+++ b/src/ume/audit.py
@@ -7,12 +7,12 @@ import hmac
 import hashlib
 import logging
 import os
-from typing import Dict, List
+from typing import Dict, List, cast
 
 try:
     from cryptography.fernet import Fernet
 except Exception:  # pragma: no cover - cryptography optional
-    Fernet = None  # type: ignore[misc, assignment]
+    Fernet = None
 
 try:
     import boto3
@@ -75,7 +75,7 @@ def _read_lines(path: str) -> List[str]:
         if ENCRYPTION_ENABLED:
             assert _fernet is not None
             try:
-                text = _fernet.decrypt(raw).decode()
+                text = cast(bytes, _fernet.decrypt(raw)).decode()
             except Exception as exc:
                 logger.error("Failed to decrypt audit log from %s: %s", path, exc)
                 return []
@@ -95,7 +95,7 @@ def _read_lines(path: str) -> List[str]:
                     return []
                 assert _fernet is not None
                 try:
-                    text = _fernet.decrypt(raw).decode()
+                    text = cast(bytes, _fernet.decrypt(raw)).decode()
                 except Exception as exc:
                     logger.error("Failed to decrypt audit log from %s: %s", path, exc)
                     return []

--- a/src/ume/consent_ledger.py
+++ b/src/ume/consent_ledger.py
@@ -9,7 +9,7 @@ from typing import Optional
 try:
     from cryptography.fernet import Fernet
 except Exception:  # pragma: no cover - cryptography optional
-    Fernet = None  # type: ignore[misc, assignment]
+    Fernet = None
 
 from .config import settings
 

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -11,12 +11,12 @@ import json
 
 from filelock import FileLock
 
-import yaml  # type: ignore
+import yaml
 
 try:
     from cryptography.fernet import Fernet
 except Exception:  # pragma: no cover - cryptography optional
-    Fernet = None  # type: ignore[misc, assignment]
+    Fernet = None
 
 from ..config import settings
 

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -185,7 +185,7 @@ def get_projects(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_projects(role, dossier.shareable):
+    if not can_read_projects(role, dossier.shareable_projects):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "projects": list_projects(dossier)}
 
@@ -198,7 +198,7 @@ def get_reflections(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_projects(role, dossier.shareable):
+    if not can_read_projects(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "reflections": list_reflections(dossier)}
 

--- a/src/ume/event_ledger.py
+++ b/src/ume/event_ledger.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List, Tuple, Optional
 try:
     from cryptography.fernet import Fernet
 except Exception:  # pragma: no cover - cryptography optional
-    Fernet = None  # type: ignore[misc, assignment]
+    Fernet = None
 
 from .config import settings
 

--- a/src/ume/policy/rules.py
+++ b/src/ume/policy/rules.py
@@ -7,7 +7,7 @@ def can_read_projects(role: str, shareable: bool = False) -> bool:
     """Return ``True`` if ``role`` may view dossier projects."""
     if shareable:
         return True
-    return role in {"ProjectManager", "Viewer"}
+    return role == "ProjectManager"
 
 
 def can_modify_telemetry(role: str) -> bool:

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -2,7 +2,14 @@ from fastapi.testclient import TestClient
 
 from ume.api import app
 from ume.config import settings
-from ume.dossier import Dossier, list_projects, list_skills, list_memories
+from ume.dossier import (
+    Dossier,
+    add_project,
+    add_reflection,
+    list_projects,
+    list_skills,
+    list_memories,
+)
 
 
 def _token(client: TestClient) -> str:
@@ -190,4 +197,70 @@ def test_reflection_and_pref_forbidden(tmp_path, monkeypatch):
         headers=headers,
     )
     assert res.status_code == 403
+
+
+def test_projects_viewer_forbidden(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    dossier = Dossier.init_dossier(tmp_path / "d6")
+    add_project(dossier, "p6")
+    dossier.shareable_projects = False
+    dossier.save()
+
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "Viewer", raising=False)
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    res = client.get("/dossier/projects/d6", headers=headers)
+    assert res.status_code == 403
+
+
+def test_projects_viewer_allowed(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    dossier = Dossier.init_dossier(tmp_path / "d7")
+    add_project(dossier, "p7")
+    dossier.shareable_projects = True
+    dossier.save()
+
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "Viewer", raising=False)
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    res = client.get("/dossier/projects/d7", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["projects"] == ["p7"]
+
+
+def test_reflections_viewer_forbidden(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    dossier = Dossier.init_dossier(tmp_path / "d8")
+    add_reflection(dossier, "r8")
+    dossier.shareable_reflections = False
+    dossier.save()
+
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "Viewer", raising=False)
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    res = client.get("/dossier/reflections/d8", headers=headers)
+    assert res.status_code == 403
+
+
+def test_reflections_viewer_allowed(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    dossier = Dossier.init_dossier(tmp_path / "d9")
+    add_reflection(dossier, "r9")
+    dossier.shareable_reflections = True
+    dossier.save()
+
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "Viewer", raising=False)
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    res = client.get("/dossier/reflections/d9", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["reflections"] == ["r9"]
 


### PR DESCRIPTION
## Summary
- test Viewer access to dossier projects and reflections based on shareable flags
- restrict `can_read_projects` so only ProjectManager can view when not shareable
- remove stale `type: ignore` hints and fix audit helper typing
- fix endpoints to respect `shareable_projects` and `shareable_reflections`

## Testing
- `pre-commit run --files tests/test_api_dossier.py src/ume/dossier_routes.py src/ume/policy/rules.py`
- `pytest tests/test_api_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d21edcbc832680297ffec2cb940d