### PR TITLE
Fix dossier endpoint permissions

### DIFF
--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -8,7 +8,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from . import api_deps as deps
-from .policy import can_modify_telemetry, can_read_projects
+from .policy import (
+    can_modify_telemetry,
+    can_read_projects,
+    can_read_reflections,
+)
 
 from .dossier import (
     Dossier,
@@ -199,7 +203,7 @@ def get_reflections(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_projects(role, dossier.shareable_reflections):
+    if not can_read_reflections(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "reflections": list_reflections(dossier)}
 
@@ -212,7 +216,7 @@ def get_skills(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_projects(role, dossier.shareable_reflections):
+    if not can_read_reflections(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "skills": list_skills(dossier)}
 
@@ -225,7 +229,7 @@ def get_values(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_projects(role, dossier.shareable_reflections):
+    if not can_read_reflections(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "values": list_values(dossier)}
 
@@ -238,7 +242,7 @@ def get_memories(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_projects(role, dossier.shareable_reflections):
+    if not can_read_reflections(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "memories": list_memories(dossier)}
 

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -6,6 +6,9 @@ from ume.dossier import (
     Dossier,
     add_project,
     add_reflection,
+    add_skill,
+    add_value,
+    add_memory,
     list_projects,
     list_skills,
     list_memories,
@@ -236,7 +239,7 @@ def test_projects_viewer_allowed(tmp_path, monkeypatch):
     assert res.json()["projects"] == ["p7"]
 
 
-def test_reflections_viewer_forbidden(tmp_path, monkeypatch):
+def test_reflections_viewer_allowed_by_role(tmp_path, monkeypatch):
     monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
     dossier = Dossier.init_dossier(tmp_path / "d8")
     add_reflection(dossier, "r8")
@@ -249,10 +252,11 @@ def test_reflections_viewer_forbidden(tmp_path, monkeypatch):
     headers = {"Authorization": f"Bearer {token}"}
 
     res = client.get("/dossier/reflections/d8", headers=headers)
-    assert res.status_code == 403
+    assert res.status_code == 200
+    assert res.json()["reflections"] == ["r8"]
 
 
-def test_reflections_viewer_allowed(tmp_path, monkeypatch):
+def test_reflections_viewer_allowed_shareable(tmp_path, monkeypatch):
     monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
     dossier = Dossier.init_dossier(tmp_path / "d9")
     add_reflection(dossier, "r9")
@@ -267,4 +271,31 @@ def test_reflections_viewer_allowed(tmp_path, monkeypatch):
     res = client.get("/dossier/reflections/d9", headers=headers)
     assert res.status_code == 200
     assert res.json()["reflections"] == ["r9"]
+
+
+def test_skills_values_memories_viewer_allowed(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    dossier = Dossier.init_dossier(tmp_path / "d10")
+    add_skill(dossier, "python")
+    add_value(dossier, "honesty")
+    add_memory(dossier, "fact")
+    dossier.shareable_reflections = False
+    dossier.save()
+
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "Viewer", raising=False)
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    res = client.get("/dossier/skills/d10", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["skills"] == ["python"]
+
+    res = client.get("/dossier/values/d10", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["values"] == ["honesty"]
+
+    res = client.get("/dossier/memories/d10", headers=headers)
+    assert res.status_code == 200
+    assert res.json()["memories"] == ["fact"]
 


### PR DESCRIPTION
## Summary
- use `can_read_reflections` when checking access for reflections-related routes
- adjust dossier API tests for new permission rules
- ensure viewer role can view skills, values, and memories

## Testing
- `ruff check src/ume/dossier_routes.py tests/test_api_dossier.py`
- `pytest tests/test_api_dossier.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6886e9bbfcec8326bff53f2ce66dda85