### PR TITLE
Add new event types and handlers

### DIFF
--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -17,6 +17,10 @@ class EventType(str, Enum):
     CREATE_EDGE = "CREATE_EDGE"
     DELETE_EDGE = "DELETE_EDGE"
     CREATE_ONTOLOGY_RELATION = "CREATE_ONTOLOGY_RELATION"
+    RESEARCH_JOB_STARTED = "RESEARCH_JOB_STARTED"
+    DATA_SOURCE_QUERIED = "DATA_SOURCE_QUERIED"
+    ENTITY_DISCOVERED = "ENTITY_DISCOVERED"
+    DOCUMENT_ARCHIVED = "DOCUMENT_ARCHIVED"
 
 
 @dataclass(frozen=True)
@@ -188,6 +192,8 @@ def parse_event(data: Dict[str, Any]) -> Event:
     if event_type in [
         EventType.CREATE_NODE,
         EventType.UPDATE_NODE_ATTRIBUTES,
+        EventType.RESEARCH_JOB_STARTED,
+        EventType.DOCUMENT_ARCHIVED,
     ]:
         if "node_id" not in data:  # Must be present in data
             msg = f"Missing required field 'node_id' for {event_type_str} event."
@@ -213,6 +219,8 @@ def parse_event(data: Dict[str, Any]) -> Event:
         EventType.CREATE_EDGE,
         EventType.DELETE_EDGE,
         EventType.CREATE_ONTOLOGY_RELATION,
+        EventType.DATA_SOURCE_QUERIED,
+        EventType.ENTITY_DISCOVERED,
     ]:
         required_fields_for_edge = {"node_id", "target_node_id", "label"}
         missing_fields = required_fields_for_edge - data.keys()

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -9,7 +9,7 @@ from confluent_kafka import Consumer, KafkaException, KafkaError
 from jsonschema import ValidationError
 
 from ..config import settings
-from ..utils import ssl_config, event_to_snake, event_to_camel
+from ..utils import ssl_config, event_to_snake
 from ..event import parse_event, EventError, EventType
 from ..processing import apply_event_to_graph, ProcessingError
 from ..schema_utils import validate_event_dict
@@ -25,6 +25,8 @@ BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
 NODE_TOPIC = settings.KAFKA_NODE_TOPIC
 EDGE_TOPIC = settings.KAFKA_EDGE_TOPIC
 DEFAULT_GROUP_ID = settings.KAFKA_GROUP_ID
+# Include newly introduced event types such as RESEARCH_JOB_STARTED and
+# ENTITY_DISCOVERED so the consumer treats them as first-class events.
 VALID_EVENT_TYPES = {e.value for e in EventType}
 
 
