### PR TITLE
Add GraphQL examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,25 @@ curl -X GET http://localhost:8000/entities/user/n1 \
   -H "Authorization: Bearer <token>"
 ```
 
+### GraphQL Queries
+Use the GraphQL endpoint at `/graphql` for advanced retrievals. List all nodes:
+
+```bash
+curl -X POST http://localhost:8000/graphql \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ nodes { id attributes } }"}'
+```
+
+Fetch every edge in the graph:
+
+```bash
+curl -X POST http://localhost:8000/graphql \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ edges { source target label } }"}'
+```
+
 ### Migrate Events to the New Schema
 Existing events can be rewritten using the latest schema version. Run the
 migration helper and redirect the output to a file:

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -200,6 +200,24 @@ curl -X POST http://localhost:8000/graphql \
   -d '{"query":"{ node(id: \"n1\") { id } }"}'
 ```
 
+Another query returns all nodes with their attributes:
+
+```bash
+curl -X POST http://localhost:8000/graphql \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ nodes { id attributes } }"}'
+```
+
+And to retrieve every edge in the graph:
+
+```bash
+curl -X POST http://localhost:8000/graphql \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ edges { source target label } }"}'
+```
+
 ### GET `/recall`
 Retrieve attribute data for the `k` nearest nodes to a query.
 


### PR DESCRIPTION
## Summary
- add GraphQL query examples to API reference
- document GraphQL queries in README

## Testing
- `pre-commit` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_688a23a864fc8326ad6f4e876deee11f