### PR TITLE
Enforce ISO-8601 event timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The events exchanged in the demo have a simple JSON structure. Here's an example
 ```json
 {
   "event_type": "demo_event",
-  "timestamp": 1678886400,
+  "timestamp": "2024-03-15T12:00:00Z",
   "payload": {
     "message": "Hello from producer_demo!"
   },
@@ -100,7 +100,7 @@ The events exchanged in the demo have a simple JSON structure. Here's an example
 **Fields:**
 
 *   `event_type` (string): Describes the kind of event. In the demo, this is hardcoded to `"demo_event"`.
-*   `timestamp` (integer): A Unix timestamp (seconds since epoch) indicating when the event was generated.
+*   `timestamp` (string): ISO 8601 timestamp indicating when the event was generated.
 *   `payload` (object): A JSON object containing the actual data of the event. The structure of the payload can vary depending on the event type. For the demo, it includes a simple `message`.
 *   `correlationId` (string, optional): Identifier used to link related events.
 *   `subjectEntity` (string, optional): The entity this event relates to.
@@ -119,7 +119,7 @@ Used to create a new directed, labeled edge between two existing nodes.
 ```json
 {
   "event_type": "CREATE_EDGE",
-  "timestamp": 1678954321,
+  "timestamp": "2024-03-15T12:05:21Z",
   "event_id": "evt_edge_create_001",
   "source": "application_A",
   "node_id": "source_node_alpha",    // ID of the source node
@@ -130,7 +130,7 @@ Used to create a new directed, labeled edge between two existing nodes.
 ```
 **Required Fields in Data for `parse_event`:**
 *   `event_type`: Must be "CREATE_EDGE".
-*   `timestamp`: Integer Unix timestamp.
+*   `timestamp`: ISO 8601 timestamp string.
 *   `node_id`: String, ID of the source node.
 *   `target_node_id`: String, ID of the target node.
 *   `label`: String, label for the edge.
@@ -145,7 +145,7 @@ Used to remove a specific directed, labeled edge between two nodes.
 ```json
 {
   "event_type": "DELETE_EDGE",
-  "timestamp": 1678954322,
+  "timestamp": "2024-03-15T12:05:22Z",
   "event_id": "evt_edge_delete_001",
   "source": "application_B",
   "node_id": "source_node_alpha",    // ID of the source node
@@ -156,7 +156,7 @@ Used to remove a specific directed, labeled edge between two nodes.
 ```
 **Required Fields in Data for `parse_event`:**
 *   `event_type`: Must be "DELETE_EDGE".
-*   `timestamp`: Integer Unix timestamp.
+*   `timestamp`: ISO 8601 timestamp string.
 *   `node_id`: String, ID of the source node.
 *   `target_node_id`: String, ID of the target node.
 *   `label`: String, label of the edge.
@@ -486,7 +486,7 @@ Basic usage:
 from ume.integrations import LangGraph
 
 client = LangGraph()
-client.send_events([{"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1"}])
+client.send_events([{"event_type": "CREATE_NODE", "timestamp": "2024-01-01T00:00:00Z", "node_id": "n1"}])
 print(client.recall({"node_id": "n1"}))
 ```
 
@@ -560,7 +560,7 @@ body must follow the schema expected by `ume.parse_event`.
 curl -X POST http://localhost:8000/events \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -d '{"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {"node_id": "n1", "attributes": {"name": "demo"}}}'
+  -d '{"event_type": "CREATE_NODE", "timestamp": "2024-01-01T00:00:00Z", "node_id": "n1", "payload": {"node_id": "n1", "attributes": {"name": "demo"}}}'
 ```
 
 The event is validated and immediately applied to the configured graph adapter.
@@ -706,12 +706,12 @@ This section outlines the basic programmatic steps to interact with the UME comp
 2.  **Define Event Data Dictionaries:**
     Event data is typically prepared as Python dictionaries.
     ```python
-    import time # Required for timestamp
+    from datetime import datetime, timezone # Required for timestamp
 
     # Event to create node_A
     event_data_create_A = {
         "event_type": "CREATE_NODE",
-        "timestamp": int(time.time()),
+        "timestamp": "2024-01-01T00:00:00Z",
         "node_id": "node_A",  # Field used by CREATE_NODE for the node to create
         "payload": {"name": "Alpha Node", "type": "concept"},
         "source": "my_script",
@@ -723,7 +723,7 @@ This section outlines the basic programmatic steps to interact with the UME comp
     # Event to create node_B
     event_data_create_B = {
         "event_type": "CREATE_NODE",
-        "timestamp": int(time.time()) + 1,
+        "timestamp": "2024-01-01T00:00:01Z",
         "node_id": "node_B",  # Field used by CREATE_NODE for the node to create
         "payload": {"name": "Beta Node", "value": 42},
         "source": "my_script",
@@ -735,7 +735,7 @@ This section outlines the basic programmatic steps to interact with the UME comp
     # Event to create an edge from node_A to node_B
     event_data_create_edge_A_B = {
         "event_type": "CREATE_EDGE",
-        "timestamp": int(time.time()) + 2,
+        "timestamp": "2024-01-01T00:00:02Z",
         "node_id": "node_A",        # Source node for the edge
         "target_node_id": "node_B",  # Target node for the edge
         "label": "KNOWS",           # Label of the edge
@@ -907,7 +907,7 @@ with UMEClient(settings) as client:
     # Example event dictionary (CREATE_NODE)
     event = {
         "event_type": "CREATE_NODE",
-        "timestamp": int(time.time()),
+        "timestamp": "2024-01-01T00:00:00Z",
         "node_id": "demo_node",
         "payload": {"name": "Demo"},
         "source": "umeclient_example",

--- a/src/ume/cli/prompt.py
+++ b/src/ume/cli/prompt.py
@@ -7,6 +7,7 @@ import logging
 import shlex
 import sys
 import time
+from datetime import datetime, timezone, timedelta
 from cmd import Cmd
 from pathlib import Path
 
@@ -64,7 +65,7 @@ class UMEPrompt(Cmd):
             enable_snapshot_autosave_and_restore(
                 base_graph, settings.UME_SNAPSHOT_PATH, 24 * 3600
             )
-        self.current_timestamp = int(time.time())
+        self.current_timestamp = datetime.now(timezone.utc)
         self.peer_cluster: str | None = None
         self.mm_topics: list[str] = [settings.KAFKA_RAW_EVENTS_TOPIC]
         self.mm_driver: "MirrorMakerDriver | None" = None
@@ -76,9 +77,9 @@ class UMEPrompt(Cmd):
         except Exception as e:  # pragma: no cover - logging failure shouldn't crash
             logging.getLogger(__name__).error("Audit log failure: %s", e)
 
-    def _get_timestamp(self) -> int:
-        self.current_timestamp += 1
-        return self.current_timestamp
+    def _get_timestamp(self) -> str:
+        self.current_timestamp += timedelta(seconds=1)
+        return self.current_timestamp.isoformat()
 
     # ----- Node commands -----
     def do_new_node(self, arg: str) -> None:

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -74,8 +74,8 @@ def parse_event(data: Dict[str, Any]) -> Event:
 
     Args:
         data (Dict[str, Any]): A dictionary potentially representing an event.
-              Common expected keys: "eventType", "timestamp" (integer Unix
-              timestamp or ISO 8601 formatted string).
+              Common expected keys: "eventType", "timestamp" (ISO 8601
+              formatted string).
               Type-specific keys:
                 - For "CREATE_NODE", "UPDATE_NODE_ATTRIBUTES": "node_id" (str), "payload" (dict).
                 - For "CREATE_EDGE", "DELETE_EDGE": "node_id" (source, str),
@@ -118,24 +118,20 @@ def parse_event(data: Dict[str, Any]) -> Event:
         logger.error("Missing required event field: timestamp")
         raise EventError("Missing required event field: timestamp")
     timestamp_raw = data["timestamp"]
-    if isinstance(timestamp_raw, str):
-        try:
-            dt = datetime.fromisoformat(timestamp_raw.replace("Z", "+00:00"))
-        except ValueError:
-            msg = "Invalid timestamp format"
-            logger.error(msg)
-            raise EventError(msg)
-        timestamp_int = int(dt.timestamp())
-    elif isinstance(timestamp_raw, int):
-        timestamp_int = timestamp_raw
-    else:
+    if not isinstance(timestamp_raw, str):
         msg = (
-            "Invalid type for 'timestamp': expected int or ISO 8601 string, "
+            "Invalid type for 'timestamp': expected ISO 8601 string, "
             f"got {type(timestamp_raw).__name__}"
-
         )
         logger.error(msg)
         raise EventError(msg)
+    try:
+        dt = datetime.fromisoformat(timestamp_raw.replace("Z", "+00:00"))
+    except ValueError:
+        msg = "Invalid timestamp format"
+        logger.error(msg)
+        raise EventError(msg)
+    timestamp_int = int(dt.timestamp())
 
     # Validate optional event_id type
     event_id_val = data.get("eventId")

--- a/src/ume/watchers/dev_log_watcher.py
+++ b/src/ume/watchers/dev_log_watcher.py
@@ -4,6 +4,7 @@ import json
 import logging
 import signal
 import time
+from datetime import datetime, timezone
 from types import FrameType
 from pathlib import Path
 from typing import Iterable
@@ -32,7 +33,7 @@ class DevLogHandler(FileSystemEventHandler):  # type: ignore[misc]
         payload = {"path": event.src_path}
         evt = Event(
             event_type=EventType.CREATE_NODE,
-            timestamp=int(time.time()),
+            timestamp=datetime.now(timezone.utc).isoformat(),
             node_id=str(event.src_path),
             payload={"node_id": str(event.src_path), "attributes": payload},
         )

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,17 +1,18 @@
 # tests/test_event.py
 import pytest
-import time
 from datetime import datetime, timezone
 from ume import Event, EventType, parse_event, EventError  # EventType constants
+
+ISO_TS = datetime.now(timezone.utc).isoformat()
 
 
 def test_parse_event_valid():
     """Test parsing a valid event dictionary."""
-    timestamp_now = int(time.time())
+    ts = datetime.now(timezone.utc)
     event_data = {
         "eventId": "test-id-123",
         "eventType": "test_event",
-        "timestamp": timestamp_now,
+        "timestamp": ts.isoformat(),
         "payload": {"key": "value", "num": 123},
         "sourceService": "test_source",
         "correlationId": "c123",
@@ -21,7 +22,7 @@ def test_parse_event_valid():
     assert isinstance(event, Event)
     assert event.event_id == "test-id-123"
     assert event.event_type == "test_event"
-    assert event.timestamp == timestamp_now
+    assert event.timestamp == int(ts.timestamp())
     assert event.payload == {"key": "value", "num": 123}
     assert event.source == "test_source"
     assert event.correlation_id == "c123"
@@ -30,16 +31,16 @@ def test_parse_event_valid():
 
 def test_parse_event_minimal_valid():
     """Test parsing a minimal valid event dictionary (event_id and source generated)."""
-    timestamp_now = int(time.time())
+    ts = datetime.now(timezone.utc)
     event_data = {
         "eventType": "minimal_event",
-        "timestamp": timestamp_now,
+        "timestamp": ts.isoformat(),
         "payload": {"data": "minimal_data"},
     }
     event = parse_event(event_data)
     assert isinstance(event, Event)
     assert event.event_type == "minimal_event"
-    assert event.timestamp == timestamp_now
+    assert event.timestamp == int(ts.timestamp())
     assert event.payload == {"data": "minimal_data"}
     assert event.event_id is not None  # Should be auto-generated
     assert isinstance(event.event_id, str)
@@ -51,10 +52,10 @@ def test_parse_event_minimal_valid():
 
 def test_parse_event_custom_type():
     """Ensure custom event types parse without strict checks."""
-    timestamp_now = int(time.time())
+    ts = datetime.now(timezone.utc)
     data = {
         "eventType": "document.artifact.archived",
-        "timestamp": timestamp_now,
+        "timestamp": ts.isoformat(),
         "payload": {"archive": True},
     }
     event = parse_event(data)
@@ -64,11 +65,11 @@ def test_parse_event_custom_type():
 
 def test_parse_event_custom_type_minimal():
     """Unknown event types should parse with minimal required fields."""
-    ts = int(time.time())
-    data = {"eventType": "document.artifact.archived", "timestamp": ts}
+    ts = datetime.now(timezone.utc)
+    data = {"eventType": "document.artifact.archived", "timestamp": ts.isoformat()}
     event = parse_event(data)
     assert event.event_type == "document.artifact.archived"
-    assert event.timestamp == ts
+    assert event.timestamp == int(ts.timestamp())
     assert event.payload == {}
 
 
@@ -99,10 +100,10 @@ def test_parse_event_timestamp_iso8601_z():
 )
 def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
     """Test parsing valid CREATE_EDGE and DELETE_EDGE events."""
-    timestamp_now = int(time.time())
+    ts = datetime.now(timezone.utc)
     event_data = {
         "eventType": event_type.value,
-        "timestamp": timestamp_now,
+        "timestamp": ts.isoformat(),
         "node_id": "s1",  # Source node
         **extra_data,  # Adds target_node_id and label
         # payload is optional for these, parse_event defaults to {}
@@ -110,7 +111,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
     event = parse_event(event_data)
     assert isinstance(event, Event)
     assert event.event_type == event_type
-    assert event.timestamp == timestamp_now
+    assert event.timestamp == int(ts.timestamp())
     assert event.node_id == "s1"
     assert event.target_node_id == extra_data["target_node_id"]
     assert event.label == extra_data["label"]
@@ -131,7 +132,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         # Case 1: Missing all required fields
         ({}, "Missing required event field: eventType"),
         # Case 2: Missing 'event_type'
-        ({"timestamp": 123, "payload": {}}, "Missing required event field: eventType"),
+        ({"timestamp": ISO_TS, "payload": {}}, "Missing required event field: eventType"),
         # Case 3: Missing 'timestamp'
         (
             {"eventType": "test", "payload": {}},
@@ -139,12 +140,12 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         ),
         # Case 4: Missing 'payload' for CREATE_NODE
         (
-            {"eventType": "CREATE_NODE", "timestamp": 123, "node_id": "n1"},
+            {"eventType": "CREATE_NODE", "timestamp": ISO_TS, "node_id": "n1"},
             "Missing required field 'payload' for CREATE_NODE event.",
         ),
         # Case 5: Invalid type for 'eventType' (int instead of str)
         (
-            {"eventType": 123, "timestamp": int(time.time()), "payload": {}},
+            {"eventType": 123, "timestamp": ISO_TS, "payload": {}},
             "Invalid type for 'eventType'",
         ),
         # Case 6: Invalid timestamp format
@@ -157,7 +158,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "CREATE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "target_node_id": "t1",
                 "label": "L",
@@ -170,7 +171,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "CREATE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "label": "L",
             },
@@ -180,7 +181,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "CREATE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "target_node_id": "t1",
             },
@@ -190,7 +191,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "CREATE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "target_node_id": 123,
                 "label": "L",
@@ -201,7 +202,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "CREATE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "target_node_id": "t1",
                 "label": 123,
@@ -212,7 +213,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "CREATE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "target_node_id": "t1",
                 "label": "L",
             },
@@ -222,7 +223,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "CREATE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "target_node_id": "t1",
                 "label": "L",
@@ -235,7 +236,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "DELETE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "label": "L",
             },
@@ -245,7 +246,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "DELETE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "target_node_id": "t1",
             },
@@ -255,7 +256,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "DELETE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "target_node_id": 123,
                 "label": "L",
@@ -266,7 +267,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "DELETE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "target_node_id": "t1",
                 "label": 123,
@@ -277,7 +278,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "DELETE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "target_node_id": "t1",
                 "label": "L",
             },
@@ -287,7 +288,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "DELETE_EDGE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "s1",
                 "target_node_id": "t1",
                 "label": "L",
@@ -299,7 +300,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "CREATE_NODE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "n1",
                 "payload": "not-a-dict",
             },
