### PR TITLE
Add canonical schema validation

### DIFF
--- a/src/ume/schema_utils.py
+++ b/src/ume/schema_utils.py
@@ -11,6 +11,7 @@ from jsonschema import validate, ValidationError
 
 
 _ENVELOPE_SCHEMA: Dict[str, Any] | None = None
+_CANONICAL_SCHEMA: Dict[str, Any] | None = None
 
 
 _SCHEMAS: Dict[str, Dict[str, Any]] = {}
@@ -27,6 +28,19 @@ def _load_envelope_schema() -> Dict[str, Any]:
         ) as f:
             _ENVELOPE_SCHEMA = json.load(f)
     return _ENVELOPE_SCHEMA
+
+
+def _load_canonical_schema() -> Dict[str, Any]:
+    """Load JSON schema for canonical event fields."""
+    global _CANONICAL_SCHEMA
+    if _CANONICAL_SCHEMA is None:
+        with (
+            resources.files("ume.schemas")
+            .joinpath("canonical_event.schema.json")
+            .open("r", encoding="utf-8")
+        ) as f:
+            _CANONICAL_SCHEMA = json.load(f)
+    return _CANONICAL_SCHEMA
 
 
 def _load_schema(event_type: str) -> Dict[str, Any]:
@@ -59,6 +73,9 @@ def validate_event_dict(event_data: Dict[str, Any]) -> None:
         except InvalidVersion as exc:
             raise ValidationError("invalid schema_version") from exc
         event_data = event_data["event"]
+
+    # Validate canonical event fields before type-specific validation
+    validate(instance=event_data, schema=_load_canonical_schema())
 
     event_type = event_data.get("eventType")
     if not isinstance(event_type, str):

--- a/src/ume/schemas/canonical_event.schema.json
+++ b/src/ume/schemas/canonical_event.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UME Canonical Event",
+  "description": "Schema defining common fields for all UME events.",
+  "version": "1.0.0",
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Type of event"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the event occurred in ISO 8601 format"
+    },
+    "eventId": {
+      "type": "string",
+      "description": "Unique identifier for this event"
+    },
+    "correlationId": {
+      "type": "string",
+      "description": "Identifier linking related events"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {
+        "id": {"type": "string"},
+        "type": {"type": "string"}
+      },
+      "description": "Entity this event pertains to"
+    },
+    "sourceService": {
+      "type": "string",
+      "description": "Originating system of the event"
+    },
+    "payload": {
+      "type": "object",
+      "description": "Event payload"
+    }
+  },
+  "required": ["eventType", "timestamp"]
+}

--- a/tests/test_schema_utils.py
+++ b/tests/test_schema_utils.py
@@ -32,3 +32,42 @@ def test_validate_envelope_schema_bad_version():
     }
     with pytest.raises(ValidationError):
         validate_event_dict(data)
+
+
+def test_canonical_schema_optional_fields_valid():
+    data = {
+        "eventType": "UNKNOWN_EVENT",
+        "timestamp": "2024-01-01T00:00:00Z",
+        "eventId": "e1",
+        "correlationId": "c1",
+        "subjectEntity": {"id": "u1", "type": "user"},
+        "sourceService": "svc",
+        "payload": {},
+    }
+    with pytest.raises(ValidationError) as exc:
+        validate_event_dict(data)
+    assert "Unknown event_type" in str(exc.value)
+
+
+def test_canonical_schema_invalid_payload_type(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    def fake_validate(instance: dict, schema: dict) -> None:  # type: ignore[override]
+        calls.append(schema)
+        if schema.get("title") == "UME Canonical Event" and not isinstance(
+            instance.get("payload"), dict
+        ):
+            raise ValidationError("payload error")
+
+    monkeypatch.setattr("ume.schema_utils.validate", fake_validate)
+
+    data = {
+        "eventType": "UNKNOWN_EVENT",
+        "timestamp": "2024-01-01T00:00:00Z",
+        "payload": "not-a-dict",
+    }
+    with pytest.raises(ValidationError) as exc:
+        validate_event_dict(data)
+
+    assert "payload error" in str(exc.value)
+    assert any(s.get("title") == "UME Canonical Event" for s in calls)


### PR DESCRIPTION
## Summary
- add canonical event schema to centralize common event fields
- load new canonical schema in `validate_event_dict`
- ensure canonical schema is applied with new unit tests

## Testing
- `ruff check src/ume/schema_utils.py tests/test_schema_utils.py src/ume/schemas/canonical_event.schema.json`
- `mypy src/ume/schema_utils.py tests/test_schema_utils.py`
- `pytest tests/test_schema_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc26f5d9083268feb3b96a1f6a1ea