### PR TITLE
Support ISO timestamps in events

### DIFF
--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -3,6 +3,7 @@ import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, Any, Optional
+from datetime import datetime
 import logging
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,8 @@ class Event:
     Attributes:
         event_type (str): The type or category of the event (e.g., "user_interaction", "system_alert",
                           "CREATE_NODE", "CREATE_EDGE").
-        timestamp (int): Unix timestamp (seconds since epoch) indicating when the event occurred or was generated.
+        timestamp (int | str): When the event occurred. Can be a Unix timestamp
+            (seconds since epoch) or an ISO 8601 formatted string.
         payload (Dict[str, Any]): A dictionary containing the actual data/details of the event.
                                   The structure of the payload can vary based on the event_type.
                                   For node-related events, this often contains node attributes.
@@ -48,7 +50,7 @@ class Event:
     """
 
     event_type: str
-    timestamp: int
+    timestamp: int | str
     payload: Dict[str, Any]  # Main content, e.g., attributes for a node
     event_id: str = field(default_factory=lambda: str(uuid.uuid4()))
     source: Optional[str] = None
@@ -103,17 +105,30 @@ def parse_event(data: Dict[str, Any]) -> Event:
         logger.error(msg)
         raise EventError(msg)
     # Map to the known EventType enum when possible but allow arbitrary strings
+    event_type_enum: EventType | str
     try:
-        event_type = EventType(event_type)
+        event_type_enum = EventType(event_type)
+        event_type_str = event_type_enum.value
     except ValueError:
-        pass
+        event_type_enum = event_type
+        event_type_str = event_type
 
     if "timestamp" not in data:
         logger.error("Missing required event field: timestamp")
         raise EventError("Missing required event field: timestamp")
     timestamp = data["timestamp"]
-    if not isinstance(timestamp, int):
-        msg = f"Invalid type for 'timestamp': expected int, got {type(timestamp).__name__}"
+    if isinstance(timestamp, str):
+        try:
+            datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        except ValueError:
+            msg = "Invalid timestamp format"
+            logger.error(msg)
+            raise EventError(msg)
+    elif not isinstance(timestamp, int):
+        msg = (
+            "Invalid type for 'timestamp': expected int or ISO 8601 string, "
+            f"got {type(timestamp).__name__}"
+        )
         logger.error(msg)
         raise EventError(msg)
 
@@ -174,22 +189,22 @@ def parse_event(data: Dict[str, Any]) -> Event:
         EventType.UPDATE_NODE_ATTRIBUTES,
     ]:
         if "node_id" not in data:  # Must be present in data
-            msg = f"Missing required field 'node_id' for {event_type} event."
+            msg = f"Missing required field 'node_id' for {event_type_str} event."
             logger.error(msg)
             raise EventError(msg)
         if not isinstance(node_id_val, str):
-            msg = f"Invalid type for 'node_id' in {event_type} event: expected str, got {type(node_id_val).__name__}"
+            msg = f"Invalid type for 'node_id' in {event_type_str} event: expected str, got {type(node_id_val).__name__}"
             logger.error(msg)
             raise EventError(msg)
 
         if "payload" not in data:  # Must be present in data for these types
-            msg = f"Missing required field 'payload' for {event_type} event."
+            msg = f"Missing required field 'payload' for {event_type_str} event."
             logger.error(msg)
             raise EventError(msg)
         # Ensure payload_val (which could be the default {} if "payload" key was missing,
         # or the actual value if present) is a dict for these event types.
         if not isinstance(payload_val, dict):
-            msg = f"Invalid type for 'payload' in {event_type} event: expected dict, got {type(payload_val).__name__}"
+            msg = f"Invalid type for 'payload' in {event_type_str} event: expected dict, got {type(payload_val).__name__}"
             logger.error(msg)
             raise EventError(msg)
 
@@ -201,7 +216,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
         required_fields_for_edge = {"node_id", "target_node_id", "label"}
         missing_fields = required_fields_for_edge - data.keys()
         if missing_fields:
-            msg = f"Missing required fields for {event_type} event: {', '.join(sorted(list(missing_fields)))}"
+            msg = f"Missing required fields for {event_type_str} event: {', '.join(sorted(list(missing_fields)))}"
             logger.error(msg)
             raise EventError(msg)
 
@@ -214,14 +229,14 @@ def parse_event(data: Dict[str, Any]) -> Event:
             if not isinstance(
                 field_val_check, str
             ):  # Already checked for presence by missing_fields logic
-                msg = f"Invalid type for '{field_name}' in {event_type} event: expected str, got {type(field_val_check).__name__}"
+                msg = f"Invalid type for '{field_name}' in {event_type_str} event: expected str, got {type(field_val_check).__name__}"
                 logger.error(msg)
                 raise EventError(msg)
 
         # For edge events, payload_val will use its default {} if "payload" was not in data.
         # If "payload" was in data, we still need to ensure it's a dict.
         if "payload" in data and not isinstance(payload_val, dict):
-            msg = f"Invalid type for 'payload' in {event_type} event (if provided): expected dict, got {type(payload_val).__name__}"
+            msg = f"Invalid type for 'payload' in {event_type_str} event (if provided): expected dict, got {type(payload_val).__name__}"
             logger.error(msg)
             raise EventError(msg)
 

--- a/src/ume/ingestion_api.py
+++ b/src/ume/ingestion_api.py
@@ -28,14 +28,14 @@ app = FastAPI(
 )
 
 
-@app.on_event("startup")
+@app.on_event("startup")  # type: ignore[misc]
 def _init_producer() -> None:
     """Initialize the Kafka producer."""
     global producer
     producer = Producer(producer_conf)
 
 
-@app.post("/events", status_code=202)
+@app.post("/events", status_code=202)  # type: ignore[misc]
 async def post_event(request: Request) -> JSONResponse:
     """Validate the request body and publish it to Kafka."""
     try:
@@ -64,7 +64,7 @@ async def post_event(request: Request) -> JSONResponse:
     return JSONResponse(status_code=202, content={"status": "accepted"})
 
 
-@app.on_event("shutdown")
+@app.on_event("shutdown")  # type: ignore[misc]
 def _close_producer() -> None:
     if producer is None:
         return

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -76,6 +76,10 @@ def run_graph_consumer(
             try:
                 data_camel = json.loads(msg.value().decode("utf-8"))
                 data = event_to_snake(data_camel)
+                validation_data = dict(data)
+                if "event_type" in validation_data:
+                    validation_data["eventType"] = validation_data.pop("event_type")
+                validate_event_dict(validation_data)
                 payload = data["event"] if "event" in data else data
                 payload_camel = event_to_camel(payload)
                 event = parse_event(payload_camel)

--- a/src/ume/pipeline/privacy_agent.py
+++ b/src/ume/pipeline/privacy_agent.py
@@ -106,7 +106,10 @@ def run_privacy_agent() -> None:
             try:
                 data_camel = json.loads(raw_bytes.decode("utf-8"))
                 data = event_to_snake(data_camel)
-                validate_event_dict(data)
+                validation_data = dict(data)
+                if "event_type" in validation_data:
+                    validation_data["eventType"] = validation_data.pop("event_type")
+                validate_event_dict(validation_data)
             except (json.JSONDecodeError, ValidationError) as exc:
                 logger.error("Invalid event received: %s", exc)
                 try:

--- a/src/ume/schemas/create_edge.schema.json
+++ b/src/ume/schemas/create_edge.schema.json
@@ -12,8 +12,11 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "integer",
-      "description": "Unix timestamp when the event occurred"
+      "anyOf": [
+        {"type": "integer"},
+        {"type": "string", "format": "date-time"}
+      ],
+      "description": "Unix timestamp or ISO8601 string when the event occurred"
     },
     "eventId": {
       "type": "string",

--- a/src/ume/schemas/create_node.schema.json
+++ b/src/ume/schemas/create_node.schema.json
@@ -12,8 +12,11 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "integer",
-      "description": "Unix timestamp when the event occurred"
+      "anyOf": [
+        {"type": "integer"},
+        {"type": "string", "format": "date-time"}
+      ],
+      "description": "Unix timestamp or ISO8601 string when the event occurred"
     },
     "eventId": {
       "type": "string",

--- a/src/ume/schemas/delete_edge.schema.json
+++ b/src/ume/schemas/delete_edge.schema.json
@@ -12,8 +12,11 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "integer",
-      "description": "Unix timestamp when the event occurred"
+      "anyOf": [
+        {"type": "integer"},
+        {"type": "string", "format": "date-time"}
+      ],
+      "description": "Unix timestamp or ISO8601 string when the event occurred"
     },
     "eventId": {
       "type": "string",

--- a/src/ume/schemas/update_node_attributes.schema.json
+++ b/src/ume/schemas/update_node_attributes.schema.json
@@ -12,8 +12,11 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "integer",
-      "description": "Unix timestamp when the event occurred"
+      "anyOf": [
+        {"type": "integer"},
+        {"type": "string", "format": "date-time"}
+      ],
+      "description": "Unix timestamp or ISO8601 string when the event occurred"
     },
     "eventId": {
       "type": "string",

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -128,10 +128,10 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
             {"eventType": 123, "timestamp": int(time.time()), "payload": {}},
             "Invalid type for 'eventType'",
         ),
-        # Case 6: Invalid type for 'timestamp' (str instead of int)
+        # Case 6: Invalid timestamp format
         (
-            {"eventType": "test", "timestamp": "not-an-int", "payload": {}},
-            "Invalid type for 'timestamp'",
+            {"eventType": "test", "timestamp": "2023-13-01T00:00:00Z", "payload": {}},
+            "Invalid timestamp format",
         ),
         # Case 7: Invalid type for 'payload' (str instead of dict)
         (

--- a/tests/test_ingestion_api.py
+++ b/tests/test_ingestion_api.py
@@ -32,7 +32,12 @@ def client(monkeypatch):
 
 def test_post_event_publishes_to_kafka(client):
     test_client, prod = client
-    event = {"eventType": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}
+    event = {
+        "eventType": "CREATE_NODE",
+        "timestamp": "2023-01-01T00:00:00Z",
+        "node_id": "n1",
+        "payload": {},
+    }
 
     res = test_client.post("/events", json=event)
     assert res.status_code == 202

--- a/tests/test_privacy_agent.py
+++ b/tests/test_privacy_agent.py
@@ -94,7 +94,7 @@ def test_privacy_agent_end_to_end(privacy_agent, monkeypatch):
     payload = {"email": "user@example.com"}
     event = {
         "eventType": "CREATE_NODE",
-        "timestamp": 1,
+        "timestamp": "2023-01-01T00:00:00Z",
         "nodeId": "n1",
         "payload": payload,
     }
@@ -135,7 +135,7 @@ def test_privacy_agent_periodic_flush(privacy_agent, monkeypatch):
     payload = {"email": "user@example.com"}
     event = {
         "eventType": "CREATE_NODE",
-        "timestamp": 1,
+        "timestamp": "2023-01-01T00:00:00Z",
         "nodeId": "n1",
         "payload": payload,
     }
@@ -175,7 +175,7 @@ def test_privacy_agent_audit_log_written(tmp_path, monkeypatch):
     payload = {"email": "user@example.com"}
     event = {
         "eventType": "CREATE_NODE",
-        "timestamp": 1,
+        "timestamp": "2023-01-01T00:00:00Z",
         "nodeId": "n1",
         "payload": payload,
     }
@@ -236,7 +236,7 @@ def test_policy_violation_goes_to_quarantine(privacy_agent, monkeypatch):
     payload = {"node_id": "n1"}
     event = {
         "eventType": "CREATE_NODE",
-        "timestamp": 1,
+        "timestamp": "2023-01-01T00:00:00Z",
         "nodeId": "n1",
         "payload": payload,
     }

--- a/tests/test_privacy_agent_rego.py
+++ b/tests/test_privacy_agent_rego.py
@@ -58,7 +58,7 @@ class FakeProducer:
 def test_rego_policy_denies_event(monkeypatch):
     event = {
         "eventType": "CREATE_NODE",
-        "timestamp": 1,
+        "timestamp": "2023-01-01T00:00:00Z",
         "nodeId": "forbidden",
         "payload": {"node_id": "forbidden", "attributes": {}},
     }
@@ -105,7 +105,7 @@ def _setup_agent(monkeypatch: pytest.MonkeyPatch, consumer: FakeConsumer, produc
 def test_event_without_consent_goes_to_quarantine(monkeypatch: pytest.MonkeyPatch) -> None:
     event = {
         "eventType": "CREATE_NODE",
-        "timestamp": 1,
+        "timestamp": "2023-01-01T00:00:00Z",
         "nodeId": "n1",
         "payload": {"node_id": "n1", "user_id": "u1", "scope": "profile", "attributes": {}},
     }
@@ -126,7 +126,7 @@ def test_event_without_consent_goes_to_quarantine(monkeypatch: pytest.MonkeyPatc
 def test_event_with_consent_published(monkeypatch: pytest.MonkeyPatch) -> None:
     event = {
         "eventType": "CREATE_NODE",
-        "timestamp": 1,
+        "timestamp": "2023-01-01T00:00:00Z",
         "nodeId": "n2",
         "payload": {"node_id": "n2", "user_id": "u1", "scope": "profile", "attributes": {}},
     }


### PR DESCRIPTION
## Summary
- allow `Event.timestamp` to accept ISO 8601 strings
- validate timestamp strings in `parse_event`
- permit string timestamps in event schemas
- adjust ingestion API and privacy agent tests for new format
- update event tests for ISO timestamp handling
- fix privacy agent and graph consumer validation for mixed-case events

## Testing
- `pre-commit run --files src/ume/event.py src/ume/ingestion_api.py src/ume/schemas/create_edge.schema.json src/ume/schemas/create_node.schema.json src/ume/schemas/delete_edge.schema.json src/ume/schemas/update_node_attributes.schema.json tests/test_event.py tests/test_ingestion_api.py tests/test_privacy_agent.py tests/test_privacy_agent_rego.py`
- `pytest -q tests/test_ingestion_api.py tests/test_privacy_agent.py tests/test_privacy_agent_rego.py tests/test_event.py`

------
https://chatgpt.com/codex/tasks/task_e_688978f7cbfc8326ae7bd8223b6274de