### PR TITLE
Add tokenization step after redaction

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -102,6 +102,7 @@ app.add_route(
         on_get=make_graphiql_handler(),
         context_value=lambda request: {"app": app},
     ),
+    methods=["GET", "POST"],
 )
 
 

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -90,10 +90,13 @@ def parse_event(data: Dict[str, Any]) -> Event:
     logger.debug("Parsing event data: %s", data)
 
     # Basic presence and type checks for common fields
-    if "eventType" not in data:
+    if "eventType" in data:
+        event_type = data["eventType"]
+    elif "event_type" in data:
+        event_type = data["event_type"]
+    else:
         logger.error("Missing required event field: eventType")
         raise EventError("Missing required event field: eventType")
-    event_type = data["eventType"]
     if not isinstance(event_type, str):
         msg = f"Invalid type for 'eventType': expected str, got {type(event_type).__name__}"
         logger.error(msg)

--- a/src/ume/integrations/base.py
+++ b/src/ume/integrations/base.py
@@ -6,6 +6,17 @@ from types import TracebackType
 
 import httpx
 import json
+from ..utils import event_to_camel
+
+
+def _camel_event(e: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert ``event_type`` to ``eventType`` while keeping other keys snake_case."""
+    data = event_to_camel(dict(e))
+    if "nodeId" in data:
+        data["node_id"] = data.pop("nodeId")
+    if "targetNodeId" in data:
+        data["target_node_id"] = data.pop("targetNodeId")
+    return data
 
 
 class IntegrationError(Exception):
@@ -25,7 +36,7 @@ class BaseClient:
 
     def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
         headers = self._auth_headers()
-        events_list = list(events)
+        events_list = [_camel_event(e) for e in events]
         if not events_list:
             return
         try:
@@ -44,7 +55,7 @@ class BaseClient:
     def store_events(self, events: Iterable[Mapping[str, Any]]) -> None:
         """Alias for :meth:`send_events` that uses the ``/store`` endpoint."""
         headers = self._auth_headers()
-        events_list = list(events)
+        events_list = [_camel_event(e) for e in events]
         if not events_list:
             return
         try:
@@ -130,7 +141,7 @@ class AsyncBaseClient:
 
     async def send_events(self, events: Iterable[Mapping[str, Any]]) -> None:
         headers = self._auth_headers()
-        events_list = list(events)
+        events_list = [_camel_event(e) for e in events]
         if not events_list:
             return
         try:
@@ -149,7 +160,7 @@ class AsyncBaseClient:
     async def store_events(self, events: Iterable[Mapping[str, Any]]) -> None:
         """Alias for :meth:`send_events` that uses the ``/store`` endpoint."""
         headers = self._auth_headers()
-        events_list = list(events)
+        events_list = [_camel_event(e) for e in events]
         if not events_list:
             return
         try:

--- a/src/ume/pipeline/privacy_agent.py
+++ b/src/ume/pipeline/privacy_agent.py
@@ -22,6 +22,17 @@ from ..event_ledger import event_ledger
 from ..plugins.alignment import load_plugins, get_plugins, PolicyViolationError
 
 
+def _add_tokens(attrs: Dict[str, object]) -> None:
+    """Tokenize textual fields and store the tokens list if any."""
+    tokens: List[str] = []
+    for key in ("name", "text", "content"):
+        val = attrs.get(key)
+        if isinstance(val, str):
+            tokens.extend(tokenize(val))
+    if tokens:
+        attrs["tokens"] = tokens
+
+
 configure_logging()
 logger = logging.getLogger(__name__)
 
@@ -146,13 +157,7 @@ def run_privacy_agent() -> None:
 
             original_payload = data.get("payload", {})
             redacted_payload, was_redacted = redact_event_payload(original_payload)
-            tokens: List[str] = []
-            for key in ("name", "text", "content"):
-                val = redacted_payload.get(key)
-                if isinstance(val, str):
-                    tokens.extend(tokenize(val))
-            if tokens:
-                redacted_payload["tokens"] = tokens
+            _add_tokens(redacted_payload)
             data["payload"] = redacted_payload
 
             dest_topic = CLEAN_TOPIC if (has_consent or not (user_id and scope)) else QUARANTINE_TOPIC

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -7,6 +7,17 @@ from .schema_manager import DEFAULT_SCHEMA_MANAGER
 from .graph_schema import load_default_schema
 from .utils import tokenize
 
+
+def _add_tokens(attrs: dict[str, object]) -> None:
+    """Tokenize textual fields and store the tokens list if any."""
+    tokens: list[str] = []
+    for key in ("name", "text", "content"):
+        val = attrs.get(key)
+        if isinstance(val, str):
+            tokens.extend(tokenize(val))
+    if tokens:
+        attrs["tokens"] = tokens
+
 DEFAULT_VERSION = load_default_schema().version
 
 
@@ -77,13 +88,7 @@ def apply_event_to_graph(
             schema = DEFAULT_SCHEMA_MANAGER.get_schema(schema_version)
             schema.validate_node_type(str(node_type))
 
-        tokens: list[str] = []
-        for key in ("name", "text", "content"):
-            val = attributes.get(key)
-            if isinstance(val, str):
-                tokens.extend(tokenize(val))
-        if tokens:
-            attributes["tokens"] = tokens
+        _add_tokens(attributes)
 
         graph.add_node(node_id, attributes)  # Call adapter's add_node
         for listener in get_registered_listeners():
@@ -115,13 +120,7 @@ def apply_event_to_graph(
                 f"'attributes' dictionary cannot be empty for UPDATE_NODE_ATTRIBUTES event: {event.event_id}"
             )
 
-        tokens = []
-        for key in ("name", "text", "content"):
-            val = attributes.get(key)
-            if isinstance(val, str):
-                tokens.extend(tokenize(val))
-        if tokens:
-            attributes["tokens"] = tokens
+        _add_tokens(attributes)
 
         graph.update_node(node_id, attributes)  # Call adapter's update_node
         for listener in get_registered_listeners():

--- a/tests/integration/test_integration_clients.py
+++ b/tests/integration/test_integration_clients.py
@@ -93,7 +93,7 @@ def test_integration_clients(tmp_path) -> None:
                 c._client = httpx.Client(base_url=str(client.base_url), transport=client._transport)  # type: ignore[attr-defined]
                 c.send_events([event])
                 result = c.recall({"vector": vec, "k": 1})
-            assert graph.get_node(nid) == {"text": nid}
+            assert graph.get_node(nid) == {"text": nid, "tokens": [nid]}
             assert "nodes" in result
 
 
@@ -126,8 +126,8 @@ async def test_async_langgraph_and_letta(tmp_path) -> None:
             ])
             result2 = await lt.recall({"vector": [0.0, 1.0], "k": 1})
 
-        assert graph.get_node("n1") == {"text": "n1"}
-        assert graph.get_node("n2") == {"text": "n2"}
+        assert graph.get_node("n1") == {"text": "n1", "tokens": ["n1"]}
+        assert graph.get_node("n2") == {"text": "n2", "tokens": ["n2"]}
         assert "nodes" in result1
         assert "nodes" in result2
 

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -54,7 +54,7 @@ def test_post_event_success(client_and_graph):
     }
     res = client.post("/events", json=event, headers={"Authorization": f"Bearer {token}"})
     assert res.status_code == 200
-    assert g.get_node("n1") == {"text": "hi"}
+    assert g.get_node("n1") == {"text": "hi", "tokens": ["hi"]}
 
 
 def test_post_event_invalid(client_and_graph):
@@ -100,8 +100,8 @@ def test_post_events_batch(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    assert g.get_node("n1") == {"text": "a"}
-    assert g.get_node("n2") == {"text": "b"}
+    assert g.get_node("n1") == {"text": "a", "tokens": ["a"]}
+    assert g.get_node("n2") == {"text": "b", "tokens": ["b"]}
 
 
 def test_post_events_batch_invalid(client_and_graph) -> None:
@@ -140,7 +140,7 @@ def test_store_event_success(client_and_graph) -> None:
     }
     res = client.post("/store", json=event, headers={"Authorization": f"Bearer {token}"})
     assert res.status_code == 200
-    assert g.get_node("n3") == {"text": "store"}
+    assert g.get_node("n3") == {"text": "store", "tokens": ["store"]}
 
 
 def test_store_events_batch(client_and_graph) -> None:
@@ -166,5 +166,5 @@ def test_store_events_batch(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    assert g.get_node("n4") == {"text": "x"}
-    assert g.get_node("n5") == {"text": "y"}
+    assert g.get_node("n4") == {"text": "x", "tokens": ["x"]}
+    assert g.get_node("n5") == {"text": "y", "tokens": ["y"]}

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -35,6 +35,21 @@ def test_apply_create_node_event_success(graph: PersistentGraph):
     assert graph.node_count == 1
 
 
+def test_create_node_adds_tokens_from_text(graph: PersistentGraph) -> None:
+    """CREATE_NODE with a text field should store tokens."""
+    node_id = "node_text"
+    event = Event(
+        event_type=EventType.CREATE_NODE,
+        timestamp=int(time.time()),
+        payload={"node_id": node_id, "attributes": {"text": "Alpha Beta"}},
+    )
+    apply_event_to_graph(event, graph)
+    assert graph.get_node(node_id) == {
+        "text": "Alpha Beta",
+        "tokens": ["alpha", "beta"],
+    }
+
+
 def test_apply_create_node_event_no_attributes(graph: PersistentGraph):
     """Test successfully creating a new node with no initial attributes."""
     node_id = "node_no_attr"


### PR DESCRIPTION
## Summary
- tokenize textual fields and store in node attributes
- accept `event_type` or `eventType` when parsing events
- convert integration client events to camelCase when sending
- ensure GraphQL route advertises POST/GET methods
- fix async `store_events` to keep node identifiers snake-cased

## Testing
- `poetry run pre-commit run --files src/ume/integrations/base.py tests/integration/test_integration_clients.py tests/test_api_events.py tests/test_processing.py src/ume/pipeline/privacy_agent.py src/ume/processing.py src/ume/event.py src/ume/api.py`
- `poetry run pytest tests/test_processing.py tests/test_api_events.py tests/integration/test_integration_clients.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6889313e0ae0832685036289d48cee70