### PR TITLE
Support async adapters in vector routes

### DIFF
--- a/src/ume/vector_routes.py
+++ b/src/ume/vector_routes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, AsyncGenerator
 import asyncio
+import inspect
 import json
 import math
 import time
@@ -13,6 +14,7 @@ from pydantic import BaseModel
 from . import api_deps as deps
 from .vector_store import VectorStore
 from .graph_adapter import IGraphAdapter
+from .graph_routes import _maybe_call
 from . import embedding
 from .metrics import (
     RECALL_SCORE,
@@ -62,7 +64,7 @@ class SemanticSearchRequest(BaseModel):
 
 
 @router.post("/search/semantic")
-def api_semantic_search(
+async def api_semantic_search(
     req: SemanticSearchRequest,
     _: str = Depends(deps.get_current_role),
     store: VectorStore = Depends(deps.get_vector_store),
@@ -78,7 +80,9 @@ def api_semantic_search(
     ids = store.query(vector, k=req.k)
     nodes = []
     for node_id in ids:
-        attrs = graph.get_node(node_id)
+        attrs = await _maybe_call(graph, "get_node", node_id)
+        if inspect.isawaitable(attrs):
+            attrs = await attrs
         if attrs is not None:
             nodes.append({"id": node_id, "attributes": attrs})
     SEMANTIC_SEARCH_LATENCY.observe(time.perf_counter() - start)
@@ -86,7 +90,7 @@ def api_semantic_search(
 
 
 @router.get("/recall")
-def api_recall(
+async def api_recall(
     query: str | None = Query(None),
     vector: List[float] | None = Query(None),
     k: int = 5,
@@ -106,7 +110,9 @@ def api_recall(
     ids = store.query(vector, k=k)
     nodes = []
     for node_id in ids:
-        attrs = graph.get_node(node_id)
+        attrs = await _maybe_call(graph, "get_node", node_id)
+        if inspect.isawaitable(attrs):
+            attrs = await attrs
         if attrs is not None:
             emb = attrs.get("embedding")
             if isinstance(emb, list) and len(emb) == len(vector):
@@ -143,7 +149,9 @@ async def api_recall_stream(
         start = time.perf_counter()
         ids = store.query(vector, k=k)
         for node_id in ids:
-            attrs = graph.get_node(node_id)
+            attrs = await _maybe_call(graph, "get_node", node_id)
+            if inspect.isawaitable(attrs):
+                attrs = await attrs
             if attrs is not None:
                 emb = attrs.get("embedding")
                 if isinstance(emb, list) and len(emb) == len(vector):

--- a/tests/test_vector_api.py
+++ b/tests/test_vector_api.py
@@ -207,3 +207,55 @@ def test_recall_stream(store_cls, monkeypatch) -> None:
             assert res.status_code == 200
             lines = [line for line in res.iter_lines() if line.startswith("data:")]
         assert lines
+
+
+def test_semantic_search_async_adapter(store_cls, monkeypatch) -> None:
+    configure_vector_store(store_cls(dim=2, use_gpu=False))
+    from ume import MockGraph
+    from ume.api import configure_graph
+    from ume.async_graph_adapter import AsyncGraphAdapterWrapper
+
+    graph = AsyncGraphAdapterWrapper(MockGraph())
+    graph._adapter.add_node("a", {"val": 1})  # type: ignore[attr-defined]
+    configure_graph(graph)
+    store = app.state.vector_store
+    store.add("a", [1.0, 0.0])
+    monkeypatch.setattr("ume.embedding.generate_embedding", lambda q: [1.0, 0.0])
+    client = TestClient(app)
+    token = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    ).json()["access_token"]
+    res = client.post(
+        "/search/semantic",
+        json={"query": "foo", "k": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"nodes": [{"id": "a", "attributes": {"val": 1}}]}
+
+
+def test_recall_async_adapter(store_cls, monkeypatch) -> None:
+    configure_vector_store(store_cls(dim=2, use_gpu=False))
+    from ume import MockGraph
+    from ume.api import configure_graph
+    from ume.async_graph_adapter import AsyncGraphAdapterWrapper
+
+    graph = AsyncGraphAdapterWrapper(MockGraph())
+    graph._adapter.add_node("a", {"val": 1})  # type: ignore[attr-defined]
+    configure_graph(graph)
+    store = app.state.vector_store
+    store.add("a", [1.0, 0.0])
+    monkeypatch.setattr("ume.embedding.generate_embedding", lambda q: [1.0, 0.0])
+    client = TestClient(app)
+    token = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    ).json()["access_token"]
+    res = client.get(
+        "/recall",
+        params={"query": "foo", "k": 1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"nodes": [{"id": "a", "attributes": {"val": 1}}]}


### PR DESCRIPTION
## Summary
- wrap graph access with `_maybe_call`
- make vector search APIs async-compatible
- cover async graph adapters in tests

## Testing
- `pre-commit run --files src/ume/vector_routes.py tests/test_vector_api.py`
- `pytest tests/test_vector_api.py::test_semantic_search_async_adapter tests/test_vector_api.py::test_recall_async_adapter -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8a4879608326b3a51bdc702e51c6