@@ -81,15 +83,14 @@ def run_graph_consumer(
                     validation_data["eventType"] = validation_data.pop("event_type")
                 validate_event_dict(validation_data)
                 payload = data["event"] if "event" in data else data
-                payload_camel = event_to_camel(payload)
-                event = parse_event(payload_camel)
+                event = parse_event(payload)
             except (json.JSONDecodeError, EventError) as exc:
                 logger.error("Invalid event skipped: %s", exc)
                 continue
 
             if event.event_type not in VALID_EVENT_TYPES:
                 try:
-                    event_ledger.append(msg.offset(), payload_camel)
+                    event_ledger.append(msg.offset(), payload)
                 except ValueError as exc:  # pragma: no cover - unlikely duplicate offset
                     logger.error("Ledger append failed: %s", exc)
                 try:

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -40,9 +40,14 @@ def apply_event_to_graph(
       `node_id` (str) and `attributes` (dict).
     - "UPDATE_NODE_ATTRIBUTES": Updates an existing node's attributes. Requires
       `event.payload` to contain `node_id` (str) and `attributes` (non-empty dict).
+    - "RESEARCH_JOB_STARTED": Alias of CREATE_NODE for job nodes.
+    - "DOCUMENT_ARCHIVED": Alias of UPDATE_NODE_ATTRIBUTES, marking a document archived.
     - "CREATE_EDGE": Creates a directed, labeled edge between two existing nodes.
       Requires `event.node_id` (source), `event.target_node_id` (target), and
       `event.label` (all strings).
+    - "DATA_SOURCE_QUERIED": Alias of CREATE_EDGE for connecting jobs to data sources.
+    - "ENTITY_DISCOVERED": Creates a node for the discovered entity (if needed)
+      and an edge from the job to that entity.
     - "DELETE_EDGE": Removes a specific edge. Requires `event.node_id` (source),
       `event.target_node_id` (target), and `event.label` (all strings).
 
@@ -62,7 +67,7 @@ def apply_event_to_graph(
     """
     for plugin in get_plugins():
         plugin.validate(event)
-    if event.event_type == EventType.CREATE_NODE:
+    if event.event_type in (EventType.CREATE_NODE, EventType.RESEARCH_JOB_STARTED):
         node_id = event.payload.get("node_id")
         if not node_id:
             raise ProcessingError(
@@ -94,7 +99,7 @@ def apply_event_to_graph(
         for listener in get_registered_listeners():
             listener.on_node_created(node_id, attributes)
 
-    elif event.event_type == EventType.UPDATE_NODE_ATTRIBUTES:
+    elif event.event_type in (EventType.UPDATE_NODE_ATTRIBUTES, EventType.DOCUMENT_ARCHIVED):
         node_id = event.payload.get("node_id")
         if not node_id:
             raise ProcessingError(
@@ -115,6 +120,8 @@ def apply_event_to_graph(
             raise ProcessingError(
                 f"'attributes' must be a dictionary for UPDATE_NODE_ATTRIBUTES event: {event.event_id}"
             )
+        if event.event_type == EventType.DOCUMENT_ARCHIVED and "archived" not in attributes:
+            attributes["archived"] = True
         if not attributes:
             raise ProcessingError(
                 f"'attributes' dictionary cannot be empty for UPDATE_NODE_ATTRIBUTES event: {event.event_id}"
@@ -126,7 +133,7 @@ def apply_event_to_graph(
         for listener in get_registered_listeners():
             listener.on_node_updated(node_id, attributes)
 
-    elif event.event_type == EventType.CREATE_EDGE:
+    elif event.event_type in (EventType.CREATE_EDGE, EventType.DATA_SOURCE_QUERIED, EventType.ENTITY_DISCOVERED):
         # parse_event should have validated presence and type of node_id, target_node_id, label
         source_node_id = event.node_id
         target_node_id = event.target_node_id
@@ -152,6 +159,16 @@ def apply_event_to_graph(
         assert isinstance(label, str)
         schema = DEFAULT_SCHEMA_MANAGER.get_schema(schema_version)
         schema.validate_edge_label(label)
+        if event.event_type == EventType.ENTITY_DISCOVERED and not graph.node_exists(target_node_id):
+            attrs = event.payload.get("attributes", {})
+            if not isinstance(attrs, dict):
+                raise ProcessingError(
+                    f"'attributes' must be a dictionary for ENTITY_DISCOVERED event: {event.event_id}"
+                )
+            _add_tokens(attrs)
+            graph.add_node(target_node_id, attrs)
+            for listener in get_registered_listeners():
+                listener.on_node_created(target_node_id, attrs)
         graph.add_edge(source_node_id, target_node_id, label)
         for listener in get_registered_listeners():
             listener.on_edge_created(source_node_id, target_node_id, label)

--- a/src/ume/schemas/data_source_queried.schema.json
+++ b/src/ume/schemas/data_source_queried.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DATA_SOURCE_QUERIED event",
+  "description": "Schema for DATA_SOURCE_QUERIED events emitted by UME producers.",
+  "version": "1.0.0",
+  "type": "object",
+  "required": ["eventType", "timestamp", "node_id", "target_node_id", "label"],
+  "properties": {
+    "eventType": {"type": "string", "minLength": 1, "description": "Type of event"},
+    "timestamp": {"type": "string", "format": "date-time", "description": "Timestamp when the event occurred in ISO 8601 format"},
+    "eventId": {"type": "string", "description": "Unique identifier for this event"},
+    "correlationId": {"type": "string", "description": "Identifier linking related events"},
+    "subjectEntity": {"type": "object", "required": ["id", "type"], "properties": {"id": {"type": "string"}, "type": {"type": "string"}}, "description": "Entity this event pertains to"},
+    "sourceService": {"type": "string", "description": "Originating system of the event"},
+    "node_id": {"type": "string", "description": "Job node identifier"},
+    "target_node_id": {"type": "string", "description": "Data source identifier"},
+    "label": {"type": "string", "description": "Edge label"},
+    "payload": {"type": "object", "description": "Optional edge attributes", "default": {}}
+  }
+}

--- a/src/ume/schemas/document_archived.schema.json
+++ b/src/ume/schemas/document_archived.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DOCUMENT_ARCHIVED event",
+  "description": "Schema for DOCUMENT_ARCHIVED events emitted by UME producers.",
+  "version": "1.0.0",
+  "type": "object",
+  "required": ["eventType", "timestamp", "node_id", "payload"],
+  "properties": {
+    "eventType": {"type": "string", "minLength": 1, "description": "Type of event"},
+    "timestamp": {"type": "string", "format": "date-time", "description": "Timestamp when the event occurred in ISO 8601 format"},
+    "eventId": {"type": "string", "description": "Unique identifier for this event"},
+    "correlationId": {"type": "string", "description": "Identifier linking related events"},
+    "subjectEntity": {"type": "object", "required": ["id", "type"], "properties": {"id": {"type": "string"}, "type": {"type": "string"}}, "description": "Entity this event pertains to"},
+    "sourceService": {"type": "string", "description": "Originating system of the event"},
+    "node_id": {"type": "string", "description": "Identifier of the document node"},
+    "payload": {"type": "object", "description": "Attributes to merge into the node"},
+    "target_node_id": {"type": "string", "description": "Unused for this event type"},
+    "label": {"type": "string", "description": "Unused for this event type"}
+  }
+}

--- a/src/ume/schemas/entity_discovered.schema.json
+++ b/src/ume/schemas/entity_discovered.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ENTITY_DISCOVERED event",
+  "description": "Schema for ENTITY_DISCOVERED events emitted by UME producers.",
+  "version": "1.0.0",
+  "type": "object",
+  "required": ["eventType", "timestamp", "node_id", "target_node_id", "label", "payload"],
+  "properties": {
+    "eventType": {"type": "string", "minLength": 1, "description": "Type of event"},
+    "timestamp": {"type": "string", "format": "date-time", "description": "Timestamp when the event occurred in ISO 8601 format"},
+    "eventId": {"type": "string", "description": "Unique identifier for this event"},
+    "correlationId": {"type": "string", "description": "Identifier linking related events"},
+    "subjectEntity": {"type": "object", "required": ["id", "type"], "properties": {"id": {"type": "string"}, "type": {"type": "string"}}, "description": "Entity this event pertains to"},
+    "sourceService": {"type": "string", "description": "Originating system of the event"},
+    "node_id": {"type": "string", "description": "Job node identifier"},
+    "target_node_id": {"type": "string", "description": "Discovered entity identifier"},
+    "label": {"type": "string", "description": "Edge label"},
+    "payload": {"type": "object", "description": "Attributes for the discovered entity"}
+  }
+}

--- a/src/ume/schemas/research_job_started.schema.json
+++ b/src/ume/schemas/research_job_started.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RESEARCH_JOB_STARTED event",
+  "description": "Schema for RESEARCH_JOB_STARTED events emitted by UME producers.",
+  "version": "1.0.0",
+  "type": "object",
+  "required": ["eventType", "timestamp", "node_id", "payload"],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Type of event"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the event occurred in ISO 8601 format"
+    },
+    "eventId": {"type": "string", "description": "Unique identifier for this event"},
+    "correlationId": {"type": "string", "description": "Identifier linking related events"},
+    "subjectEntity": {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {"id": {"type": "string"}, "type": {"type": "string"}},
+      "description": "Entity this event pertains to"
+    },
+    "sourceService": {"type": "string", "description": "Originating system of the event"},
+    "node_id": {"type": "string", "description": "Identifier of the job node"},
+    "payload": {"type": "object", "description": "Attributes for the job node"},
+    "target_node_id": {"type": "string", "description": "Unused for this event type"},
+    "label": {"type": "string", "description": "Unused for this event type"}
+  }
+}

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -118,6 +118,69 @@ def test_parse_event_valid_edge_events(event_type: EventType, extra_data: dict):
     assert event.payload == {}  # Default empty payload
 
 
+def test_parse_event_research_job_started() -> None:
+    ts = datetime.now(timezone.utc)
+    data = {
+        "eventType": EventType.RESEARCH_JOB_STARTED.value,
+        "timestamp": ts.isoformat(),
+        "node_id": "job1",
+        "payload": {"node_id": "job1", "attributes": {"status": "started"}},
+    }
+    event = parse_event(data)
+    assert event.event_type == EventType.RESEARCH_JOB_STARTED
+    assert event.node_id == "job1"
+    assert event.payload == {"node_id": "job1", "attributes": {"status": "started"}}
+
+
+def test_parse_event_data_source_queried() -> None:
+    ts = datetime.now(timezone.utc)
+    data = {
+        "eventType": EventType.DATA_SOURCE_QUERIED.value,
+        "timestamp": ts.isoformat(),
+        "node_id": "job1",
+        "target_node_id": "ds1",
+        "label": "QUERIED",
+    }
+    event = parse_event(data)
+    assert event.event_type == EventType.DATA_SOURCE_QUERIED
+    assert event.node_id == "job1"
+    assert event.target_node_id == "ds1"
+    assert event.label == "QUERIED"
+    assert event.payload == {}
+
+
+def test_parse_event_entity_discovered() -> None:
+    ts = datetime.now(timezone.utc)
+    data = {
+        "eventType": EventType.ENTITY_DISCOVERED.value,
+        "timestamp": ts.isoformat(),
+        "node_id": "job1",
+        "target_node_id": "ent1",
+        "label": "DISCOVERED",
+        "payload": {"attributes": {"name": "E1"}},
+    }
+    event = parse_event(data)
+    assert event.event_type == EventType.ENTITY_DISCOVERED
+    assert event.node_id == "job1"
+    assert event.target_node_id == "ent1"
+    assert event.label == "DISCOVERED"
+    assert event.payload == {"attributes": {"name": "E1"}}
+
+
+def test_parse_event_document_archived() -> None:
+    ts = datetime.now(timezone.utc)
+    data = {
+        "eventType": EventType.DOCUMENT_ARCHIVED.value,
+        "timestamp": ts.isoformat(),
+        "node_id": "doc1",
+        "payload": {"node_id": "doc1", "attributes": {"archived": True}},
+    }
+    event = parse_event(data)
+    assert event.event_type == EventType.DOCUMENT_ARCHIVED
+    assert event.node_id == "doc1"
+    assert event.payload == {"node_id": "doc1", "attributes": {"archived": True}}
+
+
 # The following tests are now covered by test_parse_event_invalid_inputs:
 # - test_parse_event_missing_required_field
 # - test_parse_event_missing_multiple_required_fields

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -405,3 +405,64 @@ def test_apply_delete_edge_event_invalid_field_types_propagates_error(
         ProcessingError, match="Invalid event structure for DELETE_EDGE"
     ):
         apply_event_to_graph(event_bad_label_type, graph)
+
+
+def test_apply_research_job_started_creates_node(graph: PersistentGraph) -> None:
+    event = Event(
+        event_type=EventType.RESEARCH_JOB_STARTED,
+        timestamp=int(time.time()),
+        payload={"node_id": "job1", "attributes": {"status": "started"}},
+    )
+    apply_event_to_graph(event, graph)
+    assert graph.node_exists("job1")
+    assert graph.get_node("job1") == {"status": "started"}
+
+
+def test_apply_data_source_queried_adds_edge(graph: PersistentGraph, monkeypatch: pytest.MonkeyPatch) -> None:
+    from ume.graph_schema import GraphSchema, EdgeLabel
+    from ume.schema_manager import DEFAULT_SCHEMA_MANAGER
+    schema = GraphSchema(version="1.0.0", edge_labels={"RELATES_TO": EdgeLabel("RELATES_TO", "1.0.0")})
+    monkeypatch.setattr(DEFAULT_SCHEMA_MANAGER, "get_schema", lambda v: schema)
+    graph.add_node("job1", {})
+    graph.add_node("ds1", {})
+    event = Event(
+        event_type=EventType.DATA_SOURCE_QUERIED,
+        timestamp=int(time.time()),
+        node_id="job1",
+        target_node_id="ds1",
+        label="RELATES_TO",
+        payload={},
+    )
+    apply_event_to_graph(event, graph)
+    assert ("job1", "ds1", "RELATES_TO") in graph.get_all_edges()
+
+
+def test_apply_entity_discovered_creates_node_and_edge(graph: PersistentGraph, monkeypatch: pytest.MonkeyPatch) -> None:
+    from ume.graph_schema import GraphSchema, EdgeLabel
+    from ume.schema_manager import DEFAULT_SCHEMA_MANAGER
+    schema = GraphSchema(version="1.0.0", edge_labels={"RELATES_TO": EdgeLabel("RELATES_TO", "1.0.0")})
+    monkeypatch.setattr(DEFAULT_SCHEMA_MANAGER, "get_schema", lambda v: schema)
+    graph.add_node("job1", {})
+    event = Event(
+        event_type=EventType.ENTITY_DISCOVERED,
+        timestamp=int(time.time()),
+        node_id="job1",
+        target_node_id="ent1",
+        label="RELATES_TO",
+        payload={"attributes": {"name": "E1"}},
+    )
+    apply_event_to_graph(event, graph)
+    assert graph.node_exists("ent1")
+    assert graph.get_node("ent1") == {"name": "E1", "tokens": ["E1"]}
+    assert ("job1", "ent1", "RELATES_TO") in graph.get_all_edges()
+
+
+def test_apply_document_archived_updates_node(graph: PersistentGraph) -> None:
+    graph.add_node("doc1", {"title": "D"})
+    event = Event(
+        event_type=EventType.DOCUMENT_ARCHIVED,
+        timestamp=int(time.time()),
+        payload={"node_id": "doc1", "attributes": {}},
+    )
+    apply_event_to_graph(event, graph)
+    assert graph.get_node("doc1") == {"title": "D", "archived": True}


### PR DESCRIPTION
## Summary
- add new event types in `EventType`
- handle new events in `apply_event_to_graph`
- parse payloads directly in `graph_consumer`
- define JSON schemas for the added events
- test parsing and processing of the new events

## Testing
- `ruff check .`
- `mypy --config-file mypy.ini --strict`
- `pytest tests/test_event.py::test_parse_event_research_job_started tests/test_event.py::test_parse_event_data_source_queried tests/test_event.py::test_parse_event_entity_discovered tests/test_event.py::test_parse_event_document_archived tests/test_processing.py::test_apply_research_job_started_creates_node tests/test_processing.py::test_apply_data_source_queried_adds_edge tests/test_processing.py::test_apply_entity_discovered_creates_node_and_edge tests/test_processing.py::test_apply_document_archived_updates_node -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc26f6934832697b3a9c01b243fff