### PR TITLE
Add ledger replay tests

### DIFF
--- a/tests/test_cli_internal.py
+++ b/tests/test_cli_internal.py
@@ -1,6 +1,9 @@
 import os
 from pathlib import Path
+
 import pytest
+from ume.event_ledger import EventLedger
+from ume.replay import build_graph_from_ledger
 
 
 @pytest.mark.xfail(reason="RoleBasedGraphAdapter behaves unexpectedly in this environment")
@@ -109,3 +112,40 @@ def test_up_alias(monkeypatch: pytest.MonkeyPatch) -> None:
     cli.main()
 
     assert calls == ["up", "up"]
+
+
+def test_build_graph_from_ledger_cli(tmp_path: Path) -> None:
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    ledger.append(
+        0,
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 1,
+            "node_id": "x",
+            "payload": {"node_id": "x"},
+        },
+    )
+    ledger.append(
+        1,
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 2,
+            "node_id": "y",
+            "payload": {"node_id": "y"},
+        },
+    )
+    ledger.append(
+        2,
+        {
+            "event_type": "CREATE_EDGE",
+            "timestamp": 3,
+            "node_id": "x",
+            "target_node_id": "y",
+            "label": "LINKS_TO",
+            "payload": {},
+        },
+    )
+
+    graph = build_graph_from_ledger(ledger)
+    assert set(graph.get_all_node_ids()) == {"x", "y"}
+    assert ("x", "y", "LINKS_TO") in graph.get_all_edges()

--- a/tests/test_event_ledger.py
+++ b/tests/test_event_ledger.py
@@ -1,6 +1,6 @@
 from ume.event_ledger import EventLedger
 from ume.persistent_graph import PersistentGraph
-from ume.replay import replay_from_ledger
+from ume.replay import replay_from_ledger, build_graph_from_ledger
 import pytest
 
 
@@ -103,3 +103,40 @@ def test_bookmark_persists_between_instances(tmp_path):
 
     ledger3 = EventLedger(path)
     assert ledger3.last_processed_offset == 4
+
+
+def test_build_graph_from_ledger_roundtrip(tmp_path):
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    ledger.append(
+        0,
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 1,
+            "node_id": "a",
+            "payload": {"node_id": "a"},
+        },
+    )
+    ledger.append(
+        1,
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 2,
+            "node_id": "b",
+            "payload": {"node_id": "b"},
+        },
+    )
+    ledger.append(
+        2,
+        {
+            "event_type": "CREATE_EDGE",
+            "timestamp": 3,
+            "node_id": "a",
+            "target_node_id": "b",
+            "label": "LINKS_TO",
+            "payload": {},
+        },
+    )
+
+    graph = build_graph_from_ledger(ledger)
+    assert set(graph.get_all_node_ids()) == {"a", "b"}
+    assert ("a", "b", "LINKS_TO") in graph.get_all_edges()


### PR DESCRIPTION
## Summary
- add build_graph_from_ledger check in event ledger tests
- verify graph reconstruction from ledger in CLI tests

## Testing
- `ruff check tests/test_event_ledger.py tests/test_cli_internal.py`
- `pytest tests/test_event_ledger.py::test_build_graph_from_ledger_roundtrip tests/test_cli_internal.py::test_build_graph_from_ledger_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad0fb42308326a72fe4bfb245405e