### PR TITLE
Add tokenization after redaction and embedding

### DIFF
--- a/src/ume/pipeline/privacy_agent.py
+++ b/src/ume/pipeline/privacy_agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any, Dict, Tuple, List, cast
-from ..utils import ssl_config, event_to_snake, event_to_camel
+from ..utils import ssl_config, event_to_snake, event_to_camel, tokenize
 from ..logging_utils import configure_logging
 
 from confluent_kafka import Consumer, Producer, KafkaException, KafkaError
@@ -146,6 +146,13 @@ def run_privacy_agent() -> None:
 
             original_payload = data.get("payload", {})
             redacted_payload, was_redacted = redact_event_payload(original_payload)
+            tokens: List[str] = []
+            for key in ("name", "text", "content"):
+                val = redacted_payload.get(key)
+                if isinstance(val, str):
+                    tokens.extend(tokenize(val))
+            if tokens:
+                redacted_payload["tokens"] = tokens
             data["payload"] = redacted_payload
 
             dest_topic = CLEAN_TOPIC if (has_consent or not (user_id and scope)) else QUARANTINE_TOPIC

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -5,6 +5,7 @@ from ._internal.listeners import get_registered_listeners
 from .plugins.alignment import get_plugins
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
 from .graph_schema import load_default_schema
+from .utils import tokenize
 
 DEFAULT_VERSION = load_default_schema().version
 
@@ -76,6 +77,14 @@ def apply_event_to_graph(
             schema = DEFAULT_SCHEMA_MANAGER.get_schema(schema_version)
             schema.validate_node_type(str(node_type))
 
+        tokens: list[str] = []
+        for key in ("name", "text", "content"):
+            val = attributes.get(key)
+            if isinstance(val, str):
+                tokens.extend(tokenize(val))
+        if tokens:
+            attributes["tokens"] = tokens
+
         graph.add_node(node_id, attributes)  # Call adapter's add_node
         for listener in get_registered_listeners():
             listener.on_node_created(node_id, attributes)
@@ -105,6 +114,14 @@ def apply_event_to_graph(
             raise ProcessingError(
                 f"'attributes' dictionary cannot be empty for UPDATE_NODE_ATTRIBUTES event: {event.event_id}"
             )
+
+        tokens = []
+        for key in ("name", "text", "content"):
+            val = attributes.get(key)
+            if isinstance(val, str):
+                tokens.extend(tokenize(val))
+        if tokens:
+            attributes["tokens"] = tokens
 
         graph.update_node(node_id, attributes)  # Call adapter's update_node
         for listener in get_registered_listeners():

--- a/src/ume/utils.py
+++ b/src/ume/utils.py
@@ -1,5 +1,6 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 import os
+import re
 
 
 def ssl_config() -> Dict[str, str]:
@@ -51,4 +52,12 @@ def event_to_camel(data: Dict[str, Any]) -> Dict[str, Any]:
             continue
         out[_SNAKE_TO_CAMEL.get(key, key)] = value
     return out
+
+
+_TOKEN_RE = re.compile(r"\b\w+\b")
+
+
+def tokenize(text: str) -> List[str]:
+    """Return a list of lowercase tokens from ``text``."""
+    return _TOKEN_RE.findall(text.lower())
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -30,7 +30,8 @@ def test_apply_create_node_event_success(graph: PersistentGraph):
     )
     apply_event_to_graph(event, graph)
     assert graph.node_exists(node_id)
-    assert graph.get_node(node_id) == attributes
+    stored = graph.get_node(node_id)
+    assert stored == {**attributes, "tokens": ["test", "node"]}
     assert graph.node_count == 1
 
 
@@ -104,6 +105,19 @@ def test_apply_update_node_attributes_success(graph: PersistentGraph):
     )
     apply_event_to_graph(event, graph)
     assert graph.get_node(node_id) == expected_final_attrs
+
+
+def test_update_node_adds_tokens(graph: PersistentGraph) -> None:
+    """Updating with text attributes should store tokens."""
+    node_id = "node_tokens"
+    graph.add_node(node_id, {})
+    event = Event(
+        event_type=EventType.UPDATE_NODE_ATTRIBUTES,
+        timestamp=int(time.time()),
+        payload={"node_id": node_id, "attributes": {"content": "Hello world"}},
+    )
+    apply_event_to_graph(event, graph)
+    assert graph.get_node(node_id) == {"content": "Hello world", "tokens": ["hello", "world"]}
 
 
 def test_apply_update_node_attributes_node_not_exists(graph: PersistentGraph):


### PR DESCRIPTION
## Summary
- tokenize text fields after redaction in `privacy_agent`
- add tokenization when applying node updates
- store token lists on nodes
- verify tokens in processing unit tests

## Testing
- `pre-commit run --files src/ume/pipeline/privacy_agent.py src/ume/processing.py src/ume/utils.py tests/test_processing.py`
- `pytest tests/test_processing.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d4ca589c832684016b6c35dcb70b