### PR TITLE
Add dossier audit logging

### DIFF
--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -18,6 +18,7 @@ except Exception:  # pragma: no cover - cryptography optional
     Fernet = None
 
 from ..config import settings
+from ..audit import log_audit_entry
 
 ENCRYPTION_ENABLED = settings.UME_ENCRYPTION_ENABLED
 _fernet: Fernet | None
@@ -263,6 +264,7 @@ def add_project(
     }
     dossier.projects.append(entry)
     dossier.save()
+    log_audit_entry(settings.UME_AGENT_ID, f"add_project {dossier.root.name} {entry_id}")
     return entry_id
 
 
@@ -282,19 +284,26 @@ def add_reflection(
     }
     dossier.reflections.append(entry)
     dossier.save()
+    log_audit_entry(settings.UME_AGENT_ID, f"add_reflection {dossier.root.name} {entry_id}")
     return entry_id
 
 
 def list_reflections(dossier: Dossier) -> list[str]:
     """Return a list of reflection texts."""
-    return [r.get("text", "") for r in dossier.reflections]
+    texts = [r.get("text", "") for r in dossier.reflections]
+    log_audit_entry(settings.UME_AGENT_ID, f"list_reflections {dossier.root.name}")
+    return texts
 
 def list_projects(dossier: Dossier) -> list[str]:
-    return [p.get("name", "") for p in dossier.projects]
+    names = [p.get("name", "") for p in dossier.projects]
+    log_audit_entry(settings.UME_AGENT_ID, f"list_projects {dossier.root.name}")
+    return names
 
 def update_preferences(dossier: Dossier, **prefs: Any) -> None:
     dossier.preferences.update(prefs)
     dossier.save()
+    keys = ",".join(prefs.keys())
+    log_audit_entry(settings.UME_AGENT_ID, f"update_preferences {dossier.root.name} {keys}")
 
 
 def add_value(dossier: Dossier, value: str) -> None:
@@ -302,11 +311,14 @@ def add_value(dossier: Dossier, value: str) -> None:
     if value not in dossier.values:
         dossier.values.append(value)
         dossier.save()
+        log_audit_entry(settings.UME_AGENT_ID, f"add_value {dossier.root.name} {value}")
 
 
 def list_values(dossier: Dossier) -> list[str]:
     """Return the list of values recorded in ``dossier``."""
-    return list(dossier.values)
+    vals = list(dossier.values)
+    log_audit_entry(settings.UME_AGENT_ID, f"list_values {dossier.root.name}")
+    return vals
 
 
 def add_skill(dossier: Dossier, skill: str) -> None:
@@ -314,10 +326,13 @@ def add_skill(dossier: Dossier, skill: str) -> None:
     if skill not in dossier.skills:
         dossier.skills.append(skill)
         dossier.save()
+        log_audit_entry(settings.UME_AGENT_ID, f"add_skill {dossier.root.name} {skill}")
 
 
 def list_skills(dossier: Dossier) -> list[str]:
