### PR TITLE
Update docs for ingestion API and projection engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The primary motivation behind UME is to equip AI agents with a form of persisten
 
 ## Core Modules
 The engine is built from a few key components:
+- **Ingestion API** (`src/ume/ingestion_api.py`)
+  - Validates incoming events and publishes them to Kafka (`ume-raw-events`).
 - **Privacy Agent** (`src/ume/pipeline/privacy_agent.py`)
   - Redacts personally identifiable information (PII) from incoming events using Presidio.
   - Forwards sanitized events to downstream Kafka topics.
@@ -24,10 +26,12 @@ The engine is built from a few key components:
     environment settings. The backend is selected via `UME_VECTOR_BACKEND`.
 - **CLI** (`ume_cli.py`)
   - Command-line utility for producing events, inspecting the graph, and running maintenance tasks.
+- **Projection Engine** (`src/ume/consumer_demo.py`)
+  - Consumes sanitized events from Kafka and applies them to the graph via the configured adapter.
 
 ### Event Flow
 ```
-Producer --> ume-raw-events --> Privacy Agent --> ume-clean-events --> Graph Consumer --> Graph Adapter --> Storage (SQLite/Neo4j)
+Ingestion API --> ume-raw-events --> Privacy Agent --> ume-clean-events --> Projection Engine --> Graph Adapter --> Storage (SQLite/Neo4j)
 ```
 
 ## Project Setup

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -14,6 +14,13 @@ mirror the `/snapshot/save` and `/snapshot/load` HTTP endpoints. Both accept a
 `SnapshotPath` message containing the target file path and return an empty
 response on success.
 
+## Ingestion API
+
+The standalone ingestion service listens on port `8001` and publishes raw events to Kafka.
+
+### POST `/events` (ingestion)
+Validate the request body and forward the event to the `ume-raw-events` topic.
+
 ## Endpoints
 
 ### GET `/query`
@@ -158,6 +165,18 @@ curl -X POST http://localhost:8000/events/batch \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d '[{"event_type":"CREATE_NODE","timestamp":1,"node_id":"n1","payload":{"node_id":"n1"}}]'
+```
+
+### POST `/graphql`
+Execute a GraphQL query against the graph.
+
+Example request:
+
+```bash
+curl -X POST http://localhost:8000/graphql \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ node(id: \"n1\") { id } }"}'
 ```
 
 ### GET `/recall`

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -4,19 +4,19 @@ This diagram illustrates how events flow through UME and how graph data and vect
 
 ```mermaid
 graph TD
-    Producer(Event Producer) --> RawEvents[ume-raw-events]
+    Ingest(Ingestion API) --> RawEvents[ume-raw-events]
     RawEvents --> PrivacyAgent(Privacy Agent)
     PrivacyAgent --> CleanEvents[ume-clean-events]
-    CleanEvents --> GraphConsumer(Graph Consumer)
-    GraphConsumer --> Adapter(Graph Adapter)
+    CleanEvents --> Projection(Projection Engine)
+    Projection --> Adapter(Graph Adapter)
     Adapter --> GraphDB[(Graph Storage)]
     Adapter --> VectorStore[(Vector Store)]
 ```
 
-Events originate from producers and are first written to the `ume-raw-events` topic. The Privacy Agent sanitizes sensitive
-content before forwarding messages to `ume-clean-events`. A graph consumer processes these events through the configured
-Graph Adapter. The adapter persists the knowledge graph to the chosen backend (SQLite, Neo4j, etc.) and stores
-embeddings in a dedicated vector store.
+Events enter the system through the **Ingestion API**, which publishes them to the `ume-raw-events` Kafka topic. The
+Privacy Agent sanitizes sensitive content before forwarding messages to `ume-clean-events`. The **Projection Engine** then
+consumes these sanitized events and applies them via the configured Graph Adapter. The adapter persists the knowledge
+graph to the chosen backend (SQLite, Neo4j, etc.) and stores embeddings in a dedicated vector store.
 
 When querying, the API can perform a similarity search against the vector store to retrieve relevant nodes and
 then issue graph queries to traverse relationships.
@@ -33,10 +33,12 @@ queries. The diagram below highlights how these core modules connect.
 
 ```mermaid
 graph TD
-    PrivacyAgent(Privacy Agent) --> Adapter(Graph Adapter)
+    Ingest(Ingestion API) --> Kafka[(Kafka)]
+    Kafka --> Projection(Projection Engine)
+    Projection --> Adapter(Graph Adapter)
     Adapter --> GraphDB[(Graph Storage)]
     Adapter --> VectorStore[(Vector Store)]
-    API(FastAPI Service) --> Adapter
+    API(FastAPI & GraphQL) --> Adapter
     API --> VectorStore
 ```
 
@@ -79,11 +81,12 @@ flowchart LR
 
 ```mermaid
 graph TD
-    Producer(Event Producer) --> RawEvents[ume-raw-events]
+    Ingest(Ingestion API) --> RawEvents[ume-raw-events]
     RawEvents --> PrivacyAgent
     PrivacyAgent --> PolicyDSL[Policy DSL]
     PolicyDSL --> CleanEvents[ume-clean-events]
-    CleanEvents --> Adapter
+    CleanEvents --> Projection(Projection Engine)
+    Projection --> Adapter
     Adapter --> GraphDB[(Graph Storage)]
     Adapter --> VectorStore[(Vector Store)]
 ```
@@ -165,7 +168,7 @@ fetch('/graph/dump', { headers: { Authorization: 'Bearer TOKEN' } })
 
 ## GraphQL Endpoint
 
-UME exposes a GraphQL API at `/graphql`. Submit a `POST` request with a JSON body containing a `query` field. The request must include the usual bearer token.
+The main API exposes both REST and GraphQL interfaces. Submit GraphQL queries to `/graphql` with a JSON body containing a `query` field. The request must include the usual bearer token.
 
 Example request using `curl`:
 ```bash


### PR DESCRIPTION
## Summary
- document new ingestion API and projection engine
- illustrate ingestion API → Kafka → projection engine flow in architecture docs
- add GraphQL endpoint to API reference

## Testing
- `pre-commit` *skipped*: documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_688825f054f4832681b9b95e7c3bbdfb