### PR TITLE
Add semantic search endpoint

### DIFF
--- a/src/ume/vector_routes.py
+++ b/src/ume/vector_routes.py
@@ -51,6 +51,31 @@ def api_search_vectors(
     return {"ids": ids}
 
 
+class SemanticSearchRequest(BaseModel):
+    query: str
+    k: int = 5
+
+
+@router.post("/search/semantic")
+def api_semantic_search(
+    req: SemanticSearchRequest,
+    _: str = Depends(deps.get_current_role),
+    store: VectorStore = Depends(deps.get_vector_store),
+    graph: IGraphAdapter = Depends(deps.get_graph),
+) -> Dict[str, Any]:
+    """Return attributes for the ``k`` nearest nodes to ``req.query``."""
+    vector = generate_embedding(req.query)
+    if len(vector) != store.dim:
+        raise HTTPException(status_code=400, detail="Invalid vector dimension")
+    ids = store.query(vector, k=req.k)
+    nodes = []
+    for node_id in ids:
+        attrs = graph.get_node(node_id)
+        if attrs is not None:
+            nodes.append({"id": node_id, "attributes": attrs})
+    return {"nodes": nodes}
+
+
 @router.get("/recall")
 def api_recall(
     query: str | None = Query(None),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -307,6 +307,53 @@ def test_dashboard_endpoints(monkeypatch: MonkeyPatch) -> None:
     assert isinstance(res_events.json(), list)
 
 
+def test_semantic_search(monkeypatch: MonkeyPatch) -> None:
+    import numpy as np
+    import sys
+
+    sys.modules["numpy"] = np
+    monkeypatch.setattr(settings, "UME_LEDGER_COMPACTION_INTERVAL", 0.01, raising=False)
+    monkeypatch.setattr("ume.embedding.generate_embedding", lambda _: [1.0, 0.0])
+    configure_vector_store(VectorStore(dim=2, use_gpu=False))
+    g = MockGraph()
+    g.add_node("a", {"val": 1})
+    g.add_node("b", {"val": 2})
+    configure_graph(g)
+    store = app.state.vector_store
+    store.add("a", [1.0, 0.0])
+    store.add("b", [0.0, 1.0])
+    with TestClient(app) as client:
+        token = _token(client)
+        res = client.post(
+            "/search/semantic",
+            json={"query": "foo", "k": 1},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert res.status_code == 200
+    assert res.json() == {"nodes": [{"id": "a", "attributes": {"val": 1}}]}
+
+
+def test_semantic_search_invalid_dimension(monkeypatch: MonkeyPatch) -> None:
+    import numpy as np
+    import sys
+
+    sys.modules["numpy"] = np
+    monkeypatch.setattr(settings, "UME_LEDGER_COMPACTION_INTERVAL", 0.01, raising=False)
+    monkeypatch.setattr("ume.embedding.generate_embedding", lambda _: [0.0, 1.0])
+    configure_vector_store(VectorStore(dim=2, use_gpu=False))
+    configure_graph(MockGraph())
+    app.state.vector_store.dim = 3
+    with TestClient(app) as client:
+        token = _token(client)
+        res = client.post(
+            "/search/semantic",
+            json={"query": "foo", "k": 1},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert res.status_code == 400
+    assert res.json()["detail"] == "Invalid vector dimension"
+
+
 @pytest.mark.parametrize(  # type: ignore[misc]
     "method,path,body,params",
     [
@@ -326,6 +373,7 @@ def test_dashboard_endpoints(monkeypatch: MonkeyPatch) -> None:
             None,
             [("vector", 0.0), ("vector", 0.0)],
         ),
+        ("post", "/search/semantic", {"query": "x", "k": 1}, None),
         ("get", "/metrics", None, None),
         ("get", "/metrics/summary", None, None),
         ("get", "/dashboard/stats", None, None),


### PR DESCRIPTION
## Summary
- implement `/search/semantic` route for vector queries
- test semantic search success and dimension error
- enforce auth for new endpoint
- fix invalid dimension test setup

## Testing
- `ruff check src/ume/vector_routes.py tests/test_api.py`
- `mypy --config-file mypy.ini src/ume/vector_routes.py tests/test_api.py`
- `pytest -q tests/test_api.py::test_semantic_search tests/test_api.py::test_semantic_search_invalid_dimension`

------
https://chatgpt.com/codex/tasks/task_e_6888c0226270832694c2012b6556ed98