### PR TITLE
Add Milvus backend integration tests

### DIFF
--- a/tests/compose/README.md
+++ b/tests/compose/README.md
@@ -1,0 +1,3 @@
+The integration tests require Docker to pull the official `milvusdb/milvus` image.
+Ensure `testcontainers` and `pymilvus` are installed so that the Milvus container
+can be started during testing.

--- a/tests/test_vector_backends.py
+++ b/tests/test_vector_backends.py
@@ -19,8 +19,11 @@ def milvus_available() -> bool:
         return False
 
 
+import os
+
 pytestmark = pytest.mark.skipif(
-    not milvus_available(), reason="Milvus server not available"
+    not milvus_available() and not os.environ.get("UME_DOCKER_TESTS"),
+    reason="Milvus server not available",
 )
 
 from ume.vector_store import VectorBackend
@@ -95,3 +98,63 @@ def test_close_calls_client_close() -> None:
     backend = MilvusBackend(client)
     backend.close()
     client.close.assert_called_once_with()
+
+
+import os
+import importlib.util
+from pathlib import Path
+import time
+
+from ume.vector_backends import MilvusBackend as RealMilvusBackend
+
+
+def _real_testcontainers_available() -> bool:
+    spec = importlib.util.find_spec("testcontainers")
+    if spec is None:
+        return False
+    return "src/testcontainers" not in str(Path(spec.origin).resolve())
+
+
+def _pymilvus_available() -> bool:
+    return importlib.util.find_spec("pymilvus") is not None
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("UME_DOCKER_TESTS"), reason="Docker tests disabled")
+def test_milvus_backend_add_query_delete() -> None:
+    if not _real_testcontainers_available() or not _pymilvus_available():
+        pytest.skip("testcontainers or pymilvus not available")
+
+    from testcontainers.core.container import DockerContainer
+
+    image = "milvusdb/milvus:v2.4.0"
+    container = DockerContainer(image).with_exposed_ports(19530)
+    try:
+        container.start()
+    except Exception as exc:  # pragma: no cover - environment issues
+        pytest.skip(f"Milvus container not available: {exc}")
+
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(19530)
+    uri = f"{host}:{port}"
+
+    from pymilvus import MilvusClient
+
+    for _ in range(30):
+        try:
+            client = MilvusClient(uri=uri)
+            client.list_collections()
+            break
+        except Exception:
+            time.sleep(1)
+    else:
+        container.stop()
+        pytest.skip("Milvus failed to start")
+
+    backend = RealMilvusBackend(dim=2, uri=uri, collection="test_vectors")
+    backend.add("a", [0.1, 0.2], persist=True)
+    assert backend.query([0.1, 0.2], k=1) == ["a"]
+    backend.delete("a")
+    assert backend.query([0.1, 0.2], k=1) == []
+    backend.close()
+    container.stop()


### PR DESCRIPTION
## Summary
- test MilvusBackend against a Milvus docker container when available
- document Milvus container requirement for integration tests

## Testing
- `pre-commit run --files tests/test_vector_backends.py tests/compose/README.md`
- `pytest tests/test_vector_backends.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd3f0836c8326bc017c3940112605