### PR TITLE
Add GraphQL support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1700,6 +1700,55 @@ protobuf = ">=3.20.2,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4
 grpc = ["grpcio (>=1.44.0,<2.0.0)"]
 
 [[package]]
+name = "graphene"
+version = "3.4.3"
+description = "GraphQL Framework for Python"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "graphene-3.4.3-py2.py3-none-any.whl", hash = "sha256:820db6289754c181007a150db1f7fff544b94142b556d12e3ebc777a7bf36c71"},
+    {file = "graphene-3.4.3.tar.gz", hash = "sha256:2a3786948ce75fe7e078443d37f609cbe5bb36ad8d6b828740ad3b95ed1a0aaa"},
+]
+
+[package.dependencies]
+graphql-core = ">=3.1,<3.3"
+graphql-relay = ">=3.1,<3.3"
+python-dateutil = ">=2.7.0,<3"
+typing-extensions = ">=4.7.1,<5"
+
+[package.extras]
+dev = ["coveralls (>=3.3,<5)", "mypy (>=1.10,<2)", "pytest (>=8,<9)", "pytest-asyncio (>=0.16,<2)", "pytest-benchmark (>=4,<5)", "pytest-cov (>=5,<6)", "pytest-mock (>=3,<4)", "ruff (==0.5.0)", "types-python-dateutil (>=2.8.1,<3)"]
+test = ["coveralls (>=3.3,<5)", "pytest (>=8,<9)", "pytest-asyncio (>=0.16,<2)", "pytest-benchmark (>=4,<5)", "pytest-cov (>=5,<6)", "pytest-mock (>=3,<4)"]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.6"
+description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
+optional = false
+python-versions = "<4,>=3.6"
+groups = ["main"]
+files = [
+    {file = "graphql_core-3.2.6-py3-none-any.whl", hash = "sha256:78b016718c161a6fb20a7d97bbf107f331cd1afe53e45566c59f776ed7f0b45f"},
+    {file = "graphql_core-3.2.6.tar.gz", hash = "sha256:c08eec22f9e40f0bd61d805907e3b3b1b9a320bc606e23dc145eebca07c8fbab"},
+]
+
+[[package]]
+name = "graphql-relay"
+version = "3.2.0"
+description = "Relay library for graphql-core"
+optional = false
+python-versions = ">=3.6,<4"
+groups = ["main"]
+files = [
+    {file = "graphql-relay-3.2.0.tar.gz", hash = "sha256:1ff1c51298356e481a0be009ccdff249832ce53f30559c1338f22a0e0d17250c"},
+    {file = "graphql_relay-3.2.0-py3-none-any.whl", hash = "sha256:c9b22bd28b170ba1fe674c74384a8ff30a76c8e26f88ac3aa1584dd3179953e5"},
+]
+
+[package.dependencies]
+graphql-core = ">=3.2,<3.3"
+
+[[package]]
 name = "grpcio"
 version = "1.73.1"
 description = "HTTP/2-based RPC framework"
@@ -6101,4 +6150,4 @@ vector = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "82bd5e14b29adc28e7ecf64f6a35801275c0228e6e472ddbe7181e5aa442c714"
+content-hash = "675ec79d1f6d77958d6b62978b3bd427dc1fda8a01cf3bbc35b5a611b6fd8959"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ httpx = "*"
 opentelemetry-api = "*"
 opentelemetry-sdk = "*"
 opentelemetry-exporter-otlp = "*"
