### PR TITLE
Add ingestion API and consumer to compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -86,6 +86,44 @@ services:
       timeout: 5s
       retries: 5
 
+  ingestion-api:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.api
+    command: uvicorn ume.ingestion_api:app --host 0.0.0.0 --port 8001
+    depends_on:
+      redpanda:
+        condition: service_healthy
+    env_file:
+      - ../.env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "redpanda:29092"
+    ports:
+      - "8001:8001"
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f uvicorn || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  graph-consumer:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.api
+    command: poetry run python src/ume/consumer_demo.py
+    depends_on:
+      redpanda:
+        condition: service_healthy
+    env_file:
+      - ../.env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "redpanda:29092"
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f consumer_demo.py || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   prometheus:
     image: prom/prometheus
     volumes:

--- a/poetry.lock
+++ b/poetry.lock
@@ -5162,6 +5162,23 @@ anyio = ">=3.6.2,<5"
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
+name = "starlette-graphene3"
+version = "0.6.0"
+description = "Use Graphene v3 on Starlette"
+optional = false
+python-versions = ">=3.7,<4.0"
+groups = ["main"]
+files = [
+    {file = "starlette-graphene3-0.6.0.tar.gz", hash = "sha256:cbe4ca397b24013d5b3161dd4144e9b3e836af0ef01a625bb6113946fc7d36d9"},
+    {file = "starlette_graphene3-0.6.0-py3-none-any.whl", hash = "sha256:193ff6e0900a3259ccf76b534cd84eaa2feefcaf92652b3b0f54fc784c80ce14"},
+]
+
+[package.dependencies]
+graphene = ">=3.0b6"
+graphql-core = ">=3.1,<3.3"
+starlette = ">=0.14.1"
+
+[[package]]
 name = "structlog"
 version = "25.4.0"
 description = "Structured Logging for Python"
@@ -6150,4 +6167,4 @@ vector = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "675ec79d1f6d77958d6b62978b3bd427dc1fda8a01cf3bbc35b5a611b6fd8959"
+content-hash = "71f9e78505e2c122508779246f90491924ceb55c8f15c7e88bcb3300b37b3069"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ opentelemetry-api = "*"
 opentelemetry-sdk = "*"
 opentelemetry-exporter-otlp = "*"
 graphene = "^3.4.3"
+starlette-graphene3 = "^0.6.0"
 
 
 

--- a/tests/test_api_reference.py
+++ b/tests/test_api_reference.py
@@ -44,6 +44,7 @@ def test_documented_routes_exist() -> None:
     actual = {
         (m, _normalize(route.path))
         for route in app.router.routes
+        if route.methods
         for m in route.methods
         if m in {"GET", "POST", "DELETE", "PATCH", "PUT"}
     }


### PR DESCRIPTION
## Summary
- include new containers for ingestion-api and graph-consumer
- depend on Redpanda and share .env file
- add missing starlette-graphene3 dependency
- guard against None in API reference test

## Testing
- `pre-commit run --files tests/test_api_reference.py docker/docker-compose.yml pyproject.toml`
- `poetry run pytest --maxfail=1 -q` *(332 passed, 9 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6887dbd8dce083268a82ab4fa129d1f3