### PR TITLE
Add dossier values listing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,6 +962,7 @@ Use the CLI or API to add entries and snapshot the graph when needed.
 ume dossier init user123
 # Add a value and a skill via the CLI
 ume dossier add-value user123 curiosity
+ume dossier list-values user123
 ume dossier add-skill user123 python
 
 # Trigger a snapshot through the API

--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -39,6 +39,9 @@ ume dossier add-project user123 projectA
 # Add a personal value
 ume dossier add-value user123 honesty
 
+# List values
+ume dossier list-values user123
+
 # Add a skill
 ume dossier add-skill user123 python
 
@@ -75,6 +78,9 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
   -d '{"dossier_id":"user123","value":"honesty"}' \
   http://localhost:8000/dossier/add-value
 
+# List values
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/dossier/values/user123
 # Add a skill
 curl -X POST -H "Authorization: Bearer $TOKEN" \
   -d '{"dossier_id":"user123","skill":"python"}' \
@@ -100,6 +106,17 @@ curl -X POST -H "Authorization: Bearer $TOKEN" \
 # List memories
 curl -H "Authorization: Bearer $TOKEN" \
   http://localhost:8000/dossier/memories/user123
+```
+
+## Listing Values
+
+The `/dossier/values/{id}` route returns the list of personal values stored in a dossier.
+Use `ume dossier list-values <id>` to fetch them via the CLI.
+
+```bash
+ume dossier list-values user123
+curl -H "Authorization: Bearer $TOKEN" \
+  http://localhost:8000/dossier/values/user123
 ```
 
 ## Migrating Existing Dossiers


### PR DESCRIPTION
## Summary
- document `ume dossier list-values` command
- describe `/dossier/values/{id}` API route
- show CLI example for listing values in README

## Testing
- `pre-commit run --files docs/DOSSIER_OVERVIEW.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_6886e30271f08326b61bd5614a8e532d