### PR TITLE
Update docs with tokenization and flexible event types

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -83,7 +83,8 @@ flowchart LR
 graph TD
     Ingest(Ingestion API) --> RawEvents[ume-raw-events]
     RawEvents --> PrivacyAgent
-    PrivacyAgent --> PolicyDSL[Policy DSL]
+    PrivacyAgent --> Tokenize[Tokenize Text]
+    Tokenize --> PolicyDSL[Policy DSL]
     PolicyDSL --> CleanEvents[ume-clean-events]
     CleanEvents --> Projection(Projection Engine)
     Projection --> Adapter
@@ -91,9 +92,11 @@ graph TD
     Adapter --> VectorStore[(Vector Store)]
 ```
 
-Incoming events are streamed through Redpanda topics. The Privacy Agent applies
-rules defined in the Policy DSL before forwarding sanitized events to the graph
-adapter layer.
+Incoming events are streamed through Redpanda topics. The Privacy Agent first
+redacts sensitive content and tokenizes any `name`, `text`, or `content`
+fields. These tokens are stored in the payload so downstream processors can
+generate embeddings. After tokenization the Policy DSL is evaluated and the
+resulting sanitized events are forwarded to the graph adapter layer.
 
 ## Event Ledger
 
@@ -105,6 +108,12 @@ On startup the API launches a scheduler that periodically calls
 `UME_LEDGER_OFFSET_WINDOW` offsets from the latest processed bookmark. The
 interval between compaction runs is configurable via
 `UME_LEDGER_COMPACTION_INTERVAL`.
+
+Each ledger entry preserves the original `eventType` string. The event parser
+maps known constants to the :class:`~ume.event.EventType` enum but allows
+arbitrary values to pass through unchanged. This flexibility lets producers
+introduce new event categories without requiring a code update. Custom types are
+stored and replayed like built-in events.
 
 ## Policy DSL Flow
 

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -55,6 +55,19 @@ Each edge is directed and labeled and may carry optional properties in the
 future.  At minimum an edge stores the source node ID, target node ID and
 its label.
 
+## Event Sourcing
+
+Events entering the system contain an `eventType` string describing the
+operation (for example `CREATE_NODE` or `DELETE_EDGE`). The parser attempts to
+map this value to the :class:`~ume.event.EventType` enumeration but preserves the
+original text when the value is unknown. This allows custom event categories to
+flow through the pipeline and be stored in the ledger without schema changes.
+
+During sanitization the Privacy Agent tokenizes common text fields such as
+`name`, `text` and `content`. The resulting list of tokens is attached to the
+event payload under the `tokens` key so that downstream components can create
+vector embeddings consistently.
+
 ## Versioning
 
 The schema is expected to evolve.  Node and edge type definitions should be


### PR DESCRIPTION
## Summary
- mention tokenization step in streaming pipeline
- describe flexible `eventType` values in the event ledger
- document event sourcing details and tokenization in the graph model

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68895d5c28a48326afdcecd9c5d34bc0