### PR TITLE
Update docs for event replay and history restoration

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -103,10 +103,28 @@ List entries in the event ledger.
 ### GET `/ledger/replay`
 Return a snapshot of the graph reconstructed from ledger events.
 - **Query parameters**: optional `end_offset`, optional `end_timestamp`.
+Example request:
+
+```bash
+curl -X GET -H "Authorization: Bearer <token>" \
+  "http://localhost:8000/ledger/replay?end_offset=50"
+```
+
+If `end_timestamp` is supplied, replay stops once an event newer than the
+timestamp is encountered.
 
 ### GET `/graph/history`
 Return a snapshot of the graph as it existed at a past point in time.
 - **Query parameters**: optional `offset`, optional `timestamp`.
+Example request:
+
+```bash
+curl -X GET -H "Authorization: Bearer <token>" \
+  "http://localhost:8000/graph/history?timestamp=1725000000"
+```
+
+This endpoint rebuilds the graph up to the provided cutoff and returns it as
+JSON.
 
 ### GET `/policies`
 List available Rego policy files.

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -163,6 +163,30 @@ snapshot = build_graph_from_ledger(ledger, end_timestamp=1_725_000_000)
 The `/ledger/replay` API wraps this helper and returns a JSON snapshot of the
 graph state.
 
+To update an existing graph in place, use ``replay_from_ledger`` specifying a
+``start_offset``. This allows applications to store a bookmark and resume event
+processing from the last applied offset:
+
+```python
+from ume.replay import replay_from_ledger
+
+last = replay_from_ledger(graph, ledger, start_offset=stored_offset)
+```
+
+### Restoring historical state
+
+Because the ledger is append-only, you can rebuild the graph as it looked at any
+previous moment by providing ``end_offset`` or ``end_timestamp`` when calling
+``build_graph_from_ledger``. The ``/graph/history`` API exposes this capability
+over HTTP:
+
+```bash
+curl -X GET -H "Authorization: Bearer <token>" \
+  "http://localhost:8000/graph/history?timestamp=1725000000"
+```
+
+The returned JSON snapshot reflects all events up to the requested cutoff.
+
 ## Snapshot scheduler
 
 Call :func:`ume.enable_periodic_snapshot` to write the graph to


### PR DESCRIPTION
## Summary
- document `replay_from_ledger` and restoring historical states in GRAPH_MODEL.md
- expand API reference for `/ledger/replay` and `/graph/history`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ad0fb7d7c8326b7a5802bfdfd251f