### PR TITLE
Allow custom event types

### DIFF
--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -216,6 +216,26 @@ def parse_event(data: Dict[str, Any]) -> Event:
             logger.error(msg)
             raise EventError(msg)
 
+    else:
+        # Unknown event types: validate optional fields if provided
+        if "payload" in data and not isinstance(payload_val, dict):
+            msg = (
+                f"Invalid type for 'payload': expected dict, got {type(payload_val).__name__}"
+            )
+            logger.error(msg)
+            raise EventError(msg)
+        for optional_name, optional_value in [
+            ("node_id", node_id_val),
+            ("target_node_id", target_node_id_val),
+            ("label", label_val),
+        ]:
+            if optional_value is not None and not isinstance(optional_value, str):
+                msg = (
+                    f"Invalid type for '{optional_name}': expected str, got {type(optional_value).__name__}"
+                )
+                logger.error(msg)
+                raise EventError(msg)
+
     return Event(
         event_id=event_id_val if event_id_val is not None else str(uuid.uuid4()),
         event_type=event_type,

--- a/src/ume/schemas/create_edge.schema.json
+++ b/src/ume/schemas/create_edge.schema.json
@@ -7,8 +7,8 @@
   "required": ["eventType", "timestamp", "node_id", "target_node_id", "label"],
   "properties": {
     "eventType": {
-      "const": "CREATE_EDGE",
-      "description": "Must be the literal string 'CREATE_EDGE'"
+      "type": "string",
+      "description": "Type of event"
     },
     "timestamp": {
       "type": "integer",

--- a/src/ume/schemas/create_node.schema.json
+++ b/src/ume/schemas/create_node.schema.json
@@ -7,8 +7,8 @@
   "required": ["eventType", "timestamp", "node_id", "payload"],
   "properties": {
     "eventType": {
-      "const": "CREATE_NODE",
-      "description": "Must be the literal string 'CREATE_NODE'"
+      "type": "string",
+      "description": "Type of event"
     },
     "timestamp": {
       "type": "integer",

--- a/src/ume/schemas/delete_edge.schema.json
+++ b/src/ume/schemas/delete_edge.schema.json
@@ -7,8 +7,8 @@
   "required": ["eventType", "timestamp", "node_id", "target_node_id", "label"],
   "properties": {
     "eventType": {
-      "const": "DELETE_EDGE",
-      "description": "Must be the literal string 'DELETE_EDGE'"
+      "type": "string",
+      "description": "Type of event"
     },
     "timestamp": {
       "type": "integer",

--- a/src/ume/schemas/update_node_attributes.schema.json
+++ b/src/ume/schemas/update_node_attributes.schema.json
@@ -7,8 +7,8 @@
   "required": ["eventType", "timestamp", "node_id", "payload"],
   "properties": {
     "eventType": {
-      "const": "UPDATE_NODE_ATTRIBUTES",
-      "description": "Must be the literal string 'UPDATE_NODE_ATTRIBUTES'"
+      "type": "string",
+      "description": "Type of event"
     },
     "timestamp": {
       "type": "integer",

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -48,6 +48,19 @@ def test_parse_event_minimal_valid():
     assert event.source_service is None
 
 
+def test_parse_event_custom_type():
+    """Ensure custom event types parse without strict checks."""
+    timestamp_now = int(time.time())
+    data = {
+        "eventType": "document.artifact.archived",
+        "timestamp": timestamp_now,
+        "payload": {"archive": True},
+    }
+    event = parse_event(data)
+    assert event.event_type == "document.artifact.archived"
+    assert event.payload == {"archive": True}
+
+
 @pytest.mark.parametrize(
     "event_type, extra_data",
     [


### PR DESCRIPTION
## Summary
- relax `eventType` restrictions in JSON schemas
- handle unknown `eventType` values in `parse_event`
- add test for custom event types

## Testing
- `ruff check .`
- `mypy`
- `pytest tests/test_event.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6888e24af864832682b8085013ef670e