### PR TITLE
Implement semantic search validation

### DIFF
--- a/src/ume/vector_routes.py
+++ b/src/ume/vector_routes.py
@@ -67,6 +67,8 @@ def api_semantic_search(
     vector = generate_embedding(req.query)
     if len(vector) != store.dim:
         raise HTTPException(status_code=400, detail="Invalid vector dimension")
+    if req.k <= 0:
+        raise HTTPException(status_code=400, detail="k must be positive")
     ids = store.query(vector, k=req.k)
     nodes = []
     for node_id in ids:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -353,6 +353,28 @@ def test_semantic_search_invalid_dimension(monkeypatch: MonkeyPatch) -> None:
     assert res.json()["detail"] == "Invalid vector dimension"
 
 
+def test_semantic_search_invalid_k(monkeypatch: MonkeyPatch) -> None:
+    import numpy as np
+    import sys
+
+    sys.modules["numpy"] = np
+    monkeypatch.setattr(settings, "UME_LEDGER_COMPACTION_INTERVAL", 0.01, raising=False)
+    monkeypatch.setattr("ume.embedding.generate_embedding", lambda _: [1.0, 0.0])
+    configure_vector_store(VectorStore(dim=2, use_gpu=False))
+    configure_graph(MockGraph())
+    store = app.state.vector_store
+    store.add("a", [1.0, 0.0])
+    with TestClient(app) as client:
+        token = _token(client)
+        res = client.post(
+            "/search/semantic",
+            json={"query": "foo", "k": 0},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert res.status_code == 400
+    assert res.json()["detail"] == "k must be positive"
+
+
 
 @pytest.mark.parametrize(  # type: ignore[misc]
     "method,path,body,params",


### PR DESCRIPTION
## Summary
- validate `k` parameter in `api_semantic_search`
- test error handling for invalid `k`

## Testing
- `pytest tests/test_api.py::test_semantic_search tests/test_api.py::test_semantic_search_invalid_dimension tests/test_api.py::test_semantic_search_invalid_k -q`
- `pre-commit run --files src/ume/vector_routes.py tests/test_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68892441d92483269fb1445b8cf57d26