### PR TITLE
Handle generic events without graph updates

### DIFF
--- a/src/ume/ingestion_api.py
+++ b/src/ume/ingestion_api.py
@@ -27,14 +27,14 @@ app = FastAPI(
 )
 
 
-@app.on_event("startup")  # type: ignore[misc]
+@app.on_event("startup")
 def _init_producer() -> None:
     """Initialize the Kafka producer."""
     global producer
     producer = Producer(producer_conf)
 
 
-@app.post("/events", status_code=202)  # type: ignore[misc]
+@app.post("/events", status_code=202)
 async def post_event(request: Request) -> JSONResponse:
     """Validate the request body and publish it to Kafka."""
     try:
@@ -61,7 +61,7 @@ async def post_event(request: Request) -> JSONResponse:
     return JSONResponse(status_code=202, content={"status": "accepted"})
 
 
-@app.on_event("shutdown")  # type: ignore[misc]
+@app.on_event("shutdown")
 def _close_producer() -> None:
     if producer is None:
         return

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -9,8 +9,8 @@ from confluent_kafka import Consumer, KafkaException, KafkaError
 from jsonschema import ValidationError
 
 from ..config import settings
-from ..utils import ssl_config, event_to_snake
-from ..event import parse_event, EventError
+from ..utils import ssl_config, event_to_snake, event_to_camel
+from ..event import parse_event, EventError, EventType
 from ..processing import apply_event_to_graph, ProcessingError
 from ..schema_utils import validate_event_dict
 from ..event_ledger import event_ledger
@@ -75,12 +75,31 @@ def run_graph_consumer(
             try:
                 data_camel = json.loads(msg.value().decode("utf-8"))
                 data = event_to_snake(data_camel)
-                validate_event_dict(data)
                 payload = data["event"] if "event" in data else data
-                event = parse_event(payload)
-            except (json.JSONDecodeError, ValidationError, EventError) as exc:
+                payload_camel = event_to_camel(payload)
+                event = parse_event(payload_camel)
+            except (json.JSONDecodeError, EventError) as exc:
                 logger.error("Invalid event skipped: %s", exc)
                 continue
+
+            if event.event_type not in {e.value for e in EventType}:
+                try:
+                    event_ledger.append(msg.offset(), payload_camel)
+                except ValueError as exc:  # pragma: no cover - unlikely duplicate offset
+                    logger.error("Ledger append failed: %s", exc)
+                try:
+                    event_ledger.update_bookmark(msg.offset())
+                except Exception as exc:  # pragma: no cover - unexpected errors
+                    logger.error("Failed to update bookmark: %s", exc)
+                logger.warning("Unknown event type '%s' skipped", event.event_type)
+                continue
+
+            try:
+                validate_event_dict(data)
+            except ValidationError as exc:
+                logger.error("Invalid event skipped: %s", exc)
+                continue
+
             try:
                 apply_event_to_graph(event, graph)
             except ProcessingError as exc:

--- a/tests/integration/test_pipeline_end_to_end.py
+++ b/tests/integration/test_pipeline_end_to_end.py
@@ -1,5 +1,6 @@
 import os
 import threading
+import json
 
 import pytest
 from fastapi.testclient import TestClient
@@ -43,6 +44,40 @@ class LimitingConsumer(KafkaConsumer):
         if msg is not None and not msg.error():
             self.count += 1
         return msg
+
+
+class DummyMessage:
+    def __init__(self, value: bytes, offset: int) -> None:
+        self._value = value
+        self._offset = offset
+
+    def value(self) -> bytes:  # pragma: no cover - simple accessor
+        return self._value
+
+    def error(self):  # pragma: no cover - simple accessor
+        return None
+
+    def offset(self) -> int:  # pragma: no cover - simple accessor
+        return self._offset
+
+
+class DummyConsumer:
+    def __init__(self, messages: list[DummyMessage]) -> None:
+        self.messages = messages
+        self.index = 0
+
+    def subscribe(self, topics):  # pragma: no cover - simple stub
+        self.topics = topics
+
+    def poll(self, timeout: float = 1.0):
+        if self.index >= len(self.messages):
+            raise KeyboardInterrupt
+        msg = self.messages[self.index]
+        self.index += 1
+        return msg
+
+    def close(self) -> None:  # pragma: no cover - simple stub
+        pass
 
 
 @pytest.mark.integration
@@ -118,3 +153,25 @@ def test_pipeline_end_to_end(tmp_path, monkeypatch):
     ledger.close()
     unregister_listener(listener)
     container.stop()
+
+
+def test_generic_events_go_to_ledger(tmp_path, monkeypatch, caplog):
+    msg_data = {"eventType": "CUSTOM", "timestamp": 1, "payload": {"foo": "bar"}}
+    msg = DummyMessage(json.dumps(msg_data).encode("utf-8"), 0)
+    consumer = DummyConsumer([msg])
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+
+    monkeypatch.setattr(graph_consumer, "Consumer", lambda conf: consumer)
+    monkeypatch.setattr(graph_consumer, "ssl_config", lambda: {})
+    monkeypatch.setattr(graph_consumer, "event_ledger", ledger)
+
+    graph = MockGraph()
+    with caplog.at_level("WARNING"):
+        graph_consumer.run_graph_consumer(graph, group_id="g")
+
+    assert ledger.range() == [
+        (0, {"eventType": "CUSTOM", "timestamp": 1, "payload": {"foo": "bar"}})
+    ]
+    assert ledger.last_processed_offset == 0
+    assert not graph.get_all_node_ids()
+    assert any("Unknown event type" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- handle unknown events without updating the graph
- keep raw events in the ledger for unrecognized types
- remove unnecessary type ignores in `ingestion_api`
- store generic events with camelCase keys

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini src/ume/pipeline/graph_consumer.py`
- `pytest tests/integration/test_pipeline_end_to_end.py::test_generic_events_go_to_ledger -q`


------
https://chatgpt.com/codex/tasks/task_e_6888e24b72208326ab1b39ef6f74ff22