### PR TITLE
Fix mypy warning for yaml import

### DIFF
--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -10,7 +10,7 @@ import json
 
 from filelock import FileLock
 
-import yaml
+import yaml  # type: ignore
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - typing import


### PR DESCRIPTION
## Summary
- suppress typing errors for yaml import
- run mypy to verify typing

## Testing
- `mypy --config-file mypy.ini`

------
https://chatgpt.com/codex/tasks/task_e_688bdce0535883269961e917de13859b