### PR TITLE
Add pipeline end-to-end integration test

### DIFF
--- a/tests/integration/test_pipeline_end_to_end.py
+++ b/tests/integration/test_pipeline_end_to_end.py
@@ -1,0 +1,120 @@
+import os
+import threading
+
+import pytest
+from fastapi.testclient import TestClient
+from confluent_kafka import Consumer as KafkaConsumer
+
+from ume.ingestion_api import app, producer_conf, settings as api_settings
+from ume.pipeline import graph_consumer
+from ume.event_ledger import EventLedger
+from ume.graph import MockGraph
+from ume.vector_store import VectorStoreListener
+from ume._internal.listeners import register_listener, unregister_listener
+
+
+class DummyVectorStore:
+    def __init__(self, dim: int) -> None:
+        self.dim = dim
+        self.vectors: dict[str, list[float]] = {}
+
+    def add(self, vid: str, vector: list[float]) -> None:
+        assert len(vector) == self.dim
+        self.vectors[vid] = vector
+
+    def query(self, vector: list[float], k: int = 5) -> list[str]:
+        def dist(v: list[float]) -> float:
+            return sum((a - b) ** 2 for a, b in zip(v, vector))
+        return [vid for vid, v in sorted(self.vectors.items(), key=lambda kv: dist(kv[1]))][:k]
+
+    def close(self) -> None:
+        pass
+
+
+class LimitingConsumer(KafkaConsumer):
+    def __init__(self, conf):
+        super().__init__(conf)
+        self.count = 0
+
+    def poll(self, timeout: float = 1.0):
+        if self.count >= 1:
+            raise KeyboardInterrupt
+        msg = super().poll(timeout)
+        if msg is not None and not msg.error():
+            self.count += 1
+        return msg
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("UME_DOCKER_TESTS"), reason="Docker tests disabled"
+)
+def test_pipeline_end_to_end(tmp_path, monkeypatch):
+    try:
+        from testcontainers.core.container import DockerContainer
+    except Exception as exc:
+        pytest.skip(f"Docker containers not available: {exc}")
+
+    try:
+        container = DockerContainer(
+            "docker.redpanda.com/redpandadata/redpanda:latest"
+        )
+        container.with_exposed_ports(9092)
+        container.with_command(
+            "redpanda start --smp 1 --overprovisioned --node-id 0 --check=false "
+            "--kafka-addr PLAINTEXT://0.0.0.0:9092 "
+            "--advertise-kafka-addr PLAINTEXT://127.0.0.1:9092"
+        )
+        container.start()
+    except Exception as exc:  # pragma: no cover - environment issues
+        pytest.skip(f"Redpanda not available: {exc}")
+
+    broker = f"{container.get_container_host_ip()}:{container.get_exposed_port(9092)}"
+
+    object.__setattr__(api_settings, "KAFKA_BOOTSTRAP_SERVERS", broker)
+    object.__setattr__(api_settings, "KAFKA_RAW_EVENTS_TOPIC", "pipeline_raw")
+    object.__setattr__(api_settings, "UME_AUDIT_SIGNING_KEY", "test-key")
+    producer_conf["bootstrap.servers"] = broker
+
+    object.__setattr__(graph_consumer, "BOOTSTRAP_SERVERS", broker)
+    object.__setattr__(graph_consumer, "NODE_TOPIC", "pipeline_nodes")
+    object.__setattr__(graph_consumer, "EDGE_TOPIC", "pipeline_edges")
+    object.__setattr__(graph_consumer, "DEFAULT_GROUP_ID", "pipeline_group")
+
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    monkeypatch.setattr(graph_consumer, "event_ledger", ledger)
+    monkeypatch.setattr(graph_consumer, "Consumer", LimitingConsumer)
+    monkeypatch.setattr(graph_consumer, "ssl_config", lambda: {})
+
+    graph = MockGraph()
+    store = DummyVectorStore(dim=2)
+    listener = VectorStoreListener(store)
+    register_listener(listener)
+
+    consumer_thread = threading.Thread(
+        target=graph_consumer.run_graph_consumer,
+        args=(graph,),
+        kwargs={"group_id": "pipeline_group"},
+    )
+    consumer_thread.start()
+
+    event = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n1",
+        "payload": {"node_id": "n1", "attributes": {"embedding": [1.0, 0.0]}},
+    }
+
+    with TestClient(app) as client:
+        res = client.post("/events", json=event)
+        assert res.status_code == 202
+
+    consumer_thread.join(timeout=10)
+    assert not consumer_thread.is_alive(), "graph consumer did not terminate"
+
+    assert graph.get_node("n1") == {"embedding": [1.0, 0.0]}
+    assert store.query([1.0, 0.0], k=1) == ["n1"]
+
+    ledger.close()
+    unregister_listener(listener)
+    container.stop()


### PR DESCRIPTION
## Summary
- add integration test for ingestion API and graph consumer
- ensure graph consumer thread terminates
- skip pipeline end-to-end test gracefully when Docker isn't available

## Testing
- `ruff check tests/integration/test_pipeline_end_to_end.py`
- `mypy --config-file mypy.ini --strict tests/integration/test_pipeline_end_to_end.py`
- `UME_DOCKER_TESTS=1 pytest tests/integration/test_pipeline_end_to_end.py -q`
- `pytest tests/integration/test_pipeline_end_to_end.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68881c63226c8326b7c9674428e6c278