### PR TITLE
Fix duplicate can_read_reflections

### DIFF
--- a/src/ume/policy/rules.py
+++ b/src/ume/policy/rules.py
@@ -17,13 +17,6 @@ def can_read_reflections(role: str, shareable: bool = False) -> bool:
     return role in {"ProjectManager", "Viewer"}
 
 
-def can_read_reflections(role: str, shareable: bool = False) -> bool:
-    """Return ``True`` if ``role`` may view dossier reflections."""
-    if shareable:
-        return True
-    return role in {"ProjectManager", "Viewer"}
-
-
 def can_modify_telemetry(role: str) -> bool:
     """Return ``True`` if ``role`` may update telemetry data."""
     return role == "TelemetryAdmin"


### PR DESCRIPTION
## Summary
- remove duplicate `can_read_reflections` definition

## Testing
- `pre-commit run --files src/ume/policy/rules.py src/ume/policy/__init__.py tests/test_policy_rules.py`
- `pytest tests/test_policy_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_68868520e0a8832697767d02626e8e54