### PR TITLE
Add Kafka ingestion API

### DIFF
--- a/src/ume/ingestion_api.py
+++ b/src/ume/ingestion_api.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from jsonschema import ValidationError
+from confluent_kafka import Producer, KafkaException
+
+from .config import settings
+from .schema_utils import validate_event_dict
+from .logging_utils import configure_logging
+from .utils import ssl_config
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+producer_conf = {"bootstrap.servers": settings.KAFKA_BOOTSTRAP_SERVERS}
+producer_conf.update(ssl_config())
+producer: Producer | None = None
+
+app = FastAPI(
+    title="UME Ingestion API",
+    version="0.1.0",
+    description="Publish raw events to Kafka",
+)
+
+
+@app.on_event("startup")  # type: ignore[misc]
+def _init_producer() -> None:
+    """Initialize the Kafka producer."""
+    global producer
+    producer = Producer(producer_conf)
+
+
+@app.post("/events", status_code=202)  # type: ignore[misc]
+async def post_event(request: Request) -> JSONResponse:
+    """Validate the request body and publish it to Kafka."""
+    try:
+        data = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+    try:
+        validate_event_dict(data)
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    if producer is None:
+        raise HTTPException(status_code=503, detail="Producer not initialized")
+    try:
+        producer.produce(
+            settings.KAFKA_RAW_EVENTS_TOPIC,
+            json.dumps(data).encode("utf-8"),
+        )
+        producer.poll(0)  # Trigger delivery callbacks without blocking
+    except KafkaException as exc:
+        logger.error("Failed to produce event: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to publish event")
+
+    return JSONResponse(status_code=202, content={"status": "accepted"})
+
+
+@app.on_event("shutdown")  # type: ignore[misc]
+def _close_producer() -> None:
+    if producer is None:
+        return
+    try:
+        producer.flush()
+    except Exception:
+        logger.exception("Producer flush failed")

--- a/tests/test_ingestion_api.py
+++ b/tests/test_ingestion_api.py
@@ -1,0 +1,49 @@
+from fastapi.testclient import TestClient
+import json
+import pytest
+
+from ume.ingestion_api import app, settings
+import ume.ingestion_api as ingestion_api
+
+
+class FakeProducer:
+    def __init__(self):
+        self.produced = []
+        self.poll_calls = 0
+        self.flush_calls = 0
+
+    def produce(self, topic, value):
+        self.produced.append((topic, value))
+
+    def poll(self, timeout):
+        self.poll_calls += 1
+
+    def flush(self):
+        self.flush_calls += 1
+
+
+@pytest.fixture
+def client(monkeypatch):
+    prod = FakeProducer()
+    monkeypatch.setattr(ingestion_api, "Producer", lambda conf: prod)
+    with TestClient(app) as test_client:
+        yield test_client, prod
+
+
+def test_post_event_publishes_to_kafka(client):
+    test_client, prod = client
+    event = {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}
+    res = test_client.post("/events", json=event)
+    assert res.status_code == 202
+    assert prod.produced == [
+        (settings.KAFKA_RAW_EVENTS_TOPIC, json.dumps(event).encode("utf-8"))
+    ]
+    assert prod.poll_calls == 1
+
+
+def test_invalid_event_returns_400(client):
+    test_client, prod = client
+    res = test_client.post("/events", json={"event_type": "CREATE_NODE"})
+    assert res.status_code == 400
+    assert prod.produced == []
+


### PR DESCRIPTION
## Summary
- implement `/events` ingestion API to publish raw events to Kafka
- validate events against canonical schema
- expose startup/shutdown handlers for the Kafka producer
- add unit tests for the ingestion API

## Testing
- `pre-commit run --files src/ume/ingestion_api.py tests/test_ingestion_api.py`
- `pytest tests/test_ingestion_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c979a5088326b800f8d42c066ba5