### PR TITLE
Handle generic events in pipeline graph consumer

### DIFF
--- a/src/ume/ingestion_api.py
+++ b/src/ume/ingestion_api.py
@@ -27,14 +27,14 @@ app = FastAPI(
 )
 
 
-@app.on_event("startup")
+@app.on_event("startup")  # type: ignore[misc]
 def _init_producer() -> None:
     """Initialize the Kafka producer."""
     global producer
     producer = Producer(producer_conf)
 
 
-@app.post("/events", status_code=202)
+@app.post("/events", status_code=202)  # type: ignore[misc]
 async def post_event(request: Request) -> JSONResponse:
     """Validate the request body and publish it to Kafka."""
     try:
@@ -61,7 +61,7 @@ async def post_event(request: Request) -> JSONResponse:
     return JSONResponse(status_code=202, content={"status": "accepted"})
 
 
-@app.on_event("shutdown")
+@app.on_event("shutdown")  # type: ignore[misc]
 def _close_producer() -> None:
     if producer is None:
         return

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -25,6 +25,7 @@ BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
 NODE_TOPIC = settings.KAFKA_NODE_TOPIC
 EDGE_TOPIC = settings.KAFKA_EDGE_TOPIC
 DEFAULT_GROUP_ID = settings.KAFKA_GROUP_ID
+VALID_EVENT_TYPES = {e.value for e in EventType}
 
 
 def run_graph_consumer(
@@ -82,7 +83,7 @@ def run_graph_consumer(
                 logger.error("Invalid event skipped: %s", exc)
                 continue
 
-            if event.event_type not in {e.value for e in EventType}:
+            if event.event_type not in VALID_EVENT_TYPES:
                 try:
                     event_ledger.append(msg.offset(), payload_camel)
                 except ValueError as exc:  # pragma: no cover - unlikely duplicate offset

--- a/tests/integration/test_pipeline_end_to_end.py
+++ b/tests/integration/test_pipeline_end_to_end.py
@@ -175,3 +175,28 @@ def test_generic_events_go_to_ledger(tmp_path, monkeypatch, caplog):
     assert ledger.last_processed_offset == 0
     assert not graph.get_all_node_ids()
     assert any("Unknown event type" in rec.message for rec in caplog.records)
+
+
+def test_generic_enveloped_events_go_to_ledger(tmp_path, monkeypatch, caplog):
+    envelope = {
+        "schema_version": "1.0.0",
+        "event": {"eventType": "CUSTOM", "timestamp": 1, "payload": {"foo": "bar"}},
+    }
+    msg = DummyMessage(json.dumps(envelope).encode("utf-8"), 0)
+    consumer = DummyConsumer([msg])
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+
+    monkeypatch.setattr(graph_consumer, "Consumer", lambda conf: consumer)
+    monkeypatch.setattr(graph_consumer, "ssl_config", lambda: {})
+    monkeypatch.setattr(graph_consumer, "event_ledger", ledger)
+
+    graph = MockGraph()
+    with caplog.at_level("WARNING"):
+        graph_consumer.run_graph_consumer(graph, group_id="g")
+
+    assert ledger.range() == [
+        (0, {"eventType": "CUSTOM", "timestamp": 1, "payload": {"foo": "bar"}})
+    ]
+    assert ledger.last_processed_offset == 0
+    assert not graph.get_all_node_ids()
+    assert any("Unknown event type" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- store known event types in constant
- skip graph updates for unknown events with new constant
- support typed FastAPI events with type ignore
- test ledger storage for enveloped generic events

## Testing
- `pre-commit run --files src/ume/pipeline/graph_consumer.py tests/integration/test_pipeline_end_to_end.py src/ume/ingestion_api.py`
- `pytest tests/integration/test_pipeline_end_to_end.py::test_generic_events_go_to_ledger tests/integration/test_pipeline_end_to_end.py::test_generic_enveloped_events_go_to_ledger -vv`

------
https://chatgpt.com/codex/tasks/task_e_68893ae153708326b5683760dfe20d27