### PR TITLE
Implement atomic writes for encrypted ledger

### DIFF
--- a/src/ume/event_ledger.py
+++ b/src/ume/event_ledger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import os
+import tempfile
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Optional, TYPE_CHECKING
 
@@ -138,8 +139,17 @@ class EventLedger:
             with open(self._plain_path, "rb") as f:
                 data = f.read()
             encrypted = self._fernet.encrypt(data)
-            with open(self.db_path, "wb") as f:
-                f.write(encrypted)
+            tmp_dir = Path(self.db_path).parent
+            tmp_file = tempfile.NamedTemporaryFile(
+                "wb", delete=False, dir=tmp_dir
+            )
+            try:
+                with tmp_file:
+                    tmp_file.write(encrypted)
+                os.replace(tmp_file.name, self.db_path)
+            finally:
+                if os.path.exists(tmp_file.name):
+                    os.remove(tmp_file.name)
             if os.path.exists(self._plain_path):
                 os.remove(self._plain_path)
 

--- a/tests/test_event_ledger_encryption.py
+++ b/tests/test_event_ledger_encryption.py
@@ -1,0 +1,94 @@
+import os
+
+import pytest
+from cryptography.fernet import Fernet
+
+import ume.event_ledger as event_module
+
+
+
+def _get_class():
+    return event_module.EventLedger
+
+
+def test_encrypted_ledger_roundtrip(tmp_path, monkeypatch):
+    key = Fernet.generate_key().decode()
+    from ume import config as cfg
+    monkeypatch.setattr(
+        cfg.settings, "UME_ENCRYPTION_ENABLED", True, raising=False
+    )
+    monkeypatch.setattr(cfg.settings, "UME_ENCRYPTION_KEY", key, raising=False)
+    monkeypatch.setattr(
+        event_module, "settings", cfg.settings, raising=False
+    )
+    EventLedgerCls = _get_class()
+    ledger_path = tmp_path / "ledger.db"
+    ledger = EventLedgerCls(str(ledger_path))
+    ledger.append(0, {"foo": "bar"})
+    ledger.close()
+
+    raw = ledger_path.read_bytes()
+    assert b"foo" not in raw
+
+    ledger2 = EventLedgerCls(str(ledger_path))
+    assert ledger2.range() == [(0, {"foo": "bar"})]
+    ledger2.close()
+
+
+def test_encrypted_ledger_atomic_replace_failure(tmp_path, monkeypatch):
+    key = Fernet.generate_key().decode()
+    from ume import config as cfg
+    monkeypatch.setattr(cfg.settings, "UME_ENCRYPTION_ENABLED", True, raising=False)
+    monkeypatch.setattr(cfg.settings, "UME_ENCRYPTION_KEY", key, raising=False)
+    monkeypatch.setattr(event_module, "settings", cfg.settings, raising=False)
+    EventLedgerCls = _get_class()
+    ledger_path = tmp_path / "ledger.db"
+    ledger = EventLedgerCls(str(ledger_path))
+    ledger.append(0, {"foo": "bar"})
+
+    def fail_replace(src: str, dst: str) -> None:
+        raise RuntimeError("boom")
+
+    orig_replace = os.replace
+    monkeypatch.setattr(os, "replace", fail_replace)
+    with pytest.raises(RuntimeError):
+        ledger.close()
+    monkeypatch.setattr(os, "replace", orig_replace)
+
+    assert not ledger_path.exists()
+
+    EventLedgerCls = _get_class()
+    ledger2 = EventLedgerCls(str(ledger_path))
+    assert ledger2.range() == [(0, {"foo": "bar"})]
+    ledger2.close()
+
+
+def test_encrypted_ledger_cleanup_failure(tmp_path, monkeypatch):
+    key = Fernet.generate_key().decode()
+    from ume import config as cfg
+    monkeypatch.setattr(cfg.settings, "UME_ENCRYPTION_ENABLED", True, raising=False)
+    monkeypatch.setattr(cfg.settings, "UME_ENCRYPTION_KEY", key, raising=False)
+    monkeypatch.setattr(event_module, "settings", cfg.settings, raising=False)
+    EventLedgerCls = _get_class()
+    ledger_path = tmp_path / "ledger.db"
+    ledger = EventLedgerCls(str(ledger_path))
+    ledger.append(0, {"foo": "bar"})
+
+    orig_remove = os.remove
+
+    def fail_remove(path: str) -> None:
+        if path.endswith(".dec"):
+            raise RuntimeError("boom")
+        orig_remove(path)
+
+    monkeypatch.setattr(os, "remove", fail_remove)
+    with pytest.raises(RuntimeError):
+        ledger.close()
+    monkeypatch.setattr(os, "remove", orig_remove)
+
+    assert ledger_path.exists()
+
+    EventLedgerCls = _get_class()
+    ledger2 = EventLedgerCls(str(ledger_path))
+    assert ledger2.range() == [(0, {"foo": "bar"})]
+    ledger2.close()


### PR DESCRIPTION
## Summary
- use temporary files for encrypted ledger writes
- regression tests for encrypted ledger interrupts

## Testing
- `ruff check tests/test_event_ledger_encryption.py src/ume/event_ledger.py`
- `mypy src/ume/event_ledger.py tests/test_event_ledger_encryption.py`
- `pytest -q tests/test_event_ledger_encryption.py`


------
https://chatgpt.com/codex/tasks/task_e_68896da6e7008326a7c2aab67b6f04e4