### PR TITLE
Add ISO8601 support for event timestamps

### DIFF
--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Any, Optional
 import logging
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,8 @@ def parse_event(data: Dict[str, Any]) -> Event:
 
     Args:
         data (Dict[str, Any]): A dictionary potentially representing an event.
-              Common expected keys: "eventType", "timestamp".
+              Common expected keys: "eventType", "timestamp" (integer Unix
+              timestamp or ISO 8601 formatted string).
               Type-specific keys:
                 - For "CREATE_NODE", "UPDATE_NODE_ATTRIBUTES": "node_id" (str), "payload" (dict).
                 - For "CREATE_EDGE", "DELETE_EDGE": "node_id" (source, str),
@@ -111,9 +113,21 @@ def parse_event(data: Dict[str, Any]) -> Event:
     if "timestamp" not in data:
         logger.error("Missing required event field: timestamp")
         raise EventError("Missing required event field: timestamp")
-    timestamp = data["timestamp"]
-    if not isinstance(timestamp, int):
-        msg = f"Invalid type for 'timestamp': expected int, got {type(timestamp).__name__}"
+    timestamp_raw = data["timestamp"]
+    if isinstance(timestamp_raw, int):
+        timestamp_int = timestamp_raw
+    elif isinstance(timestamp_raw, str):
+        try:
+            dt = datetime.fromisoformat(timestamp_raw.replace("Z", "+00:00"))
+        except ValueError:
+            msg = "Invalid ISO 8601 timestamp format"
+            logger.error(msg)
+            raise EventError(msg)
+        timestamp_int = int(dt.timestamp())
+    else:
+        msg = (
+            f"Invalid type for 'timestamp': expected int or ISO 8601 string, got {type(timestamp_raw).__name__}"
+        )
         logger.error(msg)
         raise EventError(msg)
 
@@ -248,7 +262,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
     return Event(
         event_id=event_id_val if event_id_val is not None else str(uuid.uuid4()),
         event_type=event_type,
-        timestamp=timestamp,
+        timestamp=timestamp_int,
         payload=payload_val,  # Use payload_val which is defaulted to {} or the actual value
         source=data.get("sourceService"),
         node_id=node_id_val,

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,6 +1,7 @@
 # tests/test_event.py
 import pytest
 import time
+from datetime import datetime, timezone
 from ume import Event, EventType, parse_event, EventError  # EventType constants
 
 
@@ -71,6 +72,24 @@ def test_parse_event_custom_type_minimal():
     assert event.payload == {}
 
 
+def test_parse_event_timestamp_iso8601():
+    """Parsing accepts ISO 8601 timestamp strings."""
+    ts = datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
+    data = {"eventType": "test", "timestamp": ts.isoformat(), "payload": {}}
+    event = parse_event(data)
+    assert event.timestamp == int(ts.timestamp())
+
+
+def test_parse_event_timestamp_iso8601_z():
+    """ISO 8601 with trailing 'Z' is supported."""
+    ts = datetime(2024, 5, 6, 7, 8, 9, tzinfo=timezone.utc)
+    iso_z = ts.isoformat().replace("+00:00", "Z")
+    data = {"eventType": "test", "timestamp": iso_z, "payload": {}}
+    event = parse_event(data)
+    assert event.timestamp == int(ts.timestamp())
+
+
+
 @pytest.mark.parametrize(
     "event_type, extra_data",
     [
@@ -128,10 +147,10 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
             {"eventType": 123, "timestamp": int(time.time()), "payload": {}},
             "Invalid type for 'eventType'",
         ),
-        # Case 6: Invalid type for 'timestamp' (str instead of int)
+        # Case 6: Invalid ISO 8601 timestamp string
         (
-            {"eventType": "test", "timestamp": "not-an-int", "payload": {}},
-            "Invalid type for 'timestamp'",
+            {"eventType": "test", "timestamp": "bad-date", "payload": {}},
+            "Invalid ISO 8601 timestamp format",
         ),
         # Case 7: Invalid type for 'payload' (str instead of dict)
         (


### PR DESCRIPTION
## Summary
- parse_event accepts integer or ISO8601 timestamps
- convert ISO8601 strings to Unix epoch
- test ISO8601 support and updated invalid input case

## Testing
- `poetry run pre-commit run --files src/ume/event.py tests/test_event.py`
- `poetry run pytest tests/test_event.py`

------
https://chatgpt.com/codex/tasks/task_e_688978f755548326ae9495e5067f791d