### PR TITLE
Add entity retrieval endpoint tests

### DIFF
--- a/src/ume/api_deps.py
+++ b/src/ume/api_deps.py
@@ -15,6 +15,7 @@ from fastapi.security import OAuth2PasswordBearer
 from .config import settings
 from .rbac_adapter import RoleBasedGraphAdapter
 from .graph_adapter import IGraphAdapter
+from .async_graph_adapter import IAsyncGraphAdapter
 from .query import Neo4jQueryEngine
 from . import VectorStore
 
@@ -129,7 +130,7 @@ async def get_entity(
 ) -> Dict[str, Any]:
     """Return attributes for node ``id`` if its ``type`` matches."""
     func = getattr(graph, "get_node")
-    if inspect.iscoroutinefunction(func):
+    if inspect.iscoroutinefunction(func) or isinstance(graph, IAsyncGraphAdapter):
         attrs = await func(id)  # type: ignore[misc]
     else:
         attrs = func(id)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -353,6 +353,36 @@ def test_semantic_search_invalid_dimension(monkeypatch: MonkeyPatch) -> None:
     assert res.json()["detail"] == "Invalid vector dimension"
 
 
+def test_get_entity_endpoint() -> None:
+    g = MockGraph()
+    g.add_node("ent1", {"type": "T", "value": 1})
+    configure_graph(g)
+    client = TestClient(app)
+    token = _token(client)
+    res = client.get(
+        "/entities/T/ent1",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {
+        "id": "ent1",
+        "attributes": {"type": "T", "value": 1},
+    }
+
+
+def test_get_entity_endpoint_not_found() -> None:
+    g = MockGraph()
+    g.add_node("ent2", {"type": "T"})
+    configure_graph(g)
+    client = TestClient(app)
+    token = _token(client)
+    res = client.get(
+        "/entities/X/ent2",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 404
+
+
 
 @pytest.mark.parametrize(  # type: ignore[misc]
     "method,path,body,params",


### PR DESCRIPTION
## Summary
- update dependency for entity retrieval
- add tests covering `/entities/{type}/{id}`

## Testing
- `ruff check src/ume/api_deps.py tests/test_api.py`
- `mypy --config-file mypy.ini --strict src/ume/api_deps.py tests/test_api.py`
- `pytest tests/test_api.py::test_get_entity_endpoint tests/test_api.py::test_get_entity_endpoint_not_found -q`


------
https://chatgpt.com/codex/tasks/task_e_6889244112188326ba8fdcf49fc3fa8f