@@ -308,7 +309,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "UPDATE_NODE_ATTRIBUTES",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "n1",
                 "payload": "not-a-dict",
             },
@@ -318,7 +319,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "CREATE_NODE",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "n1",
             },
             "Missing required field 'payload' for CREATE_NODE event",
@@ -326,7 +327,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "UPDATE_NODE_ATTRIBUTES",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "node_id": "n1",
             },
             "Missing required field 'payload' for UPDATE_NODE_ATTRIBUTES event",
@@ -335,7 +336,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "test",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "payload": {},
                 "eventId": 123,
             },
@@ -344,7 +345,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "test",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "payload": {},
                 "correlationId": 1,
             },
@@ -353,7 +354,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "test",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "payload": {},
                 "subjectEntity": 1,
             },
@@ -362,7 +363,7 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
         (
             {
                 "eventType": "test",
-                "timestamp": int(time.time()),
+                "timestamp": ISO_TS,
                 "payload": {},
                 "sourceService": 1,
             },
@@ -382,7 +383,7 @@ def test_parse_event_invalid_inputs(bad_input: dict, expected_message_part: str)
 
 def test_event_creation_default_id():
     """Test that Event dataclass generates a default UUID for event_id."""
-    event = Event(event_type="test", timestamp=int(time.time()), payload={})
+    event = Event(event_type="test", timestamp=ISO_TS, payload={})
     assert event.event_id is not None
     assert isinstance(event.event_id, str)
     # A simple check for UUID-like structure (36 chars, with hyphens)

--- a/tests/test_schema_utils.py
+++ b/tests/test_schema_utils.py
@@ -6,21 +6,21 @@ from ume.schema_utils import validate_event_dict
 def test_unknown_event_type_raises_validation_error():
     data = {
         "eventType": "UNKNOWN_EVENT",
-        "timestamp": 1,
+        "timestamp": "2024-01-01T00:00:00Z",
     }
     with pytest.raises(ValidationError):
         validate_event_dict(data)
 
 
 def test_validate_create_node_schema_success():
-    data = {"eventType": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}}
+    data = {"eventType": "CREATE_NODE", "timestamp": "2024-01-01T00:00:00Z", "node_id": "n1", "payload": {}}
     validate_event_dict(data)
 
 
 def test_validate_envelope_schema_success():
     data = {
         "schema_version": "1.0.0",
-        "event": {"eventType": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}},
+        "event": {"eventType": "CREATE_NODE", "timestamp": "2024-01-01T00:00:00Z", "node_id": "n1", "payload": {}},
     }
     validate_event_dict(data)
 
@@ -28,7 +28,7 @@ def test_validate_envelope_schema_success():
 def test_validate_envelope_schema_bad_version():
     data = {
         "schema_version": "not-a-version",
-        "event": {"eventType": "CREATE_NODE", "timestamp": 1, "node_id": "n1", "payload": {}},
+        "event": {"eventType": "CREATE_NODE", "timestamp": "2024-01-01T00:00:00Z", "node_id": "n1", "payload": {}},
     }
     with pytest.raises(ValidationError):
         validate_event_dict(data)


### PR DESCRIPTION
## Summary
- reject integer timestamps in `parse_event`
- adjust CLI timestamp generation
- make dev log watcher emit ISO-8601 timestamps
- fix tests for new timestamp format
- document ISO-8601 timestamps in README

## Testing
- `pre-commit run --files README.md src/ume/event.py src/ume/cli/prompt.py src/ume/watchers/dev_log_watcher.py tests/test_event.py tests/test_schema_utils.py`
- `pytest tests/test_event.py tests/test_schema_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8a4d2a608326a0bf9ac53a037e5b