### PR TITLE
Remove old tokenization helper

### DIFF
--- a/src/ume/pipeline/privacy_agent.py
+++ b/src/ume/pipeline/privacy_agent.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any, Dict, Tuple, List, cast
-from ..utils import ssl_config, event_to_snake, event_to_camel, tokenize
+from ..utils import ssl_config, event_to_snake, event_to_camel
+from ..tokenization import tokenize
 from ..logging_utils import configure_logging
 
 from confluent_kafka import Consumer, Producer, KafkaException, KafkaError

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -5,7 +5,7 @@ from ._internal.listeners import get_registered_listeners
 from .plugins.alignment import get_plugins
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
 from .graph_schema import load_default_schema
-from .utils import tokenize
+from .tokenization import tokenize
 
 
 def _add_tokens(attrs: dict[str, object]) -> None:

--- a/src/ume/utils.py
+++ b/src/ume/utils.py
@@ -1,6 +1,5 @@
-from typing import Any, Dict, List
+from typing import Any, Dict
 import os
-import re
 
 
 def ssl_config() -> Dict[str, str]:
@@ -54,10 +53,4 @@ def event_to_camel(data: Dict[str, Any]) -> Dict[str, Any]:
     return out
 
 
-_TOKEN_RE = re.compile(r"\b\w+\b")
-
-
-def tokenize(text: str) -> List[str]:
-    """Return a list of lowercase tokens from ``text``."""
-    return _TOKEN_RE.findall(text.lower())
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -31,7 +31,7 @@ def test_apply_create_node_event_success(graph: PersistentGraph):
     apply_event_to_graph(event, graph)
     assert graph.node_exists(node_id)
     stored = graph.get_node(node_id)
-    assert stored == {**attributes, "tokens": ["test", "node"]}
+    assert stored == {**attributes, "tokens": ["Test", "Node"]}
     assert graph.node_count == 1
 
 
@@ -46,7 +46,7 @@ def test_create_node_adds_tokens_from_text(graph: PersistentGraph) -> None:
     apply_event_to_graph(event, graph)
     assert graph.get_node(node_id) == {
         "text": "Alpha Beta",
-        "tokens": ["alpha", "beta"],
+        "tokens": ["Alpha", "Beta"],
     }
 
 
@@ -132,7 +132,7 @@ def test_update_node_adds_tokens(graph: PersistentGraph) -> None:
         payload={"node_id": node_id, "attributes": {"content": "Hello world"}},
     )
     apply_event_to_graph(event, graph)
-    assert graph.get_node(node_id) == {"content": "Hello world", "tokens": ["hello", "world"]}
+    assert graph.get_node(node_id) == {"content": "Hello world", "tokens": ["Hello", "world"]}
 
 
 def test_apply_update_node_attributes_node_not_exists(graph: PersistentGraph):

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -1,0 +1,35 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+module_path = Path(__file__).resolve().parents[1] / "src" / "ume" / "tokenization.py"
+spec = importlib.util.spec_from_file_location("ume.tokenization", module_path)
+assert spec and spec.loader
+tokenization = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = tokenization
+spec.loader.exec_module(tokenization)
+
+def test_tokenize_without_tiktoken(monkeypatch):
+    monkeypatch.setattr(tokenization, "_tiktoken", None, raising=False)
+    assert tokenization.tokenize("Foo bar") == ["Foo", "bar"]
+
+def test_tokenize_with_tiktoken(monkeypatch):
+    calls = {}
+
+    class FakeEncoding:
+        def encode(self, text):
+            calls["encode"] = text
+            return [1, 2]
+
+        def decode(self, ids):
+            return {1: "foo", 2: "bar"}[ids[0]]
+
+    class FakeTiktoken:
+        def get_encoding(self, name):
+            calls["get_encoding"] = name
+            return FakeEncoding()
+
+    monkeypatch.setattr(tokenization, "_tiktoken", FakeTiktoken(), raising=False)
+    tokens = tokenization.tokenize("hello")
+    assert tokens == ["foo", "bar"]
+    assert calls == {"get_encoding": "cl100k_base", "encode": "hello"}


### PR DESCRIPTION
## Summary
- centralize tokenization logic under `ume.tokenization`
- update processing code to use new tokenizer
- delete legacy `tokenize` util
- adjust tests to match tokenization behavior
- add dedicated unit tests for tokenizer

## Testing
- `pre-commit run --files src/ume/processing.py src/ume/pipeline/privacy_agent.py src/ume/utils.py tests/test_processing.py tests/test_tokenization.py`
- `poetry run pytest -q tests/test_processing.py tests/test_tokenization.py`

------
https://chatgpt.com/codex/tasks/task_e_688bdcdf989c83269bc787a9f559ed38