### PR TITLE
Add documentsByTopic query

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -236,6 +236,15 @@ curl -X POST http://localhost:8000/graphql \
   -d '{"query":"{ edges { source target label } }"}'
 ```
 
+To list documents related to a topic (optionally filtered by entity):
+
+```bash
+curl -X POST http://localhost:8000/graphql \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ documentsByTopic(topic: \"t1\", entity: \"e1\") { id } }"}'
+```
+
 ### GET `/recall`
 Retrieve attribute data for the `k` nearest nodes to a query.
 

--- a/src/ume/dossier/__init__.py
+++ b/src/ume/dossier/__init__.py
@@ -10,7 +10,7 @@ import json
 
 from filelock import FileLock
 
-import yaml  # type: ignore
+import yaml
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - typing import

--- a/src/ume/graphql_api.py
+++ b/src/ume/graphql_api.py
@@ -64,6 +64,15 @@ class Query(graphene.ObjectType):
         since_timestamp=graphene.Int(),
         description="Find a path between two nodes",
     )
+    documents_by_topic = graphene.List(
+        NodeType,
+        topic=graphene.String(required=True),
+        entity=graphene.String(),
+        description=(
+            "Return document nodes connected to the given topic. "
+            "If `entity` is provided only documents linked to that entity are returned."
+        ),
+    )
 
     async def resolve_node(self, info: graphene.ResolveInfo, id: str) -> NodeType | None:
         graph = info.context["app"].state.graph
@@ -113,6 +122,34 @@ class Query(graphene.ObjectType):
             edge_label,
             since_timestamp,
         )
+
+    async def resolve_documents_by_topic(
+        self,
+        info: graphene.ResolveInfo,
+        topic: str,
+        entity: str | None = None,
+    ) -> list[NodeType]:
+        graph = info.context["app"].state.graph
+        if graph is None:
+            return []
+        try:
+            doc_ids = await _maybe_call(graph, "find_connected_nodes", topic)
+        except Exception:
+            return []
+        results: list[NodeType] = []
+        for doc_id in doc_ids:
+            data = await _maybe_call(graph, "get_node", doc_id)
+            if data is None:
+                continue
+            if entity is not None:
+                try:
+                    ents = await _maybe_call(graph, "find_connected_nodes", doc_id)
+                except Exception:
+                    continue
+                if entity not in ents:
+                    continue
+            results.append(NodeType(id=doc_id, attributes=data))
+        return results
 
 
 class CreateNode(graphene.Mutation):

--- a/tests/test_graphql_advanced.py
+++ b/tests/test_graphql_advanced.py
@@ -1,0 +1,42 @@
+from fastapi.testclient import TestClient
+from ume.api import app, configure_graph
+from ume import MockGraph
+
+
+def setup_module(_):
+    g = MockGraph()
+    g.add_node("t1", {})
+    g.add_node("doc1", {})
+    g.add_node("doc2", {})
+    g.add_node("e1", {})
+    g.add_edge("t1", "doc1", "RELATES_TO")
+    g.add_edge("t1", "doc2", "RELATES_TO")
+    g.add_edge("doc1", "e1", "ASSOCIATED_WITH")
+    configure_graph(g)
+
+
+def test_documents_by_topic() -> None:
+    client = TestClient(app)
+    query = "{ documentsByTopic(topic: \"t1\") { id } }"
+    res = client.post("/graphql", json={"query": query})
+    assert res.status_code == 200
+    ids = {d["id"] for d in res.json()["data"]["documentsByTopic"]}
+    assert ids == {"doc1", "doc2"}
+
+
+def test_documents_by_topic_filtered() -> None:
+    client = TestClient(app)
+    query = "{ documentsByTopic(topic: \"t1\", entity: \"e1\") { id } }"
+    res = client.post("/graphql", json={"query": query})
+    assert res.status_code == 200
+    data = res.json()["data"]["documentsByTopic"]
+    assert data == [{"id": "doc1"}]
+
+
+def test_documents_by_topic_missing() -> None:
+    client = TestClient(app)
+    query = "{ documentsByTopic(topic: \"missing\") { id } }"
+    res = client.post("/graphql", json={"query": query})
+    assert res.status_code == 200
+    assert res.json()["data"]["documentsByTopic"] == []
+


### PR DESCRIPTION
## Summary
- implement `documentsByTopic` query in GraphQL API
- document the new query in API reference
- fix unused type ignore in dossier module
- add tests for the query

## Testing
- `pre-commit run --files src/ume/graphql_api.py src/ume/dossier/__init__.py tests/test_graphql_advanced.py docs/API_REFERENCE.md`
- `pytest tests/test_graphql.py tests/test_graphql_advanced.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688be03e35cc8326b39d9fbd11628ce5