### PR TITLE
Update migrate_dossier to handle new fields

### DIFF
--- a/scripts/migrate_dossier.py
+++ b/scripts/migrate_dossier.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Upgrade dossier files to the latest schema version."""
+"""Upgrade dossier files to the latest schema version.
+
+Reads ``meta.yaml``, ``profile.yaml``, ``projects.yaml``, ``preferences.yaml``,
+``reflections.yaml`` and, if present, ``knowledge.yaml``, ``values.yaml`` and
+``skills.yaml`` before rewriting them using the current schema.
+"""
 from __future__ import annotations
 
 import argparse
@@ -26,6 +31,9 @@ def _load_plain(root: Path) -> dict[str, Any]:
     projects = _read_yaml(root / "projects.yaml") or {}
     preferences = _read_yaml(root / "preferences.yaml") or {}
     reflections = _read_yaml(root / "reflections.yaml") or []
+    knowledge = _read_yaml(root / "knowledge.yaml") or []
+    values = _read_yaml(root / "values.yaml") or []
+    skills = _read_yaml(root / "skills.yaml") or []
 
     if isinstance(projects, dict):
         projects = projects.get("projects", [])
@@ -44,6 +52,9 @@ def _load_plain(root: Path) -> dict[str, Any]:
         "projects": projects,
         "preferences": preferences,
         "reflections": reflections,
+        "knowledge": knowledge,
+        "values": values,
+        "skills": skills,
     }
 
 
@@ -72,6 +83,9 @@ def migrate_dossier(path: Path, *, encrypt: bool = False) -> None:
     dossier.projects = data["projects"]
     dossier.preferences = data["preferences"]
     dossier.reflections = data["reflections"]
+    dossier.knowledge = data["knowledge"]
+    dossier.values = data["values"]
+    dossier.skills = data["skills"]
     dossier.telemetry_files = data["telemetry_files"]
     dossier.save()
     print(f"Migrated dossier at {path}")


### PR DESCRIPTION
## Summary
- support knowledge, values and skills YAML files when migrating dossiers
- update help text to mention new files

## Testing
- `pre-commit run --files scripts/migrate_dossier.py`

------
https://chatgpt.com/codex/tasks/task_e_6886db838dd08326a52546e5b7cbc53b