### PR TITLE
Add GraphQL node-edge and path queries

### DIFF
--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Dict, Any, Optional
 from datetime import datetime
 import logging
-from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
@@ -118,18 +117,21 @@ def parse_event(data: Dict[str, Any]) -> Event:
     if "timestamp" not in data:
         logger.error("Missing required event field: timestamp")
         raise EventError("Missing required event field: timestamp")
-    timestamp = data["timestamp"]
-    if isinstance(timestamp, str):
+    timestamp_raw = data["timestamp"]
+    if isinstance(timestamp_raw, str):
         try:
-            datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+            dt = datetime.fromisoformat(timestamp_raw.replace("Z", "+00:00"))
         except ValueError:
             msg = "Invalid timestamp format"
             logger.error(msg)
             raise EventError(msg)
-    elif not isinstance(timestamp, int):
+        timestamp_int = int(dt.timestamp())
+    elif isinstance(timestamp_raw, int):
+        timestamp_int = timestamp_raw
+    else:
         msg = (
             "Invalid type for 'timestamp': expected int or ISO 8601 string, "
-            f"got {type(timestamp).__name__}"
+            f"got {type(timestamp_raw).__name__}"
 
         )
         logger.error(msg)

--- a/src/ume/graphql_api.py
+++ b/src/ume/graphql_api.py
@@ -23,6 +23,24 @@ class NodeType(graphene.ObjectType):
 
     id = graphene.String(required=True)
     attributes = GenericScalar()
+    edges = graphene.List(
+        lambda: EdgeType,
+        label=graphene.String(),
+        description="Edges originating from this node",
+    )
+
+    async def resolve_edges(
+        self, info: graphene.ResolveInfo, label: str | None = None
+    ) -> list["EdgeType"]:
+        graph = info.context["app"].state.graph
+        if graph is None:
+            return []
+        all_edges = await _maybe_call(graph, "get_all_edges")
+        result = []
+        for src, tgt, lbl in all_edges:
+            if src == self.id and (label is None or lbl == label):
+                result.append(EdgeType(source=src, target=tgt, label=lbl))
+        return result
 
 
 class EdgeType(graphene.ObjectType):
@@ -37,6 +55,15 @@ class Query(graphene.ObjectType):
     node = graphene.Field(NodeType, id=graphene.String(required=True))
     nodes = graphene.List(NodeType)
     edges = graphene.List(EdgeType)
+    path = graphene.List(
+        graphene.String,
+        source=graphene.String(required=True),
+        target=graphene.String(required=True),
+        max_depth=graphene.Int(),
+        edge_label=graphene.String(),
+        since_timestamp=graphene.Int(),
+        description="Find a path between two nodes",
+    )
 
     async def resolve_node(self, info: graphene.ResolveInfo, id: str) -> NodeType | None:
         graph = info.context["app"].state.graph
@@ -64,6 +91,28 @@ class Query(graphene.ObjectType):
             return []
         edges = await _maybe_call(graph, "get_all_edges")
         return [EdgeType(source=s, target=t, label=lbl) for s, t, lbl in edges]
+
+    async def resolve_path(
+        self,
+        info: graphene.ResolveInfo,
+        source: str,
+        target: str,
+        max_depth: int | None = None,
+        edge_label: str | None = None,
+        since_timestamp: int | None = None,
+    ) -> list[str]:
+        graph = info.context["app"].state.graph
+        if graph is None:
+            return []
+        return await _maybe_call(
+            graph,
+            "constrained_path",
+            source,
+            target,
+            max_depth,
+            edge_label,
+            since_timestamp,
+        )
 
 
 class CreateNode(graphene.Mutation):

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -58,3 +58,20 @@ def test_create_edge_mutation() -> None:
     assert res.status_code == 200
     assert res.json()["data"]["createEdge"]["ok"] is True
     assert ("b", "a", "ba") in app.state.graph.get_all_edges()
+
+
+def test_edges_for_node() -> None:
+    client = TestClient(app)
+    query = "{ node(id: \"a\") { edges { source target label } } }"
+    res = client.post("/graphql", json={"query": query})
+    assert res.status_code == 200
+    edges = res.json()["data"]["node"]["edges"]
+    assert edges == [{"source": "a", "target": "b", "label": "ab"}]
+
+
+def test_path_query() -> None:
+    client = TestClient(app)
+    query = "{ path(source: \"a\", target: \"b\") }"
+    res = client.post("/graphql", json={"query": query})
+    assert res.status_code == 200
+    assert res.json()["data"]["path"] == ["a", "b"]


### PR DESCRIPTION
## Summary
- extend GraphQL schema with node edge listing and path query
- implement resolvers that call graph traversal functions
- test new GraphQL queries
- fix parse_event timestamp conversion

## Testing
- `ruff check src/ume/event.py src/ume/graphql_api.py tests/test_graphql.py`
- `pytest tests/test_graphql.py -q`
- `pre-commit run --files src/ume/event.py src/ume/graphql_api.py tests/test_graphql.py`


------
https://chatgpt.com/codex/tasks/task_e_688a23a821308326bcd6392af56aecdb