### PR TITLE
Add metadata fields to event schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ The events exchanged in the demo have a simple JSON structure. Here's an example
   "timestamp": 1678886400,
   "payload": {
     "message": "Hello from producer_demo!"
-  }
+  },
+  "correlationId": "demo-1",
+  "subjectEntity": "demo",
+  "sourceService": "producer_demo"
 }
 ```
 
@@ -95,6 +98,9 @@ The events exchanged in the demo have a simple JSON structure. Here's an example
 *   `event_type` (string): Describes the kind of event. In the demo, this is hardcoded to `"demo_event"`.
 *   `timestamp` (integer): A Unix timestamp (seconds since epoch) indicating when the event was generated.
 *   `payload` (object): A JSON object containing the actual data of the event. The structure of the payload can vary depending on the event type. For the demo, it includes a simple `message`.
+*   `correlationId` (string, optional): Identifier used to link related events.
+*   `subjectEntity` (string, optional): The entity this event relates to.
+*   `sourceService` (string, optional): Name of the service emitting the event.
 
 All official event types such as `CREATE_NODE` or `CREATE_EDGE` have
 corresponding JSON Schema definitions under `src/ume/schemas`.  Producers
@@ -124,7 +130,8 @@ Used to create a new directed, labeled edge between two existing nodes.
 *   `node_id`: String, ID of the source node.
 *   `target_node_id`: String, ID of the target node.
 *   `label`: String, label for the edge.
-**Optional Fields:** `event_id`, `source`, `payload`.
+**Optional Fields:** `event_id`, `source`, `payload`, `correlationId`,
+`subjectEntity`, `sourceService`.
 
 #### DELETE_EDGE Event
 
@@ -149,7 +156,8 @@ Used to remove a specific directed, labeled edge between two nodes.
 *   `node_id`: String, ID of the source node.
 *   `target_node_id`: String, ID of the target node.
 *   `label`: String, label of the edge.
-**Optional Fields:** `event_id`, `source`, `payload`.
+**Optional Fields:** `event_id`, `source`, `payload`, `correlationId`,
+`subjectEntity`, `sourceService`.
 
 **Event Flow:** *(see the full diagram in [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md))*
 
@@ -649,27 +657,39 @@ This section outlines the basic programmatic steps to interact with the UME comp
 
     # Event to create node_A
     event_data_create_A = {
-        "event_type": "CREATE_NODE", "timestamp": int(time.time()),
-        "node_id": "node_A", # Field used by CREATE_NODE for the node to create
+        "event_type": "CREATE_NODE",
+        "timestamp": int(time.time()),
+        "node_id": "node_A",  # Field used by CREATE_NODE for the node to create
         "payload": {"name": "Alpha Node", "type": "concept"},
-        "source": "my_script"
+        "source": "my_script",
+        "correlationId": "demo-1",
+        "subjectEntity": "node",
+        "sourceService": "examples",
     }
 
     # Event to create node_B
     event_data_create_B = {
-        "event_type": "CREATE_NODE", "timestamp": int(time.time()) + 1,
-        "node_id": "node_B", # Field used by CREATE_NODE for the node to create
+        "event_type": "CREATE_NODE",
+        "timestamp": int(time.time()) + 1,
+        "node_id": "node_B",  # Field used by CREATE_NODE for the node to create
         "payload": {"name": "Beta Node", "value": 42},
-        "source": "my_script"
+        "source": "my_script",
+        "correlationId": "demo-1",
+        "subjectEntity": "node",
+        "sourceService": "examples",
     }
 
     # Event to create an edge from node_A to node_B
     event_data_create_edge_A_B = {
-        "event_type": "CREATE_EDGE", "timestamp": int(time.time()) + 2,
+        "event_type": "CREATE_EDGE",
+        "timestamp": int(time.time()) + 2,
         "node_id": "node_A",        # Source node for the edge
-        "target_node_id": "node_B", # Target node for the edge
+        "target_node_id": "node_B",  # Target node for the edge
         "label": "KNOWS",           # Label of the edge
-        "source": "my_script"
+        "source": "my_script",
+        "correlationId": "demo-1",
+        "subjectEntity": "edge",
+        "sourceService": "examples",
         # "payload" is optional for CREATE_EDGE, defaults to {}
     }
     ```

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -41,6 +41,9 @@ class Event:
                                           (e.g., CREATE_EDGE, DELETE_EDGE). Defaults to None.
         label (Optional[str]): A label describing an edge or a relationship, used for edge-related events.
                                  Defaults to None.
