### PR TITLE
Add dossier init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -957,7 +957,9 @@ The dossier directory (default `~/.ume_dossier`) is seeded from the YAML files i
 `src/ume/dossier/dossier_template/` such as `skills.yaml` and `values.yaml`.
 Use the CLI or API to add entries and snapshot the graph when needed.
 
+# Initialize a dossier for a new user
 ```bash
+ume dossier init user123
 # Add a value and a skill via the CLI
 ume dossier add-value user123 curiosity
 ume dossier add-skill user123 python

--- a/tests/test_cli_dossier_init.py
+++ b/tests/test_cli_dossier_init.py
@@ -1,0 +1,72 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+import pytest
+
+
+def test_cli_dossier_init(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    import ume.dossier as real_dossier
+
+    stub = types.ModuleType("ume")
+    stub.PersistentGraph = object
+    stub.RoleBasedGraphAdapter = object
+    stub.enable_snapshot_autosave_and_restore = lambda *_, **__: None
+    stub.parse_event = lambda *_: None
+    stub.apply_event_to_graph = lambda *_: None
+    stub.load_graph_into_existing = lambda *_: None
+    stub.snapshot_graph_to_file = lambda *_: None
+    stub.ProcessingError = Exception
+    stub.EventError = Exception
+    stub.SnapshotError = Exception
+    stub.IGraphAdapter = object
+    stub.log_audit_entry = lambda *_: None
+    stub.get_audit_entries = lambda *_: []
+    stub.DEFAULT_SCHEMA_MANAGER = object()
+    stub.dossier = real_dossier
+
+    bench = types.ModuleType("ume.benchmarks")
+    bench.benchmark_vector_store = lambda *_: None
+    feder = types.ModuleType("ume.federation")
+    feder.MirrorMakerDriver = object  # type: ignore[assignment]
+    cli_pkg = types.ModuleType("ume.cli")
+    compose_pkg = types.ModuleType("ume.cli.compose")
+    compose_pkg._compose_down = lambda *_, **__: None
+    compose_pkg._compose_ps = lambda *_, **__: None
+    compose_pkg._quickstart = lambda *_, **__: None
+    cli_pkg.compose = compose_pkg
+    prompt_pkg = types.ModuleType("ume.cli.prompt")
+    prompt_pkg.UMEPrompt = object
+    prompt_pkg.create_graph_adapter = lambda *_, **__: None
+
+    sys.modules["ume"] = stub
+    sys.modules["ume.benchmarks"] = bench
+    sys.modules["ume.federation"] = feder
+    sys.modules["ume.cli"] = cli_pkg
+    sys.modules["ume.cli.compose"] = compose_pkg
+    sys.modules["ume.cli.prompt"] = prompt_pkg
+    sys.modules["ume.dossier"] = real_dossier
+
+    import ume_cli as cli
+    importlib.reload(cli)
+
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+
+    argv = sys.argv[:]
+    sys.argv = ["ume-cli", "dossier", "init", "d1"]
+    cli.main()
+    out = capsys.readouterr().out
+    sys.argv = argv
+
+    dossier_dir = tmp_path / "d1"
+    assert (dossier_dir / "profile.yaml").is_file()
+    assert "initialized" in out
+
+    for mod in [
+        "ume.cli.compose",
+        "ume.cli",
+        "ume.federation",
+        "ume.benchmarks",
+        "ume",
+    ]:
+        sys.modules.pop(mod, None)

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -86,6 +86,16 @@ def _dossier_snapshot_schedule(interval: int) -> None:
         print("Dossier snapshot scheduler stopped.")
 
 
+def _dossier_init(dossier_id: str) -> None:
+    """Initialize a dossier directory for ``dossier_id``."""
+    from ume.dossier import Dossier
+
+    base = Path(os.environ.get("UME_DOSSIER_PATH", "~/.ume_dossier")).expanduser()
+    path = base / dossier_id
+    dossier = Dossier.init_dossier(path)
+    print(f"Dossier '{dossier_id}' initialized at {dossier.root}")
+
+
 def _dossier_view(dossier_id: str) -> None:
     """Fetch and display dossier details from the running API."""
     base_url = "http://localhost:8000"
@@ -350,6 +360,8 @@ def main() -> None:
     mem_p = dossier_sub.add_parser("add-memory", help="Add a knowledge entry")
     mem_p.add_argument("dossier_id")
     mem_p.add_argument("text")
+    init_p = dossier_sub.add_parser("init", help="Initialize a new dossier")
+    init_p.add_argument("dossier_id")
     pref_p = dossier_sub.add_parser("set-pref", help="Set a preference key")
     pref_p.add_argument("dossier_id")
     pref_p.add_argument("key")
@@ -411,6 +423,8 @@ def main() -> None:
         if args.command == "dossier":
             if args.dossier_cmd == "view":
                 _dossier_view(args.dossier_id)
+            elif args.dossier_cmd == "init":
+                _dossier_init(args.dossier_id)
             elif args.dossier_cmd == "add-project":
                 _dossier_add_project(args.dossier_id, args.project_id)
             elif args.dossier_cmd == "add-reflection":


### PR DESCRIPTION
## Summary
- add `dossier init` subcommand to the CLI
- document dossier initialization in README
- test that the command creates a new dossier directory

## Testing
- `pre-commit run --files ume_cli.py tests/test_cli_dossier_init.py README.md`
- `pytest -q tests/test_cli_dossier_init.py`

------
https://chatgpt.com/codex/tasks/task_e_6883f158c4ac832683944dedb35de6ec