### PR TITLE
Add graph consumer

### DIFF
--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -1,0 +1,96 @@
+"""Kafka consumer that applies events to the graph."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from confluent_kafka import Consumer, KafkaException, KafkaError
+from jsonschema import ValidationError
+
+from ..config import settings
+from ..utils import ssl_config
+from ..event import parse_event, EventError
+from ..processing import apply_event_to_graph, ProcessingError
+from ..schema_utils import validate_event_dict
+from ..event_ledger import event_ledger
+from ..graph_adapter import IGraphAdapter
+from ..logging_utils import configure_logging
+
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
+NODE_TOPIC = settings.KAFKA_NODE_TOPIC
+EDGE_TOPIC = settings.KAFKA_EDGE_TOPIC
+DEFAULT_GROUP_ID = settings.KAFKA_GROUP_ID
+
+
+def run_graph_consumer(
+    graph: IGraphAdapter,
+    *,
+    group_id: str | None = None,
+    consumer: Consumer | None = None,
+) -> None:
+    """Consume events from Kafka and apply them to ``graph``."""
+
+    gid = group_id or DEFAULT_GROUP_ID
+    owns_consumer = False
+    if consumer is None:
+        conf = {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "group.id": gid,
+            "auto.offset.reset": "earliest",
+        }
+        conf.update(ssl_config())
+        try:
+            consumer = Consumer(conf)
+        except KafkaException as exc:  # pragma: no cover - network errors
+            logger.error("Failed to create Kafka consumer: %s", exc)
+            return
+        try:
+            consumer.subscribe([NODE_TOPIC, EDGE_TOPIC])
+        except KafkaException as exc:  # pragma: no cover - network errors
+            logger.error("Subscription failed: %s", exc)
+            consumer.close()
+            return
+        owns_consumer = True
+
+    logger.info("Graph consumer started with group_id %s", gid)
+    try:
+        while True:
+            try:
+                msg = consumer.poll(1.0)
+            except KafkaException as exc:  # pragma: no cover - network errors
+                logger.error("Poll failed: %s", exc)
+                continue
+            if msg is None:
+                continue
+            if msg.error():
+                if msg.error().code() != KafkaError._PARTITION_EOF:
+                    logger.error("Kafka error: %s", msg.error())
+                continue
+
+            try:
+                data = json.loads(msg.value().decode("utf-8"))
+                validate_event_dict(data)
+                payload = data["event"] if "event" in data else data
+                event = parse_event(payload)
+            except (json.JSONDecodeError, ValidationError, EventError) as exc:
+                logger.error("Invalid event skipped: %s", exc)
+                continue
+            try:
+                apply_event_to_graph(event, graph)
+            except ProcessingError as exc:
+                logger.error("Event processing failed: %s", exc)
+                continue
+            try:
+                event_ledger.update_bookmark(msg.offset())
+            except Exception as exc:  # pragma: no cover - unexpected errors
+                logger.error("Failed to update bookmark: %s", exc)
+    except KeyboardInterrupt:
+        logger.info("Graph consumer shutting down")
+    finally:
+        if owns_consumer:
+            consumer.close()

--- a/tests/test_graph_consumer.py
+++ b/tests/test_graph_consumer.py
@@ -1,0 +1,85 @@
+import json
+
+import pytest
+
+from ume import MockGraph
+from ume.event_ledger import EventLedger
+from ume.pipeline import graph_consumer
+
+
+class DummyMessage:
+    def __init__(self, value: bytes, offset: int) -> None:
+        self._value = value
+        self._offset = offset
+
+    def value(self) -> bytes:
+        return self._value
+
+    def error(self):
+        return None
+
+    def offset(self) -> int:
+        return self._offset
+
+
+class DummyConsumer:
+    def __init__(self, messages: list[DummyMessage]) -> None:
+        self.messages = messages
+        self.index = 0
+        self.closed = False
+
+    def subscribe(self, topics):
+        self.topics = topics
+
+    def poll(self, timeout: float = 1.0):
+        if self.index >= len(self.messages):
+            raise KeyboardInterrupt
+        msg = self.messages[self.index]
+        self.index += 1
+        return msg
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _patch_modules(monkeypatch: pytest.MonkeyPatch, consumer: DummyConsumer, ledger: EventLedger) -> None:
+    monkeypatch.setattr(graph_consumer, "Consumer", lambda conf: consumer)
+    monkeypatch.setattr(graph_consumer, "ssl_config", lambda: {})
+    monkeypatch.setattr(graph_consumer, "event_ledger", ledger)
+
+
+def test_graph_consumer_applies_events(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    events = [
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 1,
+            "node_id": "n1",
+            "payload": {"node_id": "n1"},
+        },
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 1,
+            "node_id": "n2",
+            "payload": {"node_id": "n2"},
+        },
+        {
+            "event_type": "CREATE_EDGE",
+            "timestamp": 1,
+            "node_id": "n1",
+            "target_node_id": "n2",
+            "label": "RELATES_TO",
+            "payload": {},
+        },
+    ]
+    msgs = [DummyMessage(json.dumps(e).encode("utf-8"), i) for i, e in enumerate(events)]
+    consumer = DummyConsumer(msgs)
+    _patch_modules(monkeypatch, consumer, ledger)
+
+    graph = MockGraph()
+    graph_consumer.run_graph_consumer(graph)
+
+    assert graph.node_exists("n1")
+    assert graph.node_exists("n2")
+    assert ("n1", "n2", "RELATES_TO") in graph.get_all_edges()
+    assert ledger.last_processed_offset == 2


### PR DESCRIPTION
## Summary
- implement `run_graph_consumer` for processing Kafka events
- update event ledger bookmark when events are applied
- add unit test with stub Kafka consumer

## Testing
- `pre-commit run --files src/ume/pipeline/graph_consumer.py tests/test_graph_consumer.py`
- `pytest -q tests/test_graph_consumer.py`

------
https://chatgpt.com/codex/tasks/task_e_6887dbd63d848326bc7d7e9af481c949