### PR TITLE
Add replay-graph CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -920,6 +920,11 @@ This section outlines the basic programmatic steps to interact with the UME comp
     if loaded_graph_adapter and loaded_graph_adapter.node_exists("node_A"):
         print(f"Node 'node_A' from loaded graph: {loaded_graph_adapter.get_node('node_A')}")
     ```
+7.  **Replay Graph from Ledger (Optional):**
+    Rebuild a graph directly from the event ledger for analysis:
+    ```bash
+    ume replay-graph --db-path replay.db --end-offset 100
+    ```
 This provides a basic flow for event handling and graph interaction within UME.
 
 ### Swapping Backends

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -602,7 +602,15 @@ def test_cli_ledger_replay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caps
 
     event_mod = types.ModuleType("ume.event_ledger")
     ledger = EventLedger(str(tmp_path / "ledger.db"))
-    ledger.append(0, {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "a", "payload": {"node_id": "a"}})
+    ledger.append(
+        0,
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "node_id": "a",
+            "payload": {"node_id": "a"},
+        },
+    )
     event_mod.EventLedger = EventLedger
     event_mod.event_ledger = ledger
 
@@ -624,6 +632,85 @@ def test_cli_ledger_replay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caps
     sys.argv = argv
 
     assert "\"a\"" in out
+
+    for mod in [
+        "ume.cli.compose",
+        "ume.cli",
+        "ume.federation",
+        "ume.benchmarks",
+        "ume.event_ledger",
+        "ume",
+    ]:
+        sys.modules.pop(mod, None)
+
+
+def test_cli_replay_graph(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    import importlib
+    import types
+    from ume.event_ledger import EventLedger
+
+    stub = types.ModuleType("ume")
+    stub.PersistentGraph = object
+    stub.RoleBasedGraphAdapter = object
+    stub.enable_snapshot_autosave_and_restore = lambda *_, **__: None
+    stub.parse_event = lambda *_: None
+    stub.apply_event_to_graph = lambda *_: None
+    stub.load_graph_into_existing = lambda *_: None
+    stub.snapshot_graph_to_file = lambda *_: None
+    stub.ProcessingError = Exception
+    stub.EventError = Exception
+    stub.SnapshotError = Exception
+    stub.IGraphAdapter = object
+    stub.log_audit_entry = lambda *_: None
+    stub.get_audit_entries = lambda *_: []
+    stub.DEFAULT_SCHEMA_MANAGER = object()
+    bench = types.ModuleType("ume.benchmarks")
+    bench.benchmark_vector_store = lambda *_: None
+    feder = types.ModuleType("ume.federation")
+    feder.MirrorMakerDriver = object  # type: ignore[assignment]
+    cli_pkg = types.ModuleType("ume.cli")
+    compose_pkg = types.ModuleType("ume.cli.compose")
+    compose_pkg._compose_down = lambda *_, **__: None
+    compose_pkg._compose_ps = lambda *_, **__: None
+    compose_pkg._quickstart = lambda *_, **__: None
+    cli_pkg.compose = compose_pkg
+    prompt_pkg = types.ModuleType("ume.cli.prompt")
+    prompt_pkg.UMEPrompt = object
+    prompt_pkg.create_graph_adapter = lambda *_, **__: None
+
+    event_mod = types.ModuleType("ume.event_ledger")
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    ledger.append(
+        0,
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "node_id": "a",
+            "payload": {"node_id": "a"},
+        },
+    )
+    event_mod.EventLedger = EventLedger
+    event_mod.event_ledger = ledger
+
+    sys.modules["ume"] = stub
+    sys.modules["ume.benchmarks"] = bench
+    sys.modules["ume.federation"] = feder
+    sys.modules["ume.cli"] = cli_pkg
+    sys.modules["ume.cli.compose"] = compose_pkg
+    sys.modules["ume.cli.prompt"] = prompt_pkg
+    sys.modules["ume.event_ledger"] = event_mod
+
+    import ume_cli as cli
+    importlib.reload(cli)
+
+    db_file = tmp_path / "replay.db"
+    argv = sys.argv[:]
+    sys.argv = ["ume-cli", "replay-graph", "--db-path", str(db_file), "--end-offset", "0"]
+    cli.main()
+    out = capsys.readouterr().out
+    sys.argv = argv
+
+    assert "Rebuilt graph" in out
 
     for mod in [
         "ume.cli.compose",

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -37,6 +37,18 @@ def _ledger_replay(end_offset: int | None, end_timestamp: int | None) -> None:
     )
     print(json.dumps(snapshot, indent=2))
 
+
+def _replay_graph(db_path: str | None, end_offset: int | None) -> None:
+    """Rebuild a graph from the event ledger and print a summary."""
+
+    from ume.replay import graph_from_event_ledger
+
+    graph = graph_from_event_ledger(db_path=db_path, end_offset=end_offset)
+    node_count = len(graph.get_all_node_ids())
+    edge_count = len(graph.get_all_edges())
+    location = f" at {db_path}" if db_path and db_path != ":memory:" else ""
+    print(f"Rebuilt graph{location} with {node_count} nodes and {edge_count} edges")
+
 # Detect if a lightweight stub was injected for testing.
 _UME_STUB = not hasattr(ume, "__file__")
 
@@ -449,6 +461,13 @@ def main() -> None:
     replay_parser.add_argument("--end-offset", type=int)
     replay_parser.add_argument("--end-timestamp", type=int)
 
+    replay_graph_parser = sub.add_parser(
+        "replay-graph",
+        help="Rebuild a graph from the event ledger",
+    )
+    replay_graph_parser.add_argument("--db-path", default=":memory:")
+    replay_graph_parser.add_argument("--end-offset", type=int)
+
     dossier_parser = sub.add_parser("dossier", help="Manage dossiers")
     dossier_sub = dossier_parser.add_subparsers(dest="dossier_cmd")
     view_p = dossier_sub.add_parser("view", help="View a dossier")
@@ -551,6 +570,9 @@ def main() -> None:
             return
         if args.command == "ledger-replay":
             _ledger_replay(args.end_offset, args.end_timestamp)
+            return
+        if args.command == "replay-graph":
+            _replay_graph(args.db_path, args.end_offset)
             return
         if args.command == "dossier":
             if args.dossier_cmd == "view":


### PR DESCRIPTION
## Summary
- add `replay-graph` subcommand in `ume_cli.py`
- implement helper `_replay_graph` and command parser wiring
- document command usage in README
- add unit test for the new subcommand

## Testing
- `poetry run ruff check ume_cli.py tests/test_cli_smoke.py`
- `poetry run pytest tests/test_cli_smoke.py::test_cli_replay_graph -q`

------
https://chatgpt.com/codex/tasks/task_e_688d3098f7648326aad8819402d7ec35