+        correlation_id (Optional[str]): Optional ID to correlate related events.
+        subject_entity (Optional[str]): Entity this event refers to, if any.
+        source_service (Optional[str]): Name of the service emitting the event.
     """
 
     event_type: str
@@ -51,6 +54,9 @@ class Event:
     node_id: Optional[str] = None  # Source node for edges, or target for node ops
     target_node_id: Optional[str] = None  # Target node for edges
     label: Optional[str] = None  # Label for edges
+    correlation_id: Optional[str] = None
+    subject_entity: Optional[str] = None
+    source_service: Optional[str] = None
 
 
 class EventError(ValueError):
@@ -70,7 +76,9 @@ def parse_event(data: Dict[str, Any]) -> Event:
                 - For "CREATE_NODE", "UPDATE_NODE_ATTRIBUTES": "node_id" (str), "payload" (dict).
                 - For "CREATE_EDGE", "DELETE_EDGE": "node_id" (source, str),
                   "target_node_id" (str), "label" (str).
-              Optional common keys: "event_id" (str), "source" (str).
+              Optional common keys: "event_id" (str), "source" (str),
+                "correlationId" (str), "subjectEntity" (str),
+                "sourceService" (str).
               "payload" (dict) is optional for edge events, defaulting to {}.
 
     Returns:
@@ -102,6 +110,17 @@ def parse_event(data: Dict[str, Any]) -> Event:
 
     # Validate optional event_id type
     event_id_val = data.get("event_id")
+
+    # Get potential values, to be validated by type-specific logic or used if optional
+    node_id_val = data.get("node_id")
+    target_node_id_val = data.get("target_node_id")
+    label_val = data.get("label")
+    correlation_id_val = data.get("correlationId")
+    subject_entity_val = data.get("subjectEntity")
+    source_service_val = data.get("sourceService")
+    # Default payload to {} if not present; specific event types might require it later
+    payload_val = data.get("payload", {})
+
     if event_id_val is not None and not isinstance(event_id_val, str):
         msg = (
             f"Invalid type for 'event_id': expected str, got {type(event_id_val).__name__}"
@@ -109,12 +128,26 @@ def parse_event(data: Dict[str, Any]) -> Event:
         logger.error(msg)
         raise EventError(msg)
 
-    # Get potential values, to be validated by type-specific logic or used if optional
-    node_id_val = data.get("node_id")
-    target_node_id_val = data.get("target_node_id")
-    label_val = data.get("label")
-    # Default payload to {} if not present; specific event types might require it later
-    payload_val = data.get("payload", {})
+    if correlation_id_val is not None and not isinstance(correlation_id_val, str):
+        msg = (
+            f"Invalid type for 'correlationId': expected str, got {type(correlation_id_val).__name__}"
+        )
+        logger.error(msg)
+        raise EventError(msg)
+
+    if subject_entity_val is not None and not isinstance(subject_entity_val, str):
+        msg = (
+            f"Invalid type for 'subjectEntity': expected str, got {type(subject_entity_val).__name__}"
+        )
+        logger.error(msg)
+        raise EventError(msg)
+
+    if source_service_val is not None and not isinstance(source_service_val, str):
+        msg = (
+            f"Invalid type for 'sourceService': expected str, got {type(source_service_val).__name__}"
+        )
+        logger.error(msg)
+        raise EventError(msg)
 
     if event_type in [
         EventType.CREATE_NODE.value,
@@ -181,4 +214,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
         node_id=node_id_val,
         target_node_id=target_node_id_val,
         label=label_val,
+        correlation_id=correlation_id_val,
+        subject_entity=subject_entity_val,
+        source_service=source_service_val,
     )

--- a/src/ume/schema_utils.py
+++ b/src/ume/schema_utils.py
@@ -46,7 +46,11 @@ def _load_schema(event_type: str) -> Dict[str, Any]:
 
 
 def validate_event_dict(event_data: Dict[str, Any]) -> None:
-    """Validate a raw event dictionary or envelope against its JSON schema."""
+    """Validate a raw event dictionary or envelope against its JSON schema.
+
+    Updated schemas include optional ``correlationId``, ``subjectEntity`` and
+    ``sourceService`` fields which will also be validated when present.
+    """
     if "event" in event_data and "schema_version" in event_data:
         validate(instance=event_data, schema=_load_envelope_schema())
         version = event_data["schema_version"]

--- a/src/ume/schemas/create_edge.schema.json
+++ b/src/ume/schemas/create_edge.schema.json
@@ -22,6 +22,18 @@
       "type": "string",
       "description": "Originating system of the event"
     },
+    "correlationId": {
+      "type": "string",
+      "description": "Identifier linking related events"
+    },
+    "subjectEntity": {
+      "type": "string",
+      "description": "Entity this event pertains to"
+    },
+    "sourceService": {
+      "type": "string",
+      "description": "Service originating the event"
+    },
     "node_id": {
       "type": "string",
       "description": "Source node identifier"

--- a/src/ume/schemas/create_node.schema.json
+++ b/src/ume/schemas/create_node.schema.json
@@ -22,6 +22,18 @@
       "type": "string",
       "description": "Originating system of the event"
     },
+    "correlationId": {
+      "type": "string",
+      "description": "Identifier linking related events"
+    },
+    "subjectEntity": {
+      "type": "string",
+      "description": "Entity this event pertains to"
+    },
+    "sourceService": {
+      "type": "string",
+      "description": "Service originating the event"
+    },
     "node_id": {
       "type": "string",
       "description": "Identifier of the node to create"

--- a/src/ume/schemas/delete_edge.schema.json
+++ b/src/ume/schemas/delete_edge.schema.json
@@ -22,6 +22,18 @@
       "type": "string",
       "description": "Originating system of the event"
     },
+    "correlationId": {
+      "type": "string",
+      "description": "Identifier linking related events"
+    },
+    "subjectEntity": {
+      "type": "string",
+      "description": "Entity this event pertains to"
+    },
+    "sourceService": {
+      "type": "string",
+      "description": "Service originating the event"
+    },
     "node_id": {
       "type": "string",
       "description": "Source node identifier"

--- a/src/ume/schemas/update_node_attributes.schema.json
+++ b/src/ume/schemas/update_node_attributes.schema.json
@@ -22,6 +22,18 @@
       "type": "string",
       "description": "Originating system of the event"
     },
+    "correlationId": {
+      "type": "string",
+      "description": "Identifier linking related events"
+    },
+    "subjectEntity": {
+      "type": "string",
+      "description": "Entity this event pertains to"
+    },
+    "sourceService": {
+      "type": "string",
+      "description": "Service originating the event"
+    },
     "node_id": {
       "type": "string",
       "description": "Identifier of the node to update"

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -13,6 +13,9 @@ def test_parse_event_valid():
         "timestamp": timestamp_now,
         "payload": {"key": "value", "num": 123},
         "source": "test_source",
+        "correlationId": "c123",
+        "subjectEntity": "user",
+        "sourceService": "tests",
     }
     event = parse_event(event_data)
     assert isinstance(event, Event)
@@ -21,6 +24,9 @@ def test_parse_event_valid():
     assert event.timestamp == timestamp_now
     assert event.payload == {"key": "value", "num": 123}
     assert event.source == "test_source"
+    assert event.correlation_id == "c123"
+    assert event.subject_entity == "user"
+    assert event.source_service == "tests"
 
 
 def test_parse_event_minimal_valid():
@@ -39,6 +45,9 @@ def test_parse_event_minimal_valid():
     assert event.event_id is not None  # Should be auto-generated
     assert isinstance(event.event_id, str)
     assert event.source is None  # Should default to None
+    assert event.correlation_id is None
+    assert event.subject_entity is None
+    assert event.source_service is None
 
 
 @pytest.mark.parametrize(
@@ -290,6 +299,33 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
                 "event_id": 123,
             },
             "Invalid type for 'event_id'",
+        ),
+        (
+            {
+                "event_type": "test",
+                "timestamp": int(time.time()),
+                "payload": {},
+                "correlationId": 1,
+            },
+            "Invalid type for 'correlationId'",
+        ),
+        (
+            {
+                "event_type": "test",
+                "timestamp": int(time.time()),
+                "payload": {},
+                "subjectEntity": 1,
+            },
+            "Invalid type for 'subjectEntity'",
+        ),
+        (
+            {
+                "event_type": "test",
+                "timestamp": int(time.time()),
+                "payload": {},
+                "sourceService": 1,
+            },
+            "Invalid type for 'sourceService'",
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- extend event JSON schemas with optional metadata fields
- store `correlation_id`, `subject_entity` and `source_service` in the `Event` dataclass
- parse the new metadata fields in `parse_event`
- document the new fields in validation utilities
- test event parsing for the added fields
- update README examples to showcase the new fields

## Testing
- `pre-commit run --files README.md src/ume/event.py src/ume/schema_utils.py src/ume/schemas/create_edge.schema.json src/ume/schemas/create_node.schema.json src/ume/schemas/delete_edge.schema.json src/ume/schemas/update_node_attributes.schema.json tests/test_event.py`
- `pytest -q tests/test_event.py`


------
https://chatgpt.com/codex/tasks/task_e_6887fb790a4c83269f574e14668d50aa