### PR TITLE
Refactor pipeline to camelCase events

### DIFF
--- a/src/ume/ingestion_api.py
+++ b/src/ume/ingestion_api.py
@@ -11,7 +11,7 @@ from confluent_kafka import Producer, KafkaException
 from .config import settings
 from .schema_utils import validate_event_dict
 from .logging_utils import configure_logging
-from .utils import ssl_config
+from .utils import ssl_config, event_to_snake
 
 configure_logging()
 logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ async def post_event(request: Request) -> JSONResponse:
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON")
     try:
-        validate_event_dict(data)
+        validate_event_dict(event_to_snake(data))
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -9,7 +9,7 @@ from confluent_kafka import Consumer, KafkaException, KafkaError
 from jsonschema import ValidationError
 
 from ..config import settings
-from ..utils import ssl_config
+from ..utils import ssl_config, event_to_snake
 from ..event import parse_event, EventError
 from ..processing import apply_event_to_graph, ProcessingError
 from ..schema_utils import validate_event_dict
@@ -73,7 +73,8 @@ def run_graph_consumer(
                 continue
 
             try:
-                data = json.loads(msg.value().decode("utf-8"))
+                data_camel = json.loads(msg.value().decode("utf-8"))
+                data = event_to_snake(data_camel)
                 validate_event_dict(data)
                 payload = data["event"] if "event" in data else data
                 event = parse_event(payload)

--- a/src/ume/pipeline/privacy_agent.py
+++ b/src/ume/pipeline/privacy_agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any, Dict, Tuple, List, cast
-from ..utils import ssl_config
+from ..utils import ssl_config, event_to_snake, event_to_camel
 from ..logging_utils import configure_logging
 
 from confluent_kafka import Consumer, Producer, KafkaException, KafkaError
@@ -93,7 +93,8 @@ def run_privacy_agent() -> None:
 
             raw_bytes = msg.value()
             try:
-                data = json.loads(raw_bytes.decode("utf-8"))
+                data_camel = json.loads(raw_bytes.decode("utf-8"))
+                data = event_to_snake(data_camel)
                 validate_event_dict(data)
             except (json.JSONDecodeError, ValidationError) as exc:
                 logger.error("Invalid event received: %s", exc)
@@ -134,7 +135,7 @@ def run_privacy_agent() -> None:
                 try:
                     producer.produce(
                         QUARANTINE_TOPIC,
-                        value=json.dumps({"error": str(exc), "event": data}).encode(
+                        value=json.dumps({"error": str(exc), "event": event_to_camel(data)}).encode(
                             "utf-8"
                         ),
                     )
@@ -150,7 +151,7 @@ def run_privacy_agent() -> None:
             dest_topic = CLEAN_TOPIC if (has_consent or not (user_id and scope)) else QUARANTINE_TOPIC
 
             try:
-                producer.produce(dest_topic, value=json.dumps(data).encode("utf-8"))
+                producer.produce(dest_topic, value=json.dumps(event_to_camel(data)).encode("utf-8"))
                 pending += 1
                 try:
                     event_ledger.append(msg.offset(), data)

--- a/src/ume/utils.py
+++ b/src/ume/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Any, Dict
 import os
 
 
@@ -15,3 +15,40 @@ def ssl_config() -> Dict[str, str]:
             "ssl.key.location": key,
         }
     return {}
+
+
+# ----------------------------------------------------------------------------
+# Event field conversion helpers
+
+_CAMEL_TO_SNAKE = {
+    "eventId": "event_id",
+    "eventType": "event_type",
+    "nodeId": "node_id",
+    "targetNodeId": "target_node_id",
+    "schemaVersion": "schema_version",
+}
+
+_SNAKE_TO_CAMEL = {v: k for k, v in _CAMEL_TO_SNAKE.items()}
+
+
+def event_to_snake(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``data`` with camelCase fields converted to snake_case."""
+    out: Dict[str, Any] = {}
+    for key, value in data.items():
+        if key == "event" and isinstance(value, dict):
+            out[key] = event_to_snake(value)
+            continue
+        out[_CAMEL_TO_SNAKE.get(key, key)] = value
+    return out
+
+
+def event_to_camel(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``data`` with snake_case fields converted to camelCase."""
+    out: Dict[str, Any] = {}
+    for key, value in data.items():
+        if key == "event" and isinstance(value, dict):
+            out[key] = event_to_camel(value)
+            continue
+        out[_SNAKE_TO_CAMEL.get(key, key)] = value
+    return out
+

--- a/tests/test_graph_consumer.py
+++ b/tests/test_graph_consumer.py
@@ -52,22 +52,22 @@ def test_graph_consumer_applies_events(tmp_path, monkeypatch: pytest.MonkeyPatch
     ledger = EventLedger(str(tmp_path / "ledger.db"))
     events = [
         {
-            "event_type": "CREATE_NODE",
+            "eventType": "CREATE_NODE",
             "timestamp": 1,
-            "node_id": "n1",
+            "nodeId": "n1",
             "payload": {"node_id": "n1"},
         },
         {
-            "event_type": "CREATE_NODE",
+            "eventType": "CREATE_NODE",
             "timestamp": 1,
-            "node_id": "n2",
+            "nodeId": "n2",
             "payload": {"node_id": "n2"},
         },
         {
-            "event_type": "CREATE_EDGE",
+            "eventType": "CREATE_EDGE",
             "timestamp": 1,
-            "node_id": "n1",
-            "target_node_id": "n2",
+            "nodeId": "n1",
+            "targetNodeId": "n2",
             "label": "RELATES_TO",
             "payload": {},
         },

--- a/tests/test_ingestion_api.py
+++ b/tests/test_ingestion_api.py
@@ -32,7 +32,7 @@ def client(monkeypatch):
 
 def test_post_event_publishes_to_kafka(client):
     test_client, prod = client
-    event = {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}
+    event = {"eventType": "CREATE_NODE", "timestamp": 1, "nodeId": "n1", "payload": {}}
     res = test_client.post("/events", json=event)
     assert res.status_code == 202
     assert prod.produced == [
@@ -43,7 +43,7 @@ def test_post_event_publishes_to_kafka(client):
 
 def test_invalid_event_returns_400(client):
     test_client, prod = client
-    res = test_client.post("/events", json={"event_type": "CREATE_NODE"})
+    res = test_client.post("/events", json={"eventType": "CREATE_NODE"})
     assert res.status_code == 400
     assert prod.produced == []
 

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -93,9 +93,9 @@ class FakeProducer:
 def test_privacy_agent_end_to_end(privacy_agent, monkeypatch):
     payload = {"email": "user@example.com"}
     event = {
-        "event_type": "CREATE_NODE",
+        "eventType": "CREATE_NODE",
         "timestamp": 1,
-        "node_id": "n1",
+        "nodeId": "n1",
         "payload": payload,
     }
     msg = FakeMessage(json.dumps(event).encode("utf-8"))
@@ -134,9 +134,9 @@ def test_privacy_agent_end_to_end(privacy_agent, monkeypatch):
 def test_privacy_agent_periodic_flush(privacy_agent, monkeypatch):
     payload = {"email": "user@example.com"}
     event = {
-        "event_type": "CREATE_NODE",
+        "eventType": "CREATE_NODE",
         "timestamp": 1,
-        "node_id": "n1",
+        "nodeId": "n1",
         "payload": payload,
     }
     msgs = [FakeMessage(json.dumps(event).encode("utf-8")) for _ in range(3)]
@@ -174,9 +174,9 @@ def test_privacy_agent_audit_log_written(tmp_path, monkeypatch):
 
     payload = {"email": "user@example.com"}
     event = {
-        "event_type": "CREATE_NODE",
+        "eventType": "CREATE_NODE",
         "timestamp": 1,
-        "node_id": "n1",
+        "nodeId": "n1",
         "payload": payload,
     }
     msg = FakeMessage(json.dumps(event).encode("utf-8"))
@@ -235,9 +235,9 @@ def test_invalid_json_goes_to_quarantine(privacy_agent, monkeypatch):
 def test_policy_violation_goes_to_quarantine(privacy_agent, monkeypatch):
     payload = {"node_id": "n1"}
     event = {
-        "event_type": "CREATE_NODE",
+        "eventType": "CREATE_NODE",
         "timestamp": 1,
-        "node_id": "n1",
+        "nodeId": "n1",
         "payload": payload,
     }
     msg = FakeMessage(json.dumps(event).encode("utf-8"))
@@ -265,5 +265,5 @@ def test_policy_violation_goes_to_quarantine(privacy_agent, monkeypatch):
     assert len(quarantine) == 1
     data = json.loads(quarantine[0].decode("utf-8"))
     assert data["error"] == "denied"
-    assert data["event"]["node_id"] == "n1"
+    assert data["event"]["nodeId"] == "n1"
     assert not any(topic == privacy_agent.CLEAN_TOPIC for topic, _ in producer.produced)

--- a/tests/test_privacy_agent_additional.py
+++ b/tests/test_privacy_agent_additional.py
@@ -85,7 +85,7 @@ def test_invalid_json_skips_message(monkeypatch):
 
 
 def test_validation_error_skips_message(monkeypatch):
-    event = {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}
+    event = {"eventType": "CREATE_NODE", "timestamp": 1, "nodeId": "n1", "payload": {}}
     msg = type("Msg", (), {"error": lambda self: None, "value": lambda self: json.dumps(event).encode("utf-8")})()
     consumer = FakeConsumer([msg])
     producer = FakeProducer()

--- a/tests/test_privacy_agent_ledger.py
+++ b/tests/test_privacy_agent_ledger.py
@@ -61,9 +61,9 @@ class FakeProducer:
 
 def test_privacy_agent_writes_to_ledger_and_replay(tmp_path, monkeypatch):
     event = {
-        "event_type": "CREATE_NODE",
+        "eventType": "CREATE_NODE",
         "timestamp": 1,
-        "node_id": "n1",
+        "nodeId": "n1",
         "payload": {"node_id": "n1"},
     }
     msg = FakeMessage(json.dumps(event).encode("utf-8"), offset=5)

--- a/tests/test_privacy_agent_rego.py
+++ b/tests/test_privacy_agent_rego.py
@@ -57,9 +57,9 @@ class FakeProducer:
 
 def test_rego_policy_denies_event(monkeypatch):
     event = {
-        "event_type": "CREATE_NODE",
+        "eventType": "CREATE_NODE",
         "timestamp": 1,
-        "node_id": "forbidden",
+        "nodeId": "forbidden",
         "payload": {"node_id": "forbidden", "attributes": {}},
     }
     msg = FakeMessage(json.dumps(event).encode("utf-8"))
@@ -104,9 +104,9 @@ def _setup_agent(monkeypatch: pytest.MonkeyPatch, consumer: FakeConsumer, produc
 
 def test_event_without_consent_goes_to_quarantine(monkeypatch: pytest.MonkeyPatch) -> None:
     event = {
-        "event_type": "CREATE_NODE",
+        "eventType": "CREATE_NODE",
         "timestamp": 1,
-        "node_id": "n1",
+        "nodeId": "n1",
         "payload": {"node_id": "n1", "user_id": "u1", "scope": "profile", "attributes": {}},
     }
     msg = FakeMessage(json.dumps(event).encode("utf-8"))
@@ -125,9 +125,9 @@ def test_event_without_consent_goes_to_quarantine(monkeypatch: pytest.MonkeyPatc
 
 def test_event_with_consent_published(monkeypatch: pytest.MonkeyPatch) -> None:
     event = {
-        "event_type": "CREATE_NODE",
+        "eventType": "CREATE_NODE",
         "timestamp": 1,
-        "node_id": "n2",
+        "nodeId": "n2",
         "payload": {"node_id": "n2", "user_id": "u1", "scope": "profile", "attributes": {}},
     }
     msg = FakeMessage(json.dumps(event).encode("utf-8"))


### PR DESCRIPTION
## Summary
- convert event field names between snake_case and camelCase
- handle camelCase events in ingestion API
- update privacy agent and graph consumer to use camelCase over Kafka while retaining ledger format
- adjust unit tests for new field names

## Testing
- `ruff check src/ume/ingestion_api.py src/ume/pipeline/privacy_agent.py src/ume/pipeline/graph_consumer.py src/ume/utils.py tests/test_ingestion_api.py tests/test_privacy_agent.py tests/test_privacy_agent_additional.py tests/test_privacy_agent_ledger.py tests/test_privacy_agent_rego.py tests/test_graph_consumer.py`
- `pytest tests/test_ingestion_api.py tests/test_privacy_agent.py tests/test_privacy_agent_additional.py tests/test_privacy_agent_ledger.py tests/test_privacy_agent_rego.py tests/test_graph_consumer.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68882cfb32908326a276175394254d1f