### PR TITLE
Add optional tokenization helper

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -6167,4 +6167,4 @@ vector = []
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "71f9e78505e2c122508779246f90491924ceb55c8f15c7e88bcb3300b37b3069"
+content-hash = "bd27b9a645b952971eaf1abcfaa8e2a8b4539d46224e1fdde14e5aac65d2c5c8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ types-pyyaml = {version = "^6.0.12.20250516", allow-prereleases = true}
 
 [tool.poetry.extras]
 vector = ["faiss-gpu"]
-embedding = ["sentence-transformers"]
+embedding = ["sentence-transformers", "tiktoken"]
 policy = ["regopy"]
 integrations = []
 grpc_server = ["grpcio"]

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -102,6 +102,7 @@ from .dossier.scheduler import (
     start_dossier_snapshot_scheduler,
     stop_dossier_snapshot_scheduler,
 )
+from .tokenization import tokenize
 
 # Import the API lazily via __getattr__ to avoid circular imports during
 # initialization. The ``api`` module will be loaded on first attribute access.
@@ -186,6 +187,7 @@ __all__ = [
     "ResourceScheduler",
     "ScheduledTask",
     "Dossier",
+    "tokenize",
 
 
 ]

--- a/src/ume/tokenization.py
+++ b/src/ume/tokenization.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    import tiktoken as _tiktoken
+else:  # pragma: no cover - optional dependency
+    try:
+        import tiktoken as _tiktoken
+    except ModuleNotFoundError:  # pragma: no cover - allow missing dep
+        _tiktoken = None  # type: ignore[assignment]
+
+
+def tokenize(text: str) -> list[str]:
+    """Return a list of tokens for ``text`` using ``tiktoken`` if available."""
+    if _tiktoken is None:
+        return text.split()
+    encoding = _tiktoken.get_encoding("cl100k_base")
+    token_ids = encoding.encode(text)
+    return [encoding.decode([tid]) for tid in token_ids]


### PR DESCRIPTION
## Summary
- implement `tokenize` helper leveraging optional tiktoken
- expose helper via `ume` package
- allow installing `tiktoken` with the `embedding` extra

## Testing
- `poetry run ruff check .`
- `poetry run mypy --no-warn-unused-ignores`
- `poetry run pytest tests/test_agent_orchestrator.py::test_envelope_wrapping -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d4c9a71c8326ba54d91d3cfcde8c