### PR TITLE
Add automatic VectorStore listener registration

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -67,7 +67,7 @@ TOKEN_CLEANUP_INTERVAL = 60.0
 
 _token_cleanup_task: asyncio.Task | None = None
 _ledger_compaction_stop: Callable[[], None] | None = None
-_vector_listener: Any | None = None
+_vector_listener: VectorStoreListener | None = None
 
 
 logger = logging.getLogger(__name__)

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -18,7 +18,11 @@ from fastapi.testclient import TestClient
 
 FaissBackend = get_backend("faiss")
 from ume.api import configure_vector_store, app
-from ume._internal.listeners import register_listener, unregister_listener
+from ume._internal.listeners import (
+    register_listener,
+    unregister_listener,
+    get_registered_listeners,
+)
 from ume.api import configure_graph
 from prometheus_client import Gauge, Histogram
 import logging
@@ -404,6 +408,21 @@ def test_events_endpoint_indexes_nodes(store_cls, monkeypatch: pytest.MonkeyPatc
         res = client.post("/events", json=event, headers={"Authorization": f"Bearer {token}"})
         assert res.status_code == 200
     assert store.query([1.0, 0.0], k=1) == ["n1"]
+
+
+def test_listener_registered_on_startup(store_cls) -> None:
+    """VectorStoreListener is auto-registered and removed with app startup/shutdown."""
+    configure_graph(MockGraph())
+    store = store_cls(dim=2, use_gpu=False)
+    configure_vector_store(store)
+    before = get_registered_listeners()
+    with TestClient(app):
+        current = get_registered_listeners()
+        assert len(current) == len(before) + 1
+        assert any(
+            isinstance(listener, VectorStoreListener) for listener in current
+        )
+    assert get_registered_listeners() == before
 
 
 def test_create_default_store_dimension_autoset(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- ensure the API tracks VectorStoreListener instance type for startup
- add a test for automatic VectorStoreListener registration

## Testing
- `poetry run ruff check src tests`
- `poetry run mypy src/ume/api.py tests/test_vector_store.py`
- `pytest tests/test_vector_store.py::test_events_endpoint_indexes_nodes tests/test_vector_store.py::test_listener_registered_on_startup -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1b7e31908326aea1dee53b52d08a