### PR TITLE
Allow arbitrary event types

### DIFF
--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -93,11 +93,17 @@ def parse_event(data: Dict[str, Any]) -> Event:
     if "eventType" not in data:
         logger.error("Missing required event field: eventType")
         raise EventError("Missing required event field: eventType")
-    event_type = data["eventType"]
-    if not isinstance(event_type, str):
-        msg = f"Invalid type for 'eventType': expected str, got {type(event_type).__name__}"
+    event_type_raw = data["eventType"]
+    if not isinstance(event_type_raw, str):
+        msg = f"Invalid type for 'eventType': expected str, got {type(event_type_raw).__name__}"
         logger.error(msg)
         raise EventError(msg)
+    # Map to the known EventType enum when possible but allow arbitrary strings
+    event_type: EventType | str
+    try:
+        event_type = EventType(event_type_raw)
+    except ValueError:
+        event_type = event_type_raw
 
     if "timestamp" not in data:
         logger.error("Missing required event field: timestamp")
@@ -161,8 +167,8 @@ def parse_event(data: Dict[str, Any]) -> Event:
         raise EventError(msg)
 
     if event_type in [
-        EventType.CREATE_NODE.value,
-        EventType.UPDATE_NODE_ATTRIBUTES.value,
+        EventType.CREATE_NODE,
+        EventType.UPDATE_NODE_ATTRIBUTES,
     ]:
         if "node_id" not in data:  # Must be present in data
             msg = f"Missing required field 'node_id' for {event_type} event."
@@ -185,9 +191,9 @@ def parse_event(data: Dict[str, Any]) -> Event:
             raise EventError(msg)
 
     elif event_type in [
-        EventType.CREATE_EDGE.value,
-        EventType.DELETE_EDGE.value,
-        EventType.CREATE_ONTOLOGY_RELATION.value,
+        EventType.CREATE_EDGE,
+        EventType.DELETE_EDGE,
+        EventType.CREATE_ONTOLOGY_RELATION,
     ]:
         required_fields_for_edge = {"node_id", "target_node_id", "label"}
         missing_fields = required_fields_for_edge - data.keys()

--- a/src/ume/schemas/create_edge.schema.json
+++ b/src/ume/schemas/create_edge.schema.json
@@ -8,6 +8,7 @@
   "properties": {
     "eventType": {
       "type": "string",
+      "minLength": 1,
       "description": "Type of event"
     },
     "timestamp": {

--- a/src/ume/schemas/create_node.schema.json
+++ b/src/ume/schemas/create_node.schema.json
@@ -8,6 +8,7 @@
   "properties": {
     "eventType": {
       "type": "string",
+      "minLength": 1,
       "description": "Type of event"
     },
     "timestamp": {

--- a/src/ume/schemas/delete_edge.schema.json
+++ b/src/ume/schemas/delete_edge.schema.json
@@ -8,6 +8,7 @@
   "properties": {
     "eventType": {
       "type": "string",
+      "minLength": 1,
       "description": "Type of event"
     },
     "timestamp": {

--- a/src/ume/schemas/update_node_attributes.schema.json
+++ b/src/ume/schemas/update_node_attributes.schema.json
@@ -8,6 +8,7 @@
   "properties": {
     "eventType": {
       "type": "string",
+      "minLength": 1,
       "description": "Type of event"
     },
     "timestamp": {

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -61,6 +61,16 @@ def test_parse_event_custom_type():
     assert event.payload == {"archive": True}
 
 
+def test_parse_event_custom_type_minimal():
+    """Unknown event types should parse with minimal required fields."""
+    ts = int(time.time())
+    data = {"eventType": "document.artifact.archived", "timestamp": ts}
+    event = parse_event(data)
+    assert event.event_type == "document.artifact.archived"
+    assert event.timestamp == ts
+    assert event.payload == {}
+
+
 @pytest.mark.parametrize(
     "event_type, extra_data",
     [


### PR DESCRIPTION
## Summary
- allow unknown event types to be parsed by mapping to enum when possible
- update JSON schemas to accept any string for eventType
- test parsing unknown event types without payload

## Testing
- `pre-commit run --files src/ume/event.py tests/test_event.py src/ume/schemas/create_node.schema.json src/ume/schemas/update_node_attributes.schema.json src/ume/schemas/create_edge.schema.json src/ume/schemas/delete_edge.schema.json`
- `pytest tests/test_event.py::test_parse_event_custom_type tests/test_event.py::test_parse_event_custom_type_minimal -q`

------
https://chatgpt.com/codex/tasks/task_e_68893ae0cd1883269334a5b58a9a6ab3