-    return list(dossier.skills)
+    skills = list(dossier.skills)
+    log_audit_entry(settings.UME_AGENT_ID, f"list_skills {dossier.root.name}")
+    return skills
 
 
 def add_memory(
@@ -337,8 +352,11 @@ def add_memory(
     }
     dossier.knowledge.append(entry)
     dossier.save()
+    log_audit_entry(settings.UME_AGENT_ID, f"add_memory {dossier.root.name} {entry_id}")
     return entry_id
 
 
 def list_memories(dossier: Dossier) -> list[str]:
-    return [m.get("text", "") for m in dossier.knowledge]
+    texts = [m.get("text", "") for m in dossier.knowledge]
+    log_audit_entry(settings.UME_AGENT_ID, f"list_memories {dossier.root.name}")
+    return texts

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -13,6 +13,7 @@ from .policy import (
     can_read_reflections,
 )
 from .config import settings
+from .audit import log_audit_entry
 
 
 from .dossier import (
@@ -90,6 +91,7 @@ def view_dossier(dossier_id: str, role: str = Depends(deps.get_current_role)) ->
     dossier = Dossier.load(path)
     if not can_read_projects(role, dossier.shareable_projects):
         raise HTTPException(status_code=403, detail="Not authorized")
+    log_audit_entry(settings.UME_AGENT_ID, f"view_dossier {dossier_id}")
     return {
         "dossier_id": dossier_id,
         "projects": list_projects(dossier),
@@ -109,6 +111,7 @@ def add_project(req: AddProjectRequest, role: str = Depends(deps.get_current_rol
     else:
         dossier = Dossier.init_dossier(path)
     dossier_add_project(dossier, req.project_id)
+    log_audit_entry(settings.UME_AGENT_ID, f"add_project {req.project_id}")
     return cast(
         Dict[str, object],
         {
@@ -130,6 +133,7 @@ def add_reflection_endpoint(
     path = _dossier_path(req.dossier_id)
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
     add_reflection(dossier, req.text, req.links)
+    log_audit_entry(settings.UME_AGENT_ID, f"add_reflection {req.dossier_id}")
     return {"status": "ok"}
 
 
@@ -143,6 +147,7 @@ def add_memory_endpoint(
     path = _dossier_path(req.dossier_id)
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
     add_memory(dossier, req.text, req.links)
+    log_audit_entry(settings.UME_AGENT_ID, f"add_memory {req.dossier_id}")
     return {"status": "ok"}
 
 
@@ -156,6 +161,7 @@ def set_preference(
     path = _dossier_path(req.dossier_id)
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
     update_preferences(dossier, **{req.key: req.value})
+    log_audit_entry(settings.UME_AGENT_ID, f"set_pref {req.dossier_id} {req.key}")
     return {"status": "ok"}
 
 
@@ -168,6 +174,7 @@ def add_value_endpoint(
     path = _dossier_path(req.dossier_id)
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
     add_value(dossier, req.value)
+    log_audit_entry(settings.UME_AGENT_ID, f"add_value {req.dossier_id}")
     return {"status": "ok"}
 
 
@@ -180,6 +187,7 @@ def add_skill_endpoint(
     path = _dossier_path(req.dossier_id)
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
     add_skill(dossier, req.skill)
+    log_audit_entry(settings.UME_AGENT_ID, f"add_skill {req.dossier_id}")
     return {"status": "ok"}
 
 
@@ -193,7 +201,9 @@ def get_projects(
     dossier = Dossier.load(path)
     if not can_read_projects(role, dossier.shareable_projects):
         raise HTTPException(status_code=403, detail="Not authorized")
-    return {"dossier_id": dossier_id, "projects": list_projects(dossier)}
+    result = {"dossier_id": dossier_id, "projects": list_projects(dossier)}
+    log_audit_entry(settings.UME_AGENT_ID, f"get_projects {dossier_id}")
+    return result
 
 
 @router.get("/reflections/{dossier_id}")
@@ -206,7 +216,9 @@ def get_reflections(
     dossier = Dossier.load(path)
     if not can_read_reflections(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
-    return {"dossier_id": dossier_id, "reflections": list_reflections(dossier)}
+    result = {"dossier_id": dossier_id, "reflections": list_reflections(dossier)}
+    log_audit_entry(settings.UME_AGENT_ID, f"get_reflections {dossier_id}")
+    return result
 
 
 @router.get("/skills/{dossier_id}")
@@ -219,7 +231,9 @@ def get_skills(
     dossier = Dossier.load(path)
     if not can_read_reflections(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
-    return {"dossier_id": dossier_id, "skills": list_skills(dossier)}
+    result = {"dossier_id": dossier_id, "skills": list_skills(dossier)}
+    log_audit_entry(settings.UME_AGENT_ID, f"get_skills {dossier_id}")
+    return result
 
 
 @router.get("/values/{dossier_id}")
@@ -232,7 +246,9 @@ def get_values(
     dossier = Dossier.load(path)
     if not can_read_reflections(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
-    return {"dossier_id": dossier_id, "values": list_values(dossier)}
+    result = {"dossier_id": dossier_id, "values": list_values(dossier)}
+    log_audit_entry(settings.UME_AGENT_ID, f"get_values {dossier_id}")
+    return result
 
 
 @router.get("/memories/{dossier_id}")
@@ -245,7 +261,9 @@ def get_memories(
     dossier = Dossier.load(path)
     if not can_read_reflections(role, dossier.shareable_reflections):
         raise HTTPException(status_code=403, detail="Not authorized")
-    return {"dossier_id": dossier_id, "memories": list_memories(dossier)}
+    result = {"dossier_id": dossier_id, "memories": list_memories(dossier)}
+    log_audit_entry(settings.UME_AGENT_ID, f"get_memories {dossier_id}")
+    return result
 
 
 @router.post("/snapshot")
@@ -259,6 +277,7 @@ def snapshot_endpoint(
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
     dest = dossier.snapshot()
+    log_audit_entry(settings.UME_AGENT_ID, f"snapshot {req.dossier_id}")
     return {"status": "ok", "path": str(dest)}
 
 
@@ -274,5 +293,6 @@ def add_activity_endpoint(
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
     dossier.add_activity(req.payload)
+    log_audit_entry(settings.UME_AGENT_ID, f"add_activity {req.dossier_id}")
     return {"status": "ok"}
 

--- a/tests/test_dossier_audit.py
+++ b/tests/test_dossier_audit.py
@@ -1,0 +1,28 @@
+import importlib
+import os
+
+import ume
+from ume.config import settings
+from ume.dossier import Dossier, add_project, list_projects
+
+
+def test_dossier_helper_audit(tmp_path, monkeypatch):
+    monkeypatch.setenv("UME_AUDIT_LOG_PATH", str(tmp_path / "audit.log"))
+    monkeypatch.setenv("UME_AGENT_ID", "tester")
+
+    importlib.reload(ume.config)
+    importlib.reload(ume.audit)
+    importlib.reload(ume.dossier)
+
+    monkeypatch.setattr(settings, "UME_DOSSIER_PATH", str(tmp_path), raising=False)
+
+    dossier = Dossier.init_dossier(tmp_path / "d1")
+    open(os.environ["UME_AUDIT_LOG_PATH"], "w").close()
+    start = len(ume.audit.get_audit_entries())
+
+    add_project(dossier, "p1")
+    list_projects(dossier)
+
+    entries = ume.audit.get_audit_entries()[start:]
+    assert any("add_project" in e["reason"] for e in entries)
+    assert any("list_projects" in e["reason"] for e in entries)


### PR DESCRIPTION
## Summary
- log audit entries for dossier operations
- record dossier API reads/writes
- test audit logging for dossier helper functions

## Testing
- `pre-commit run --files src/ume/dossier/__init__.py src/ume/dossier_routes.py tests/test_dossier_audit.py`
- `pytest tests/test_dossier_audit.py`

------
https://chatgpt.com/codex/tasks/task_e_688789986e5c8326bc4cc99ad39f8716