### PR TITLE
Add Milvus backend integration test

### DIFF
--- a/tests/compose/README.md
+++ b/tests/compose/README.md
@@ -1,3 +1,4 @@
 The integration tests require Docker to pull the official `milvusdb/milvus` image.
 Ensure `testcontainers` and `pymilvus` are installed so that the Milvus container
-can be started during testing.
+can be started during testing. Set the environment variable `UME_DOCKER_TESTS=1`
+to enable these Docker-based tests.

--- a/tests/test_vector_backends.py
+++ b/tests/test_vector_backends.py
@@ -158,3 +158,37 @@ def test_milvus_backend_add_query_delete() -> None:
     assert backend.query([0.1, 0.2], k=1) == []
     backend.close()
     container.stop()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("UME_DOCKER_TESTS"), reason="Docker tests disabled")
+def test_milvus_backend_roundtrip() -> None:
+    if not _real_testcontainers_available() or not _pymilvus_available():
+        pytest.skip("testcontainers or pymilvus not available")
+
+    from testcontainers.core.container import DockerContainer
+
+    image = "milvusdb/milvus:v2.4.0"
+    with DockerContainer(image).with_exposed_ports(19530) as container:
+        host = container.get_container_host_ip()
+        port = container.get_exposed_port(19530)
+        uri = f"{host}:{port}"
+
+        from pymilvus import MilvusClient
+
+        for _ in range(30):
+            try:
+                client = MilvusClient(uri=uri)
+                client.list_collections()
+                break
+            except Exception:
+                time.sleep(1)
+        else:
+            pytest.skip("Milvus failed to start")
+
+        backend = RealMilvusBackend(dim=2, uri=uri, collection="roundtrip_vectors")
+        backend.add("x", [0.5, 0.6], persist=True)
+        assert backend.query([0.5, 0.6], k=1) == ["x"]
+        backend.delete("x")
+        assert backend.query([0.5, 0.6], k=1) == []
+        backend.close()


### PR DESCRIPTION
## Summary
- add roundtrip Milvus integration test using testcontainers
- document UME_DOCKER_TESTS env var requirement

## Testing
- `pre-commit run --files tests/test_vector_backends.py tests/compose/README.md`
- `pytest tests/test_vector_backends.py::test_milvus_backend_add_query_delete tests/test_vector_backends.py::test_milvus_backend_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_688d1b7e8bcc8326bd0a1d745198bdf1