### PR TITLE
Add GraphQL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The engine is built from a few key components:
 - **FastAPI API** (`src/ume/api.py`)
   - HTTP service exposing graph queries and analytics endpoints.
   - Enforces role-based access to graph operations.
+  - Provides a GraphQL endpoint at `/graphql` for advanced queries.
   - **Graph Adapters** (`src/ume/graph_adapter.py`, `src/ume/neo4j_graph.py`)
     - Define a common interface for manipulating different graph backends.
     - Includes adapters for in-memory, SQLite, Postgres, Redis, and Neo4j storage as well as RBAC wrappers.

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -162,3 +162,28 @@ fetch('/graph/dump', { headers: { Authorization: 'Bearer TOKEN' } })
     // pass data.nodes and data.edges to vis-network
   });
 ```
+
+## GraphQL Endpoint
+
+UME exposes a GraphQL API at `/graphql`. Submit a `POST` request with a JSON body containing a `query` field. The request must include the usual bearer token.
+
+Example request using `curl`:
+```bash
+curl -X POST http://localhost:8000/graphql \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "{ node(id: \"alpha\") { id attributes } }"}'
+```
+
+An example query to retrieve a node and its edges:
+```graphql
+{
+  node(id: "alpha") {
+    id
+    edges {
+      target
+      label
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary
- document the GraphQL endpoint in the architecture overview
- mention `/graphql` under Core Modules in the README

## Testing
- [no tests run: documentation only]

------
https://chatgpt.com/codex/tasks/task_e_6887c79ac42c8326bb3a1ee5d2e146ba