### PR TITLE
Add research job GraphQL docs and test

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -246,7 +246,9 @@ curl -X POST http://localhost:8000/graphql \
 ```
 
 To locate documents gathered by a research job you can query the path from the
-topic node through the job to a document:
+topic node through the job to a document. The returned list shows each node
+encountered along the way and reveals which research job performed the
+collection:
 
 ```bash
 curl -X POST http://localhost:8000/graphql \
@@ -254,6 +256,9 @@ curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
   -d '{"query":"{ path(source: \"t1\", target: \"doc3\", maxDepth: 2) }"}'
 ```
+
+This example would return `["t1", "job1", "doc3"]` when document `doc3`
+was discovered by research job `job1` for topic `t1`.
 
 ### GET `/recall`
 Retrieve attribute data for the `k` nearest nodes to a query.

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -44,6 +44,9 @@ Properties:
 - `REMEMBERS`: connects a `UserMemory` node to an `AgentIntent` that created it.
 - `ASSOCIATED_WITH`: Generic association between any two nodes.
 - `CAUSES`: Expresses a causal relationship from one event or context to another.
+- `LINKS_TO`: Represents a generic connection between nodes.
+- `CONNECTS_TO`: Used for network-style associations.
+- `RELATES_TO`: Indicates a topical relationship.
 - `NEW_LABEL`: Links research job nodes to the documents they discover.
 
 Example edge creation event:

--- a/tests/test_graphql_advanced.py
+++ b/tests/test_graphql_advanced.py
@@ -56,3 +56,22 @@ def test_path_via_research_job() -> None:
     assert res.status_code == 200
     assert res.json()["data"]["path"] == ["t1", "job1", "doc3"]
 
+
+def test_path_via_research_job_filtered_by_label() -> None:
+    g = MockGraph()
+    g.add_node("t1", {})
+    g.add_node("job1", {})
+    g.add_node("doc3", {})
+    g.add_edge("t1", "job1", "RELATES_TO")
+    g.add_edge("job1", "doc3", "RELATES_TO")
+    configure_graph(g)
+
+    client = TestClient(app)
+    query = (
+        "{ path(source: \"t1\", target: \"doc3\", maxDepth: 2,"
+        " edgeLabel: \"RELATES_TO\") }"
+    )
+    res = client.post("/graphql", json={"query": query})
+    assert res.status_code == 200
+    assert res.json()["data"]["path"] == ["t1", "job1", "doc3"]
+


### PR DESCRIPTION
## Summary
- document how to fetch research job results via GraphQL
- list new edge labels in the graph schema docs
- test path query with an edge label filter

## Testing
- `ruff check tests/test_graphql_advanced.py`
- `mypy tests/test_graphql_advanced.py`
- `pytest tests/test_graphql_advanced.py -k filtered_by_label -q`

------
https://chatgpt.com/codex/tasks/task_e_688d2bc7f4a883268c662c55f686d833