### PR TITLE
Add canonical schema validation tests

### DIFF
--- a/src/ume/schema_utils.py
+++ b/src/ume/schema_utils.py
@@ -62,8 +62,11 @@ def _load_schema(event_type: str) -> Dict[str, Any]:
 def validate_event_dict(event_data: Dict[str, Any]) -> None:
     """Validate a raw event dictionary or envelope against its JSON schema.
 
-    Updated schemas include optional ``correlationId``, ``subjectEntity`` and
-    ``sourceService`` fields which will also be validated when present.
+    The function first validates the event against the canonical event schema,
+    ensuring common fields like ``eventId`` and ``sourceService`` conform before
+    applying the event-type specific schema. Updated schemas include optional
+    ``correlationId``, ``subjectEntity`` and ``sourceService`` fields which will
+    also be validated when present.
     """
     if "event" in event_data and "schema_version" in event_data:
         validate(instance=event_data, schema=_load_envelope_schema())

--- a/tests/test_schema_utils.py
+++ b/tests/test_schema_utils.py
@@ -71,3 +71,31 @@ def test_canonical_schema_invalid_payload_type(monkeypatch):
 
     assert "payload error" in str(exc.value)
     assert any(s.get("title") == "UME Canonical Event" for s in calls)
+
+
+def test_canonical_schema_missing_event_type(monkeypatch):
+    """Missing eventType should trigger canonical schema validation."""
+
+    def fake_validate(instance: dict, schema: dict) -> None:  # type: ignore[override]
+        if schema.get("title") == "UME Canonical Event" and "eventType" not in instance:
+            raise ValidationError("eventType required")
+
+    monkeypatch.setattr("ume.schema_utils.validate", fake_validate)
+
+    data = {"timestamp": "2024-01-01T00:00:00Z"}
+    with pytest.raises(ValidationError):
+        validate_event_dict(data)
+
+
+def test_canonical_schema_missing_timestamp(monkeypatch):
+    """Missing timestamp should trigger canonical schema validation."""
+
+    def fake_validate(instance: dict, schema: dict) -> None:  # type: ignore[override]
+        if schema.get("title") == "UME Canonical Event" and "timestamp" not in instance:
+            raise ValidationError("timestamp required")
+
+    monkeypatch.setattr("ume.schema_utils.validate", fake_validate)
+
+    data = {"eventType": "CREATE_NODE"}
+    with pytest.raises(ValidationError):
+        validate_event_dict(data)


### PR DESCRIPTION
## Summary
- update `validate_event_dict` docstring to mention canonical schema validation
- add tests checking `validate_event_dict` enforces canonical schema fields

## Testing
- `pre-commit run --files src/ume/schema_utils.py tests/test_schema_utils.py`
- `pytest tests/test_schema_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0dfa63c48326b86fd76ac2f9aac4