### PR TITLE
Add node entity retrieval endpoint

### DIFF
--- a/src/ume/api_deps.py
+++ b/src/ume/api_deps.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import logging
 import time
 import threading
+import inspect
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Any
 
 from fastapi import Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer
@@ -119,4 +120,20 @@ def get_vector_store() -> VectorStore:
     if store is None:
         raise HTTPException(status_code=500, detail="Vector store not configured")
     return store
+
+
+async def get_entity(
+    type: str,
+    id: str,
+    graph: IGraphAdapter = Depends(get_graph),
+) -> Dict[str, Any]:
+    """Return attributes for node ``id`` if its ``type`` matches."""
+    func = getattr(graph, "get_node")
+    if inspect.iscoroutinefunction(func):
+        attrs = await func(id)  # type: ignore[misc]
+    else:
+        attrs = func(id)
+    if attrs is None or attrs.get("type") != type:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    return attrs
 

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -354,6 +354,15 @@ async def api_get_document(
     return {"id": document_id, "content": doc.get("content", "")}
 
 
+@router.get("/entities/{type}/{id}")
+async def api_get_entity(
+    id: str,
+    entity: Dict[str, Any] = Depends(deps.get_entity),
+) -> Dict[str, Any]:
+    """Return node ``id`` if its ``type`` matches the path parameter."""
+    return {"id": id, "attributes": entity}
+
+
 @router.post("/events")
 async def api_post_event(
     req: EventRequest,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -307,6 +307,23 @@ def test_dashboard_endpoints(monkeypatch: MonkeyPatch) -> None:
     assert isinstance(res_events.json(), list)
 
 
+def test_get_entity_endpoint() -> None:
+    g = MockGraph()
+    g.add_node("ent1", {"type": "T", "value": 1})
+    configure_graph(g)
+    client = TestClient(app)
+    token = _token(client)
+    res = client.get(
+        "/entities/T/ent1",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {
+        "id": "ent1",
+        "attributes": {"type": "T", "value": 1},
+    }
+
+
 @pytest.mark.parametrize(  # type: ignore[misc]
     "method,path,body,params",
     [
@@ -330,6 +347,7 @@ def test_dashboard_endpoints(monkeypatch: MonkeyPatch) -> None:
         ("get", "/metrics/summary", None, None),
         ("get", "/dashboard/stats", None, None),
         ("get", "/dashboard/recent_events", None, None),
+        ("get", "/entities/T/x", None, None),
         ("get", "/vectors/benchmark", None, None),
         ("get", "/recall", None, [("query", "test")]),
     ],


### PR DESCRIPTION
## Summary
- expose `/entities/{type}/{id}` route to fetch a node only if its `type` attribute matches
- implement `get_entity` dependency in `api_deps`
- test the endpoint and ensure it requires authentication

## Testing
- `ruff check .`
- `pytest tests/test_api.py::test_get_entity_endpoint tests/test_api.py::test_endpoints_require_authentication -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c021d7948326b17cb1464f289e1d