### PR TITLE
Remove isawaitable checks

### DIFF
--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -30,11 +30,13 @@ router = APIRouter()
 
 async def _maybe_call(graph: IGraphAdapter, name: str, *args: Any) -> Any:
     func = getattr(graph, name)
-    if inspect.iscoroutinefunction(func):
-        return await func(*args)
-    if isinstance(graph, IAsyncGraphAdapter):
-        return await func(*args)
-    return func(*args)
+    if inspect.iscoroutinefunction(func) or isinstance(graph, IAsyncGraphAdapter):
+        result = await func(*args)
+    else:
+        result = func(*args)
+    if inspect.isawaitable(result):
+        result = await result
+    return result
 
 
 class ShortestPathRequest(BaseModel):

--- a/src/ume/vector_routes.py
+++ b/src/ume/vector_routes.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, AsyncGenerator
 import asyncio
-import inspect
 import json
 import math
 import time
@@ -81,8 +80,6 @@ async def api_semantic_search(
     nodes = []
     for node_id in ids:
         attrs = await _maybe_call(graph, "get_node", node_id)
-        if inspect.isawaitable(attrs):
-            attrs = await attrs
         if attrs is not None:
             nodes.append({"id": node_id, "attributes": attrs})
     SEMANTIC_SEARCH_LATENCY.observe(time.perf_counter() - start)
@@ -111,8 +108,6 @@ async def api_recall(
     nodes = []
     for node_id in ids:
         attrs = await _maybe_call(graph, "get_node", node_id)
-        if inspect.isawaitable(attrs):
-            attrs = await attrs
         if attrs is not None:
             emb = attrs.get("embedding")
             if isinstance(emb, list) and len(emb) == len(vector):
@@ -150,8 +145,6 @@ async def api_recall_stream(
         ids = store.query(vector, k=k)
         for node_id in ids:
             attrs = await _maybe_call(graph, "get_node", node_id)
-            if inspect.isawaitable(attrs):
-                attrs = await attrs
             if attrs is not None:
                 emb = attrs.get("embedding")
                 if isinstance(emb, list) and len(emb) == len(vector):


### PR DESCRIPTION
## Summary
- remove unused `inspect` import and awaitable checks from vector routes
- ensure `_maybe_call` handles pending awaitables returned from wrapped graph functions

## Testing
- `pre-commit run --files src/ume/graph_routes.py src/ume/vector_routes.py`
- `pytest tests/test_vector_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688d309874d88326a56d3224c5aeeccc