+graphene = "^3.4.3"
 
 
 

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -25,6 +25,7 @@ except Exception:  # pragma: no cover - allow tests without opentelemetry instal
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, Response
+from starlette_graphene3 import GraphQLApp, make_graphiql_handler
 
 from .metrics import REQUEST_COUNT, REQUEST_LATENCY
 from .retention import (
@@ -50,6 +51,7 @@ from .snapshot_routes import router as snapshot_router
 from .ledger_routes import router as ledger_router
 from .dossier_routes import router as dossier_router
 from .consent_ledger import consent_ledger  # noqa: F401
+from .graphql_api import schema as graphql_schema
 
 from . import api_deps
 
@@ -93,6 +95,14 @@ app.include_router(feedback_router)
 app.include_router(snapshot_router)
 app.include_router(ledger_router)
 app.include_router(dossier_router)
+app.add_route(
+    "/graphql",
+    GraphQLApp(
+        graphql_schema,
+        on_get=make_graphiql_handler(),
+        context_value=lambda request: {"app": app},
+    ),
+)
 
 
 

--- a/src/ume/graphql_api.py
+++ b/src/ume/graphql_api.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+# mypy: ignore-errors
+
+import inspect
+from typing import Any
+
+import graphene
+from graphene.types.generic import GenericScalar
+
+
+async def _maybe_call(obj: Any, name: str, *args: Any) -> Any:
+    method = getattr(obj, name)
+    if inspect.iscoroutinefunction(method):
+        return await method(*args)
+    result = method(*args)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+class NodeType(graphene.ObjectType):
+    """Graph node representation."""
+
+    id = graphene.String(required=True)
+    attributes = GenericScalar()
+
+
+class EdgeType(graphene.ObjectType):
+    """Graph edge representation."""
+
+    source = graphene.String(required=True)
+    target = graphene.String(required=True)
+    label = graphene.String(required=True)
+
+
+class Query(graphene.ObjectType):
+    node = graphene.Field(NodeType, id=graphene.String(required=True))
+    nodes = graphene.List(NodeType)
+
+    async def resolve_node(self, info: graphene.ResolveInfo, id: str) -> NodeType | None:
+        graph = info.context["app"].state.graph
+        if graph is None:
+            return None
+        data = await _maybe_call(graph, "get_node", id)
+        if data is None:
+            return None
+        return NodeType(id=id, attributes=data)
+
+    async def resolve_nodes(self, info: graphene.ResolveInfo) -> list[NodeType]:
+        graph = info.context["app"].state.graph
+        if graph is None:
+            return []
+        ids = await _maybe_call(graph, "get_all_node_ids")
+        result = []
+        for nid in ids:
+            data = await _maybe_call(graph, "get_node", nid)
+            result.append(NodeType(id=nid, attributes=data or {}))
+        return result
+
+
+class CreateNode(graphene.Mutation):
+    class Arguments:
+        id = graphene.String(required=True)
+        attributes = GenericScalar()
+
+    ok = graphene.Boolean()
+    node = graphene.Field(NodeType)
+
+    async def mutate(self, info: graphene.ResolveInfo, id: str, attributes: dict[str, Any] | None = None) -> "CreateNode":
+        graph = info.context["app"].state.graph
+        await _maybe_call(graph, "add_node", id, attributes or {})
+        return CreateNode(ok=True, node=NodeType(id=id, attributes=attributes or {}))
+
+
+class CreateEdge(graphene.Mutation):
+    class Arguments:
+        source = graphene.String(required=True)
+        target = graphene.String(required=True)
+        label = graphene.String(required=True)
+
+    ok = graphene.Boolean()
+
+    async def mutate(self, info: graphene.ResolveInfo, source: str, target: str, label: str) -> "CreateEdge":
+        graph = info.context["app"].state.graph
+        await _maybe_call(graph, "add_edge", source, target, label)
+        return CreateEdge(ok=True)
+
+
+class Mutation(graphene.ObjectType):
+    create_node = CreateNode.Field()
+    create_edge = CreateEdge.Field()
+
+
+schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+from ume.api import app, configure_graph
+from ume import MockGraph
+
+
+def setup_module(_):
+    g = MockGraph()
+    g.add_node("a", {"x": 1})
+    configure_graph(g)
+
+
+def test_query_nodes() -> None:
+    client = TestClient(app)
+    res = client.post("/graphql", json={"query": "{ nodes { id attributes } }"})
+    assert res.status_code == 200
+    data = res.json()["data"]["nodes"]
+    assert {"id": "a", "attributes": {"x": 1}} in data
+
+
+def test_create_node_mutation() -> None:
+    client = TestClient(app)
+    mutation = (
+        "mutation($id: String!, $attrs: GenericScalar) {"
+        "  createNode(id: $id, attributes: $attrs) { ok node { id attributes } }"
+        "}"
+    )
+    res = client.post(
+        "/graphql",
+        json={"query": mutation, "variables": {"id": "b", "attrs": {"y": 2}}},
+    )
+    assert res.status_code == 200
+    assert res.json()["data"]["createNode"]["ok"] is True
+    assert app.state.graph.get_node("b") == {"y": 2}


### PR DESCRIPTION
## Summary
- add graphene dependency
- expose GraphQL schema and route
- implement GraphQL schema for nodes and edges
- test simple GraphQL queries and mutations

## Testing
- `pre-commit run --files pyproject.toml poetry.lock src/ume/api.py src/ume/graphql_api.py tests/test_graphql.py`
- `pytest tests/test_graphql.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c799edb083268ec271d915e81450