### PR TITLE
Fix dossier permission helper

### DIFF
--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -7,7 +7,11 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from . import api_deps as deps
-from .policy import can_modify_telemetry, can_read_projects
+from .policy import (
+    can_modify_telemetry,
+    can_read_projects,
+    can_read_reflections,
+)
 from .config import settings
 
 

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -276,7 +276,7 @@ def test_reflections_viewer_allowed(tmp_path, monkeypatch):
 
 
 def test_skills_values_memories_viewer_allowed(tmp_path, monkeypatch):
-    monkeypatch.setenv("UME_DOSSIER_PATH", str(tmp_path))
+    monkeypatch.setattr(settings, "UME_DOSSIER_PATH", str(tmp_path), raising=False)
     dossier = Dossier.init_dossier(tmp_path / "d10")
     add_skill(dossier, "python")
     add_value(dossier, "honesty")


### PR DESCRIPTION
## Summary
- import `can_read_reflections` for dossier endpoints
- patch test to set settings attribute instead of env var

## Testing
- `pre-commit run --files src/ume/dossier_routes.py tests/test_api_dossier.py`
- `pytest -q tests/test_api_dossier.py`

------
https://chatgpt.com/codex/tasks/task_e_688784cbfd1c8326a1acc52eb8f1012a