### PR TITLE
Add dossier shareable flag management

### DIFF
--- a/docs/DOSSIER_OVERVIEW.md
+++ b/docs/DOSSIER_OVERVIEW.md
@@ -74,6 +74,9 @@ ume dossier list-reflections user123
 # Add a memory
 ume dossier add-memory user123 "remember this"
 
+# Update shareable flags
+ume dossier set-shareable user123 --projects true
+
 # List memories
 ume dossier list-memories user123
 ```
@@ -131,6 +134,11 @@ curl -H "Authorization: Bearer $TOKEN" \
 curl -X POST -H "Authorization: Bearer $TOKEN" \
   -d '{"dossier_id":"user123","text":"remember this"}' \
   http://localhost:8000/dossier/add-memory
+
+# Set shareable flags
+curl -X POST -H "Authorization: Bearer $TOKEN" \
+  -d '{"dossier_id":"user123","shareable_projects":true}' \
+  http://localhost:8000/dossier/set-shareable
 
 # List memories
 curl -H "Authorization: Bearer $TOKEN" \

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -324,6 +324,25 @@ def update_preferences(dossier: Dossier, **prefs: Any) -> None:
     log_audit_entry(settings.UME_AGENT_ID, f"update_preferences {dossier.root.name} {keys}")
 
 
+def update_shareable_flags(dossier: Dossier, **flags: Any) -> None:
+    """Update shareable booleans and persist ``meta.yaml``."""
+    valid = {
+        "shareable",
+        "shareable_projects",
+        "shareable_reflections",
+        "shareable_skills",
+        "shareable_values",
+        "shareable_memories",
+    }
+    updates = {k: bool(v) for k, v in flags.items() if k in valid}
+    for key, value in updates.items():
+        setattr(dossier, key, value)
+    if updates:
+        dossier.save()
+        keys = ",".join(updates.keys())
+        log_audit_entry(settings.UME_AGENT_ID, f"update_shareable {dossier.root.name} {keys}")
+
+
 def add_value(dossier: Dossier, value: str) -> None:
     """Append a value string if not present."""
     if value not in dossier.values:

--- a/src/ume/dossier_routes.py
+++ b/src/ume/dossier_routes.py
@@ -32,6 +32,7 @@ from .dossier import (
     list_skills,
     list_memories,
     update_preferences,
+    update_shareable_flags,
 )
 
 router = APIRouter(prefix="/dossier")
@@ -64,6 +65,16 @@ class SetPreferenceRequest(BaseModel):
     dossier_id: str
     key: str
     value: Any
+
+
+class SetShareableRequest(BaseModel):
+    dossier_id: str
+    shareable: bool | None = None
+    shareable_projects: bool | None = None
+    shareable_reflections: bool | None = None
+    shareable_skills: bool | None = None
+    shareable_values: bool | None = None
+    shareable_memories: bool | None = None
 
 
 class AddValueRequest(BaseModel):
@@ -171,6 +182,28 @@ def set_preference(
     dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
     update_preferences(dossier, **{req.key: req.value})
     log_audit_entry(settings.UME_AGENT_ID, f"set_pref {req.dossier_id} {req.key}")
+    return {"status": "ok"}
+
+
+@router.post("/set-shareable")
+def set_shareable(
+    req: SetShareableRequest, role: str = Depends(deps.get_current_role)
+) -> Dict[str, str]:
+    """Update shareable flags in ``meta.yaml``."""
+    if role != "ProjectManager":
+        raise HTTPException(status_code=403, detail="Not authorized")
+    path = _dossier_path(req.dossier_id)
+    dossier = Dossier.load(path) if path.exists() else Dossier.init_dossier(path)
+    flags = {
+        k: v
+        for k, v in req.dict().items()
+        if k != "dossier_id" and v is not None
+    }
+    update_shareable_flags(dossier, **flags)
+    log_audit_entry(
+        settings.UME_AGENT_ID,
+        f"set_shareable {req.dossier_id} {','.join(flags.keys())}",
+    )
     return {"status": "ok"}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,8 @@ class _DummyMetric:  # pragma: no cover - simple stub
 prom_stub.Counter = _DummyMetric  # type: ignore[attr-defined]
 prom_stub.Histogram = _DummyMetric  # type: ignore[attr-defined]
 prom_stub.Gauge = _DummyMetric  # type: ignore[attr-defined]
+prom_stub.generate_latest = lambda *_: b""
+prom_stub.CONTENT_TYPE_LATEST = "text/plain"
 
 if importlib.util.find_spec("prometheus_client") is None:
     sys.modules.setdefault("prometheus_client", prom_stub)

--- a/tests/test_api_dossier.py
+++ b/tests/test_api_dossier.py
@@ -1,5 +1,31 @@
 from fastapi.testclient import TestClient
 
+import sys
+import types
+
+class _DummyLimiter:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def __call__(self, *args, **kwargs):
+        return None
+
+    @classmethod
+    async def init(cls, *args, **kwargs):
+        return None
+
+sys.modules["fastapi_limiter"] = type("m", (), {"FastAPILimiter": _DummyLimiter})
+sys.modules[
+    "fastapi_limiter.depends"
+] = type("m", (), {"RateLimiter": _DummyLimiter})
+sys.modules.setdefault("sse_starlette", type("m", (), {}))
+sys.modules.setdefault(
+    "sse_starlette.sse",
+    type("m", (), {"EventSourceResponse": object}),
+)
+sys.modules["grpc._utilities"] = type("m", (), {"first_version_is_lower": lambda *_: False})
+sys.modules["grpc"] = type("m", (), {"__version__": "1.0"})
+
 from ume.api import app
 from ume.config import settings
 from ume.dossier import (
@@ -300,4 +326,38 @@ def test_skills_values_memories_viewer_allowed(tmp_path, monkeypatch):
     res = client.get("/dossier/memories/d10", headers=headers)
     assert res.status_code == 200
     assert res.json()["memories"] == ["fact"]
+
+
+def test_set_shareable_endpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "ProjectManager", raising=False)
+    monkeypatch.setattr(settings, "UME_DOSSIER_PATH", str(tmp_path), raising=False)
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    res = client.post(
+        "/dossier/set-shareable",
+        json={"dossier_id": "d11", "shareable_projects": True},
+        headers=headers,
+    )
+    assert res.status_code == 200
+
+    dossier = Dossier.load(tmp_path / "d11")
+    assert dossier.shareable_projects is True
+
+
+def test_set_shareable_forbidden(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "UME_OAUTH_ROLE", "Viewer", raising=False)
+    monkeypatch.setattr(settings, "UME_DOSSIER_PATH", str(tmp_path), raising=False)
+    Dossier.init_dossier(tmp_path / "d12")
+    client = TestClient(app)
+    token = _token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    res = client.post(
+        "/dossier/set-shareable",
+        json={"dossier_id": "d12", "shareable_projects": True},
+        headers=headers,
+    )
+    assert res.status_code == 403
 

--- a/tests/test_dossier_cli.py
+++ b/tests/test_dossier_cli.py
@@ -58,6 +58,10 @@ async def add_memory(payload: dict):
 async def set_pref(payload: dict):
     return {'dossier_id': payload['dossier_id'], 'key': payload['key'], 'value': payload['value']}
 
+@app.post('/dossier/set-shareable')
+async def set_shareable(payload: dict):
+    return {'status': 'ok'}
+
 @app.post('/dossier/add-value')
 async def add_value(payload: dict):
     return {'dossier_id': payload['dossier_id'], 'value': payload['value']}
@@ -201,6 +205,22 @@ def test_dossier_set_pref(tmp_path: Path):
             "method": "POST",
             "url": "http://localhost:8000/dossier/set-pref",
             "json": {"dossier_id": "d3", "key": "theme", "value": "dark"},
+        }
+    ]
+
+
+def test_dossier_set_shareable(tmp_path: Path):
+    proc, requests = _run_cli(
+        tmp_path,
+        ["dossier", "set-shareable", "d4", "--projects", "true"],
+    )
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout) == {"status": "ok"}
+    assert requests == [
+        {
+            "method": "POST",
+            "url": "http://localhost:8000/dossier/set-shareable",
+            "json": {"dossier_id": "d4", "shareable_projects": True},
         }
     ]
 

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -165,6 +165,27 @@ def _dossier_set_pref(dossier_id: str, key: str, value: str) -> None:
         print(f"Request failed: {exc}")
 
 
+def _dossier_set_shareable(dossier_id: str, **flags: str) -> None:
+    """Send a request to update shareable flags."""
+    base_url = "http://localhost:8000"
+    headers = {}
+    if settings.UME_API_TOKEN:
+        headers["Authorization"] = f"Bearer {settings.UME_API_TOKEN}"
+    payload: dict[str, object] = {"dossier_id": dossier_id}
+    payload.update(flags)
+    try:
+        resp = httpx.post(
+            f"{base_url}/dossier/set-shareable",
+            json=payload,
+            headers=headers,
+            timeout=5,
+        )
+        resp.raise_for_status()
+        print(json.dumps(resp.json(), indent=2))
+    except httpx.HTTPError as exc:
+        print(f"Request failed: {exc}")
+
+
 def _dossier_add_value(dossier_id: str, value: str) -> None:
     """Send a request to append a value."""
     base_url = "http://localhost:8000"
@@ -384,6 +405,14 @@ def main() -> None:
     pref_p.add_argument("dossier_id")
     pref_p.add_argument("key")
     pref_p.add_argument("value")
+    share_p = dossier_sub.add_parser("set-shareable", help="Update shareable flags")
+    share_p.add_argument("dossier_id")
+    share_p.add_argument("--shareable", choices=["true", "false"])
+    share_p.add_argument("--projects", dest="shareable_projects", choices=["true", "false"])
+    share_p.add_argument("--reflections", dest="shareable_reflections", choices=["true", "false"])
+    share_p.add_argument("--skills", dest="shareable_skills", choices=["true", "false"])
+    share_p.add_argument("--values", dest="shareable_values", choices=["true", "false"])
+    share_p.add_argument("--memories", dest="shareable_memories", choices=["true", "false"])
     val_p = dossier_sub.add_parser("add-value", help="Add a value entry")
     val_p.add_argument("dossier_id")
     val_p.add_argument("value")
@@ -453,6 +482,20 @@ def main() -> None:
                 _dossier_add_memory(args.dossier_id, args.text)
             elif args.dossier_cmd == "set-pref":
                 _dossier_set_pref(args.dossier_id, args.key, args.value)
+            elif args.dossier_cmd == "set-shareable":
+                flags = {}
+                for name in [
+                    "shareable",
+                    "shareable_projects",
+                    "shareable_reflections",
+                    "shareable_skills",
+                    "shareable_values",
+                    "shareable_memories",
+                ]:
+                    val = getattr(args, name)
+                    if val is not None:
+                        flags[name] = val == "true"
+                _dossier_set_shareable(args.dossier_id, **flags)
             elif args.dossier_cmd == "add-value":
                 _dossier_add_value(args.dossier_id, args.value)
             elif args.dossier_cmd == "add-skill":


### PR DESCRIPTION
## Summary
- allow updating shareable flags directly on the dossier
- expose `/dossier/set-shareable` endpoint
- support `dossier set-shareable` in the CLI
- document the new command in the dossier overview
- cover API and CLI behaviour in tests

## Testing
- `pre-commit run --files docs/DOSSIER_OVERVIEW.md src/ume/dossier/__init__.py src/ume/dossier_routes.py tests/test_api_dossier.py tests/test_dossier_cli.py ume_cli.py`
- `poetry run pytest tests/test_api_dossier.py tests/test_dossier_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_688798a37f9483269a830de489f532a1