### PR TITLE
Add ledger replay CLI

### DIFF
--- a/src/ume/replay.py
+++ b/src/ume/replay.py
@@ -51,3 +51,34 @@ def build_graph_from_ledger(
         end_timestamp=end_timestamp,
     )
     return graph
+
+
+def graph_from_event_ledger(
+    *,
+    end_offset: int | None = None,
+    end_timestamp: int | None = None,
+    db_path: str | None = ":memory:",
+    graph: IGraphAdapter | None = None,
+) -> IGraphAdapter:
+    """Rebuild a graph from the global :data:`event_ledger`."""
+
+    from .event_ledger import event_ledger
+
+    return build_graph_from_ledger(
+        event_ledger,
+        graph=graph,
+        end_offset=end_offset,
+        end_timestamp=end_timestamp,
+        db_path=db_path,
+    )
+
+
+def snapshot_from_event_ledger(
+    *, end_offset: int | None = None, end_timestamp: int | None = None
+) -> dict[str, object]:
+    """Return a snapshot built from :data:`event_ledger`."""
+
+    graph = graph_from_event_ledger(
+        end_offset=end_offset, end_timestamp=end_timestamp
+    )
+    return graph.dump()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -566,6 +566,76 @@ def test_cli_snapshot_schedule(
         sys.modules.pop(mod, None)
 
 
+def test_cli_ledger_replay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    import importlib
+    import types
+    from ume.event_ledger import EventLedger
+
+    stub = types.ModuleType("ume")
+    stub.PersistentGraph = object
+    stub.RoleBasedGraphAdapter = object
+    stub.enable_snapshot_autosave_and_restore = lambda *_, **__: None
+    stub.parse_event = lambda *_: None
+    stub.apply_event_to_graph = lambda *_: None
+    stub.load_graph_into_existing = lambda *_: None
+    stub.snapshot_graph_to_file = lambda *_: None
+    stub.ProcessingError = Exception
+    stub.EventError = Exception
+    stub.SnapshotError = Exception
+    stub.IGraphAdapter = object
+    stub.log_audit_entry = lambda *_: None
+    stub.get_audit_entries = lambda *_: []
+    stub.DEFAULT_SCHEMA_MANAGER = object()
+    bench = types.ModuleType("ume.benchmarks")
+    bench.benchmark_vector_store = lambda *_: None
+    feder = types.ModuleType("ume.federation")
+    feder.MirrorMakerDriver = object  # type: ignore[assignment]
+    cli_pkg = types.ModuleType("ume.cli")
+    compose_pkg = types.ModuleType("ume.cli.compose")
+    compose_pkg._compose_down = lambda *_, **__: None
+    compose_pkg._compose_ps = lambda *_, **__: None
+    compose_pkg._quickstart = lambda *_, **__: None
+    cli_pkg.compose = compose_pkg
+    prompt_pkg = types.ModuleType("ume.cli.prompt")
+    prompt_pkg.UMEPrompt = object
+    prompt_pkg.create_graph_adapter = lambda *_, **__: None
+
+    event_mod = types.ModuleType("ume.event_ledger")
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    ledger.append(0, {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "a", "payload": {"node_id": "a"}})
+    event_mod.EventLedger = EventLedger
+    event_mod.event_ledger = ledger
+
+    sys.modules["ume"] = stub
+    sys.modules["ume.benchmarks"] = bench
+    sys.modules["ume.federation"] = feder
+    sys.modules["ume.cli"] = cli_pkg
+    sys.modules["ume.cli.compose"] = compose_pkg
+    sys.modules["ume.cli.prompt"] = prompt_pkg
+    sys.modules["ume.event_ledger"] = event_mod
+
+    import ume_cli as cli
+    importlib.reload(cli)
+
+    argv = sys.argv[:]
+    sys.argv = ["ume-cli", "ledger-replay", "--end-offset", "0"]
+    cli.main()
+    out = capsys.readouterr().out
+    sys.argv = argv
+
+    assert "\"a\"" in out
+
+    for mod in [
+        "ume.cli.compose",
+        "ume.cli",
+        "ume.federation",
+        "ume.benchmarks",
+        "ume.event_ledger",
+        "ume",
+    ]:
+        sys.modules.pop(mod, None)
+
+
 def test_cli_dossier_snapshot_schedule(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -26,6 +26,17 @@ from ume.cli.compose import (
 quickstart = _quickstart
 from ume.cli.prompt import UMEPrompt, create_graph_adapter
 
+
+def _ledger_replay(end_offset: int | None, end_timestamp: int | None) -> None:
+    """Print a graph snapshot reconstructed from the event ledger."""
+
+    from ume.replay import snapshot_from_event_ledger
+
+    snapshot = snapshot_from_event_ledger(
+        end_offset=end_offset, end_timestamp=end_timestamp
+    )
+    print(json.dumps(snapshot, indent=2))
+
 # Detect if a lightweight stub was injected for testing.
 _UME_STUB = not hasattr(ume, "__file__")
 
@@ -432,6 +443,12 @@ def main() -> None:
     )
     snap_parser.add_argument("--interval", type=int, default=60)
 
+    replay_parser = sub.add_parser(
+        "ledger-replay", help="Output a snapshot built from the ledger"
+    )
+    replay_parser.add_argument("--end-offset", type=int)
+    replay_parser.add_argument("--end-timestamp", type=int)
+
     dossier_parser = sub.add_parser("dossier", help="Manage dossiers")
     dossier_sub = dossier_parser.add_subparsers(dest="dossier_cmd")
     view_p = dossier_sub.add_parser("view", help="View a dossier")
@@ -531,6 +548,9 @@ def main() -> None:
             return
         if args.command == "snapshot-schedule":
             _snapshot_schedule(args.interval)
+            return
+        if args.command == "ledger-replay":
+            _ledger_replay(args.end_offset, args.end_timestamp)
             return
         if args.command == "dossier":
             if args.dossier_cmd == "view":


### PR DESCRIPTION
## Summary
- expose helper functions to rebuild graph from the default `event_ledger`
- add `ledger-replay` subcommand to `ume_cli.py` that prints a snapshot
- test CLI ledger replay command

## Testing
- `pre-commit run --files ume_cli.py src/ume/replay.py tests/test_cli_smoke.py`
- `pytest tests/test_cli_smoke.py::test_cli_ledger_replay -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad0fa9ca4832689ff7f7b9eb42b30