### PR TITLE
Add research job path example and schema docs

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -245,6 +245,16 @@ curl -X POST http://localhost:8000/graphql \
   -d '{"query":"{ documentsByTopic(topic: \"t1\", entity: \"e1\") { id } }"}'
 ```
 
+To locate documents gathered by a research job you can query the path from the
+topic node through the job to a document:
+
+```bash
+curl -X POST http://localhost:8000/graphql \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"{ path(source: \"t1\", target: \"doc3\", maxDepth: 2) }"}'
+```
+
 ### GET `/recall`
 Retrieve attribute data for the `k` nearest nodes to a query.
 

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -32,11 +32,19 @@ Properties:
 - `payload` *(object)*: Raw or processed perceptual data.
   Example: `{"image": "base64..."}`.
 
+### NewType
+Represents an additional concept introduced in schema version `2.0.0`.
+
+Properties:
+- `type_id` *(string, required)*: Unique identifier for the new entity.
+- Other attributes depend on the producer.
+
 ## Edge Labels
 
 - `REMEMBERS`: connects a `UserMemory` node to an `AgentIntent` that created it.
 - `ASSOCIATED_WITH`: Generic association between any two nodes.
 - `CAUSES`: Expresses a causal relationship from one event or context to another.
+- `NEW_LABEL`: Links research job nodes to the documents they discover.
 
 Example edge creation event:
 

--- a/tests/test_graphql_advanced.py
+++ b/tests/test_graphql_advanced.py
@@ -40,3 +40,19 @@ def test_documents_by_topic_missing() -> None:
     assert res.status_code == 200
     assert res.json()["data"]["documentsByTopic"] == []
 
+
+def test_path_via_research_job() -> None:
+    g = MockGraph()
+    g.add_node("t1", {})
+    g.add_node("job1", {})
+    g.add_node("doc3", {})
+    g.add_edge("t1", "job1", "RELATES_TO")
+    g.add_edge("job1", "doc3", "RELATES_TO")
+    configure_graph(g)
+
+    client = TestClient(app)
+    query = "{ path(source: \"t1\", target: \"doc3\", maxDepth: 2) }"
+    res = client.post("/graphql", json={"query": query})
+    assert res.status_code == 200
+    assert res.json()["data"]["path"] == ["t1", "job1", "doc3"]
+


### PR DESCRIPTION
## Summary
- document how to query documents discovered by a research job
- mention new node and edge types in graph schema docs
- test GraphQL path query for research job scenario

## Testing
- `pre-commit run --files docs/API_REFERENCE.md docs/GRAPH_MODEL.md tests/test_graphql_advanced.py`
- `pytest tests/test_event.py tests/test_processing.py tests/test_graphql.py tests/test_graphql_advanced.py --cov=ume --cov-fail-under=30`

------
https://chatgpt.com/codex/tasks/task_e_688cdc2c7de483269a6ec098a59df1d1