### PR TITLE
Update docs with event schema and flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,17 @@ Used to create a new directed, labeled edge between two existing nodes.
 }
 ```
 
+```json
+{
+  "eventType": "CREATE_ONTOLOGY_RELATION",
+  "timestamp": "2024-03-15T12:14:00Z",
+  "node_id": "term_a",
+  "target_node_id": "term_b",
+  "label": "IS_A",
+  "payload": {}
+}
+```
+
 #### DELETE_EDGE Event
 
 Used to remove a specific directed, labeled edge between two nodes.
@@ -216,12 +227,11 @@ Producer (canonical JSON) --> ume-raw-events --> Privacy Agent --> ume-clean-eve
      --> Projection Engine --> Graph Adapter --> Storage (SQLite/Neo4j/Arango) & Vector Store
 ```
 
-1. `producer_demo.py` publishes raw events to the `ume-raw-events` Kafka topic.
-2. The **Privacy Agent** consumes these events, redacts PII, and forwards sanitized messages to `ume-clean-events`.
-3. A graph consumer reads sanitized events and applies them via the configured **Graph Adapter**.
-4. The adapter persists nodes and edges to the chosen backend, such as SQLite, Neo4j, or ArangoDB, and writes embeddings to a vector store.
-   When events contain an `embedding` attribute the `VectorStoreListener` automatically
-   indexes it for similarity search.
+1. `producer_demo.py` publishes raw events conforming to the canonical schema to the `ume-raw-events` Kafka topic.
+2. The **Privacy Agent** validates each event, redacts PII and forwards sanitized messages to `ume-clean-events`.
+3. The projection engine consumes these sanitized events and applies them to the graph via the configured **Graph Adapter**.
+4. The adapter persists nodes and edges to the chosen backend (SQLite, Neo4j, ArangoDB, ...). Listeners such as `VectorStoreListener` automatically
+   index any `embedding` vectors for similarity search.
 
 When nodes include textual attributes, the consumer generates vector embeddings using the configured model. These embeddings are stored in the vector store and queried via similarity search to locate relevant nodes before running graph traversals. The same fields are tokenized and the resulting tokens are saved under a `tokens` attribute for search. If the optional [tiktoken](https://github.com/openai/tiktoken) library is installed, it provides OpenAI-compatible tokenization.
 

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -112,6 +112,58 @@ vector embeddings consistently.
 }
 ```
 
+#### Example: ENTITY_DISCOVERED
+
+```json
+{
+  "eventType": "ENTITY_DISCOVERED",
+  "timestamp": "2024-03-15T12:12:00Z",
+  "node_id": "job_123",
+  "target_node_id": "entity_789",
+  "label": "FOUND",
+  "payload": {"name": "Foo"}
+}
+```
+
+#### Example: DOCUMENT_ARCHIVED
+
+```json
+{
+  "eventType": "DOCUMENT_ARCHIVED",
+  "timestamp": "2024-03-15T12:13:00Z",
+  "node_id": "doc_1",
+  "payload": {"archived_by": "agent_42"}
+}
+```
+
+#### Example: CREATE_ONTOLOGY_RELATION
+
+```json
+{
+  "eventType": "CREATE_ONTOLOGY_RELATION",
+  "timestamp": "2024-03-15T12:14:00Z",
+  "node_id": "term_a",
+  "target_node_id": "term_b",
+  "label": "IS_A",
+  "payload": {}
+}
+```
+
+### Event Flow
+
+```
+Producer (canonical JSON) --> ume-raw-events --> Privacy Agent --> ume-clean-events
+    --> Projection Engine --> Graph Adapter --> Graph Storage & Vector Store
+```
+
+1. Producers emit events following the canonical schema above.
+2. The Privacy Agent validates and redacts sensitive data before forwarding to `ume-clean-events`.
+3. The projection engine processes sanitized events and updates the graph via the chosen adapter.
+4. `VectorStoreListener` automatically indexes any `embedding` vectors during this step.
+
+As events pass from ingestion through projection they retain the canonical schema, ensuring
+consistent processing across components.
+
 As events pass from the ingestion API through the Privacy Agent and into the projection engine, they retain this schema. The engine applies them to the graph and notifies listeners such as `VectorStoreListener`, which adds any embedded vectors to the configured index automatically.
 
 ## Versioning


### PR DESCRIPTION
## Summary
- expand canonical event table usage
- document new event types in README and GRAPH_MODEL docs
- explain ingestion through projection pipeline with automatic vector indexing

## Testing
- `pre-commit` *(skipped: documentation only)*

------
https://chatgpt.com/codex/tasks/task_e_688d2bc73a808326a07a89d5ca0af7a8