### PR TITLE
Add shareability flags for dossier sections

### DIFF
--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -126,6 +126,51 @@ can_read_reflections {
     input.role == "Viewer"
 }
 
+# Allow reading skills if that section is shareable or the caller has a valid role
+default can_read_skills = false
+
+can_read_skills {
+    input.metadata.shareable_skills
+}
+
+can_read_skills {
+    input.role == "ProjectManager"
+}
+
+can_read_skills {
+    input.role == "Viewer"
+}
+
+# Allow reading values if that section is shareable or the caller has a valid role
+default can_read_values = false
+
+can_read_values {
+    input.metadata.shareable_values
+}
+
+can_read_values {
+    input.role == "ProjectManager"
+}
+
+can_read_values {
+    input.role == "Viewer"
+}
+
+# Allow reading memories if that section is shareable or the caller has a valid role
+default can_read_memories = false
+
+can_read_memories {
+    input.metadata.shareable_memories
+}
+
+can_read_memories {
+    input.role == "ProjectManager"
+}
+
+can_read_memories {
+    input.role == "Viewer"
+}
+
 allow_add_project {
     input.role == "ProjectManager"
 }

--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -7,6 +7,8 @@ The user dossier is a lightweight collection of YAML files that track basic prof
 A newly initialized dossier contains:
 
 - `meta.yaml` – schema version metadata and shareable flags
+  (`shareable_projects`, `shareable_reflections`,
+  `shareable_skills`, `shareable_values`, `shareable_memories`)
 - `profile.yaml` – basic user details (name, email)
 - `projects.yaml` – list of active projects
 - `preferences.yaml` – arbitrary key/value settings

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -40,6 +40,9 @@ class Dossier:
     shareable: bool = False
     shareable_projects: bool = False
     shareable_reflections: bool = False
+    shareable_skills: bool = False
+    shareable_values: bool = False
+    shareable_memories: bool = False
     profile: dict[str, Any] = field(default_factory=dict)
     projects: list[dict[str, Any]] = field(default_factory=list)
     preferences: dict[str, Any] = field(default_factory=dict)
@@ -80,6 +83,9 @@ class Dossier:
                     "shareable": self.shareable,
                     "shareable_projects": self.shareable_projects,
                     "shareable_reflections": self.shareable_reflections,
+                    "shareable_skills": self.shareable_skills,
+                    "shareable_values": self.shareable_values,
+                    "shareable_memories": self.shareable_memories,
                     "telemetry_files": self.telemetry_files,
                 },
             )
@@ -103,6 +109,15 @@ class Dossier:
         )
         self.shareable_reflections = bool(
             meta.get("shareable_reflections", meta.get("shareable", self.shareable))
+        )
+        self.shareable_skills = bool(
+            meta.get("shareable_skills", meta.get("shareable", self.shareable))
+        )
+        self.shareable_values = bool(
+            meta.get("shareable_values", meta.get("shareable", self.shareable))
+        )
+        self.shareable_memories = bool(
+            meta.get("shareable_memories", meta.get("shareable", self.shareable))
         )
         self.telemetry_files = meta.get("telemetry_files", [])
         self.profile = self._read_yaml(self.root / "profile.yaml") or {}
@@ -200,6 +215,9 @@ class Dossier:
                         "shareable": self.shareable,
                         "shareable_projects": self.shareable_projects,
                         "shareable_reflections": self.shareable_reflections,
+                        "shareable_skills": self.shareable_skills,
+                        "shareable_values": self.shareable_values,
+                        "shareable_memories": self.shareable_memories,
                         "telemetry_files": self.telemetry_files,
                     },
                 )

--- a/src/ume/dossier/dossier_template/meta.yaml
+++ b/src/ume/dossier/dossier_template/meta.yaml
@@ -2,4 +2,7 @@ schema_version: 1
 shareable: false
 shareable_projects: false
 shareable_reflections: false
+shareable_skills: false
+shareable_values: false
+shareable_memories: false
 telemetry_files: []

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -11,6 +11,9 @@ from .policy import (
     can_modify_telemetry,
     can_read_projects,
     can_read_reflections,
+    can_read_skills,
+    can_read_values,
+    can_read_memories,
 )
 from .config import settings
 
@@ -95,6 +98,9 @@ def view_dossier(dossier_id: str, role: str = Depends(deps.get_current_role)) ->
         "projects": list_projects(dossier),
         "shareable_projects": dossier.shareable_projects,
         "shareable_reflections": dossier.shareable_reflections,
+        "shareable_skills": dossier.shareable_skills,
+        "shareable_values": dossier.shareable_values,
+        "shareable_memories": dossier.shareable_memories,
     }
 
 
