### PR TITLE
Update timestamp format in schemas

### DIFF
--- a/src/ume/schemas/create_edge.schema.json
+++ b/src/ume/schemas/create_edge.schema.json
@@ -12,8 +12,9 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "integer",
-      "description": "Unix timestamp when the event occurred"
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the event occurred in ISO 8601 format"
     },
     "eventId": {
       "type": "string",

--- a/src/ume/schemas/create_node.schema.json
+++ b/src/ume/schemas/create_node.schema.json
@@ -12,8 +12,9 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "integer",
-      "description": "Unix timestamp when the event occurred"
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the event occurred in ISO 8601 format"
     },
     "eventId": {
       "type": "string",

--- a/src/ume/schemas/delete_edge.schema.json
+++ b/src/ume/schemas/delete_edge.schema.json
@@ -12,8 +12,9 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "integer",
-      "description": "Unix timestamp when the event occurred"
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the event occurred in ISO 8601 format"
     },
     "eventId": {
       "type": "string",

--- a/src/ume/schemas/update_node_attributes.schema.json
+++ b/src/ume/schemas/update_node_attributes.schema.json
@@ -12,8 +12,9 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "integer",
-      "description": "Unix timestamp when the event occurred"
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the event occurred in ISO 8601 format"
     },
     "eventId": {
       "type": "string",


### PR DESCRIPTION
## Summary
- update JSON schemas to expect ISO 8601 timestamps
- clarify timestamp description wording

## Testing
- `pre-commit run --files src/ume/schemas/create_edge.schema.json src/ume/schemas/create_node.schema.json src/ume/schemas/delete_edge.schema.json src/ume/schemas/update_node_attributes.schema.json`
- `poetry run pytest tests/test_api.py::test_semantic_search tests/test_api.py::test_semantic_search_invalid_dimension tests/test_api.py::test_semantic_search_invalid_k -q`


------
https://chatgpt.com/codex/tasks/task_e_688978f7542c8326992d189b718e12cf