### PR TITLE
Add dossier attachment support

### DIFF
--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -52,12 +52,14 @@ class AddReflectionRequest(BaseModel):
     dossier_id: str
     text: str
     links: list[str] | None = None
+    attachments: list[str] | None = None
 
 
 class AddMemoryRequest(BaseModel):
     dossier_id: str
     text: str
     links: list[str] | None = None
+    attachments: list[str] | None = None
 
 
 class SetPreferenceRequest(BaseModel):
@@ -141,7 +143,7 @@ def add_reflection_endpoint(
         raise HTTPException(status_code=403, detail="Not authorized")
     path = _dossier_path(req.dossier_id)
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
-    add_reflection(dossier, req.text, req.links)
+    add_reflection(dossier, req.text, req.links, req.attachments)
     log_audit_entry(settings.UME_AGENT_ID, f"add_reflection {req.dossier_id}")
     return {"status": "ok"}
 
@@ -155,7 +157,7 @@ def add_memory_endpoint(
         raise HTTPException(status_code=403, detail="Not authorized")
     path = _dossier_path(req.dossier_id)
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
-    add_memory(dossier, req.text, req.links)
+    add_memory(dossier, req.text, req.links, req.attachments)
     log_audit_entry(settings.UME_AGENT_ID, f"add_memory {req.dossier_id}")
     return {"status": "ok"}
 

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -92,14 +92,22 @@ def test_reflection_and_pref_endpoints(tmp_path, monkeypatch):
 
     res = client.post(
         "/dossier/add-reflection",
-        json={"dossier_id": "d4", "text": "thinking"},
+        json={
+            "dossier_id": "d4",
+            "text": "thinking",
+            "attachments": ["img.png"],
+        },
         headers=headers,
     )
     assert res.status_code == 200
 
     res = client.post(
         "/dossier/add-memory",
-        json={"dossier_id": "d4", "text": "fact"},
+        json={
+            "dossier_id": "d4",
+            "text": "fact",
+            "attachments": ["doc.pdf"],
+        },
         headers=headers,
     )
     assert res.status_code == 200
@@ -120,7 +128,9 @@ def test_reflection_and_pref_endpoints(tmp_path, monkeypatch):
 
     dossier = Dossier.load(tmp_path / "d4")
     assert dossier.reflections[0]["text"] == "thinking"
+    assert dossier.reflections[0]["attachments"] == ["img.png"]
     assert "id" in dossier.reflections[0]
+    assert dossier.knowledge[0]["attachments"] == ["doc.pdf"]
     assert dossier.preferences["theme"] == "dark"
 
     res = client.post(

--- a/tests/test_dossier_cli.py
+++ b/tests/test_dossier_cli.py
@@ -48,11 +48,19 @@ async def add_project(payload: dict):
 
 @app.post('/dossier/add-reflection')
 async def add_reflection(payload: dict):
-    return {'dossier_id': payload['dossier_id'], 'reflection': payload['text']}
+    return {
+        'dossier_id': payload['dossier_id'],
+        'reflection': payload['text'],
+        'attachments': payload.get('attachments', []),
+    }
 
 @app.post('/dossier/add-memory')
 async def add_memory(payload: dict):
-    return {'dossier_id': payload['dossier_id'], 'memory': payload['text']}
+    return {
+        'dossier_id': payload['dossier_id'],
+        'memory': payload['text'],
+        'attachments': payload.get('attachments', []),
+    }
 
 @app.post('/dossier/set-pref')
 async def set_pref(payload: dict):
@@ -152,36 +160,64 @@ def test_dossier_add_project(tmp_path: Path):
 
 def test_dossier_add_reflection(tmp_path: Path):
     proc, requests = _run_cli(
-        tmp_path, ["dossier", "add-reflection", "d2", "thinking"]
+        tmp_path,
+        [
+            "dossier",
+            "add-reflection",
+            "d2",
+            "thinking",
+            "--attach",
+            "img.png",
+            "--attach",
+            "notes.txt",
+        ],
     )
     assert proc.returncode == 0
     assert json.loads(proc.stdout) == {
         "dossier_id": "d2",
         "reflection": "thinking",
+        "attachments": ["img.png", "notes.txt"],
     }
     assert requests == [
         {
             "method": "POST",
             "url": "http://localhost:8000/dossier/add-reflection",
-            "json": {"dossier_id": "d2", "text": "thinking"},
+            "json": {
+                "dossier_id": "d2",
+                "text": "thinking",
+                "attachments": ["img.png", "notes.txt"],
+            },
         }
     ]
 
 
 def test_dossier_add_memory(tmp_path: Path):
     proc, requests = _run_cli(
-        tmp_path, ["dossier", "add-memory", "d2", "fact"]
+        tmp_path,
+        [
+            "dossier",
+            "add-memory",
+            "d2",
+            "fact",
+            "--attach",
+            "doc.pdf",
+        ],
     )
     assert proc.returncode == 0
     assert json.loads(proc.stdout) == {
         "dossier_id": "d2",
         "memory": "fact",
+        "attachments": ["doc.pdf"],
     }
     assert requests == [
         {
             "method": "POST",
             "url": "http://localhost:8000/dossier/add-memory",
-            "json": {"dossier_id": "d2", "text": "fact"},
+            "json": {
+                "dossier_id": "d2",
+                "text": "fact",
+                "attachments": ["doc.pdf"],
+            },
         }
     ]
 

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -125,13 +125,17 @@ def _dossier_add_project(dossier_id: str, project_id: str) -> None:
         print(f"Request failed: {exc}")
 
 
-def _dossier_add_reflection(dossier_id: str, text: str) -> None:
+def _dossier_add_reflection(
+    dossier_id: str, text: str, attachments: list[str] | None = None
+) -> None:
     """Send a request to append a reflection."""
     base_url = "http://localhost:8000"
     headers = {}
     if settings.UME_API_TOKEN:
         headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
     payload = {"dossier_id": dossier_id, "text": text}
+    if attachments:
+        payload["attachments"] = attachments
     try:
         resp = httpx.post(
             f"{base_url}/dossier/add-reflection",
@@ -277,13 +281,17 @@ def _dossier_list_reflections(dossier_id: str) -> None:
         print(f"Request failed: {exc}")
 
 
-def _dossier_add_memory(dossier_id: str, text: str) -> None:
+def _dossier_add_memory(
+    dossier_id: str, text: str, attachments: list[str] | None = None
+) -> None:
     """Send a request to append a memory entry."""
     base_url = "http://localhost:8000"
     headers = {}
     if settings.UME_API_TOKEN:
         headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
     payload = {"dossier_id": dossier_id, "text": text}
+    if attachments:
+        payload["attachments"] = attachments
     try:
         resp = httpx.post(
             f"{base_url}/dossier/add-memory",
@@ -375,9 +383,21 @@ def main() -> None:
     refl_p = dossier_sub.add_parser("add-reflection", help="Add a reflection entry")
     refl_p.add_argument("dossier_id")
     refl_p.add_argument("text")
+    refl_p.add_argument(
+        "--attach",
+        action="append",
+        default=[],
+        help="Attachment for the reflection (repeatable)",
+    )
     mem_p = dossier_sub.add_parser("add-memory", help="Add a knowledge entry")
     mem_p.add_argument("dossier_id")
     mem_p.add_argument("text")
+    mem_p.add_argument(
+        "--attach",
+        action="append",
+        default=[],
+        help="Attachment for the memory (repeatable)",
+    )
     init_p = dossier_sub.add_parser("init", help="Initialize a new dossier")
     init_p.add_argument("dossier_id")
     pref_p = dossier_sub.add_parser("set-pref", help="Set a preference key")
@@ -448,9 +468,9 @@ def main() -> None:
             elif args.dossier_cmd == "add-project":
                 _dossier_add_project(args.dossier_id, args.project_id)
             elif args.dossier_cmd == "add-reflection":
-                _dossier_add_reflection(args.dossier_id, args.text)
+                _dossier_add_reflection(args.dossier_id, args.text, args.attach)
             elif args.dossier_cmd == "add-memory":
-                _dossier_add_memory(args.dossier_id, args.text)
+                _dossier_add_memory(args.dossier_id, args.text, args.attach)
             elif args.dossier_cmd == "set-pref":
                 _dossier_set_pref(args.dossier_id, args.key, args.value)
             elif args.dossier_cmd == "add-value":


### PR DESCRIPTION
## Summary
- allow reflections and memories to receive attachments
- forward attachments through CLI and API
- test dossier attachments via API and CLI

## Testing
- `pre-commit run --files src/ume/dossier_routes.py ume_cli.py tests/test_api_dossier.py tests/test_dossier_cli.py`
- `pytest tests/test_api_dossier.py -k test_reflection_and_pref_endpoints -q`
- `pytest tests/test_dossier_cli.py::test_dossier_add_reflection tests/test_dossier_cli.py::test_dossier_add_memory -q`


------
https://chatgpt.com/codex/tasks/task_e_688798a2f67083268085b096163095a6