@@ -116,6 +122,9 @@ def add_project(req: AddProjectRequest, role: str = Depends(deps.get_current_rol
             "projects": list_projects(dossier),
             "shareable_projects": dossier.shareable_projects,
             "shareable_reflections": dossier.shareable_reflections,
+            "shareable_skills": dossier.shareable_skills,
+            "shareable_values": dossier.shareable_values,
+            "shareable_memories": dossier.shareable_memories,
         },
     )
 
@@ -217,7 +226,7 @@ def get_skills(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_reflections(role, dossier.shareable_reflections):
+    if not can_read_skills(role, dossier.shareable_skills):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "skills": list_skills(dossier)}
 
@@ -230,7 +239,7 @@ def get_values(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_reflections(role, dossier.shareable_reflections):
+    if not can_read_values(role, dossier.shareable_values):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "values": list_values(dossier)}
 
@@ -243,7 +252,7 @@ def get_memories(
     if not path.exists():
         raise HTTPException(status_code=404, detail="Dossier not found")
     dossier = Dossier.load(path)
-    if not can_read_reflections(role, dossier.shareable_reflections):
+    if not can_read_memories(role, dossier.shareable_memories):
         raise HTTPException(status_code=403, detail="Not authorized")
     return {"dossier_id": dossier_id, "memories": list_memories(dossier)}
 

--- a/src/ume/policy/__init__.py
+++ b/src/ume/policy/__init__.py
@@ -5,12 +5,18 @@ from .rules import (
     can_modify_telemetry,
     can_read_projects,
     can_read_reflections,
+    can_read_skills,
+    can_read_values,
+    can_read_memories,
 )
 
 __all__ = [
     "PolicyAPI",
     "can_read_projects",
     "can_read_reflections",
+    "can_read_skills",
+    "can_read_values",
+    "can_read_memories",
     "can_modify_telemetry",
 ]
 

--- a/src/ume/policy/rules.py
+++ b/src/ume/policy/rules.py
@@ -17,6 +17,27 @@ def can_read_reflections(role: str, shareable: bool = False) -> bool:
     return role in {"ProjectManager", "Viewer"}
 
 
+def can_read_skills(role: str, shareable: bool = False) -> bool:
+    """Return ``True`` if ``role`` may view dossier skills."""
+    if shareable:
+        return True
+    return role in {"ProjectManager", "Viewer"}
+
+
+def can_read_values(role: str, shareable: bool = False) -> bool:
+    """Return ``True`` if ``role`` may view dossier values."""
+    if shareable:
+        return True
+    return role in {"ProjectManager", "Viewer"}
+
+
+def can_read_memories(role: str, shareable: bool = False) -> bool:
+    """Return ``True`` if ``role`` may view dossier memories."""
+    if shareable:
+        return True
+    return role in {"ProjectManager", "Viewer"}
+
+
 def can_modify_telemetry(role: str) -> bool:
     """Return ``True`` if ``role`` may update telemetry data."""
     return role == "TelemetryAdmin"

--- a/tests/test_dossier.py
+++ b/tests/test_dossier.py
@@ -31,6 +31,9 @@ def test_dossier_init_and_helpers(tmp_path):
     assert dossier.shareable is False
     assert dossier.shareable_projects is False
     assert dossier.shareable_reflections is False
+    assert dossier.shareable_skills is False
+    assert dossier.shareable_values is False
+    assert dossier.shareable_memories is False
 
     pid = add_project(dossier, "demo", attachments=["file.txt"])
 
@@ -43,6 +46,9 @@ def test_dossier_init_and_helpers(tmp_path):
     dossier.shareable = True
     dossier.shareable_projects = True
     dossier.shareable_reflections = True
+    dossier.shareable_skills = True
+    dossier.shareable_values = True
+    dossier.shareable_memories = True
     dossier.save()
 
     reloaded = Dossier.load(tmp_path)
@@ -67,6 +73,9 @@ def test_dossier_init_and_helpers(tmp_path):
     assert reloaded.shareable is True
     assert reloaded.shareable_projects is True
     assert reloaded.shareable_reflections is True
+    assert reloaded.shareable_skills is True
+    assert reloaded.shareable_values is True
+    assert reloaded.shareable_memories is True
 
 
 def test_dossier_env_load(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- track shareability for skills, values, and memories in Dossier
- propagate shareability to API routes and template
- document new shareable flags
- test Dossier persistence of new flags
- add helpers for shareability policies

## Testing
- `pre-commit run --files src/ume/policy/rules.py src/ume/policy/__init__.py src/ume/dossier_routes.py`
- `pytest tests/integration/test_integration_clients.py::test_async_langgraph_and_letta tests/integration/test_notebooks.py::test_notebook_runs[nb_path0] tests/integration/test_notebooks.py::test_notebook_runs[nb_path1] tests/test_api_scheduler.py::test_api_compaction_thread_stops -q`
- `pytest -q` *(318 passed, 17 skipped, 364 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68878996013c8326bebe6e12f005b693