### PR TITLE
Add projection engine consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The engine is built from a few key components:
     environment settings. The backend is selected via `UME_VECTOR_BACKEND`.
 - **CLI** (`ume_cli.py`)
   - Command-line utility for producing events, inspecting the graph, and running maintenance tasks.
-- **Projection Engine** (`src/ume/consumer_demo.py`)
+- **Projection Engine** (`src/ume/projection_engine.py`)
   - Consumes sanitized events from Kafka and applies them to the graph via the configured adapter.
 
 ### Event Flow
@@ -74,7 +74,7 @@ The current system consists of the following main components:
     *   The demo uses a topic named `ume-clean-events`, configured for unlimited retention and immutable append-only storage so it acts as the canonical audit trail.
     *   The Docker setup also includes Redpanda Console, which provides a UI and schema registry capabilities, accessible typically on `localhost:8081` (for the console) while Redpanda itself exposes a schema registry via Pandaproxy on `localhost:8082`.
 
-3.  **Event Consumer (`src/ume/consumer_demo.py`):**
+3.  **Event Consumer (`src/ume/projection_engine.py`):**
     *   This script subscribes to topics on the message broker to receive and process events.
     *   In the demo, it connects to the Kafka/Redpanda broker at `localhost:9092`, subscribes to the `ume-clean-events` topic using the group ID `ume_client_group`.
     *   Upon receiving an event, it logs the event's content. In a more complete system, this component would be responsible for parsing the event, updating the memory graph, triggering actions, or other processing tasks.
@@ -248,6 +248,7 @@ For current plans and eventual detailed documentation on the UME graph model, pl
 
 *   [**Graph Model Documentation (docs/GRAPH_MODEL.md)**](docs/GRAPH_MODEL.md)
 *   [**Graph Listener Guide (docs/GRAPH_LISTENERS.md)**](docs/GRAPH_LISTENERS.md)
+*   [**Projection Engine (docs/PROJECTION_ENGINE.md)**](docs/PROJECTION_ENGINE.md)
 *   [**LLM Ferry (docs/LLM_FERRY.md)**](docs/LLM_FERRY.md)
 *   [**Angel Bridge (docs/ANGEL_BRIDGE.md)**](docs/ANGEL_BRIDGE.md)
 *   [**API Reference (docs/API_REFERENCE.md)**](docs/API_REFERENCE.md)
@@ -476,9 +477,9 @@ poetry run ume down
 ```
 See [docs/SSL_SETUP.md](docs/SSL_SETUP.md) for details.
 
-### 3. Run the Consumer Demo
+### 3. Run the Projection Engine
 ```bash
-poetry run python src/ume/consumer_demo.py
+poetry run ume-projection
 ```
 This script subscribes to topic `ume-clean-events` on `localhost:9092` and waits for messages.
 

--- a/docs/ENV_EXAMPLE.md
+++ b/docs/ENV_EXAMPLE.md
@@ -39,6 +39,12 @@ LLM_FERRY_API_KEY=
 
 # Number of hours of events to include in Angel Bridge summaries
 ANGEL_BRIDGE_LOOKBACK_HOURS=24
+# Kafka broker configuration for the projection engine
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+# Topic containing sanitized events
+KAFKA_CLEAN_EVENTS_TOPIC=ume-clean-events
+# Consumer group used by projection engine
+KAFKA_GROUP_ID=ume_client_group
 ```
 
 Set `UME_DOSSIER_PATH` to change where UME stores user dossier files if you want to relocate them from the default location.

--- a/docs/PROJECTION_ENGINE.md
+++ b/docs/PROJECTION_ENGINE.md
@@ -1,0 +1,46 @@
+# Projection Engine
+
+`ume.projection_engine` consumes sanitized events from Kafka and applies them to the configured graph adapter. It keeps the local graph in sync with the latest events published by the Privacy Agent.
+
+## Configuration
+
+The engine reads the following settings from `Settings`:
+
+- `KAFKA_BOOTSTRAP_SERVERS` &ndash; comma separated list of brokers.
+- `KAFKA_CLEAN_EVENTS_TOPIC` &ndash; topic containing sanitized events.
+- `KAFKA_GROUP_ID` &ndash; consumer group used for the projection engine.
+
+These may be provided in your environment or a `.env` file:
+
+```bash
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+KAFKA_CLEAN_EVENTS_TOPIC=ume-clean-events
+KAFKA_GROUP_ID=ume_client_group
+```
+
+## Running under systemd
+
+```ini
+[Unit]
+Description=UME Projection Engine
+After=network.target
+
+[Service]
+EnvironmentFile=/opt/ume/.env
+ExecStart=/opt/ume/.venv/bin/ume-projection
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+## Docker Compose
+
+```yaml
+  ume-projection:
+    image: ume:latest
+    command: ume-projection
+    env_file: ./ume.env
+    depends_on:
+      - redpanda
+```

--- a/env.example
+++ b/env.example
@@ -39,3 +39,11 @@ ANGEL_BRIDGE_LOOKBACK_HOURS=24
 
 # Enable or disable logging of watcher activity to each dossier
 UME_ACTIVITY_LOG_ENABLED=true
+
+# Kafka broker configuration for the projection engine
+KAFKA_BOOTSTRAP_SERVERS=localhost:9092
+# Topic containing sanitized events
+KAFKA_CLEAN_EVENTS_TOPIC=ume-clean-events
+# Consumer group used by projection engine
+KAFKA_GROUP_ID=ume_client_group
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ grpc_server = ["grpcio"]
 produce_demo = "ume.producer_demo:main"
 ume-cli = "ume_cli:main"
 ume = "ume.__main__:main"
+ume-projection = "ume.projection_engine:main"
 compile-protos = "scripts.compile_protos:main"
 
 

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -122,20 +122,23 @@ def parse_event(data: Dict[str, Any]) -> Event:
         logger.error("Missing required event field: timestamp")
         raise EventError("Missing required event field: timestamp")
     timestamp_raw = data["timestamp"]
-    if not isinstance(timestamp_raw, str):
+    if isinstance(timestamp_raw, int):
+        timestamp_int = timestamp_raw
+    elif isinstance(timestamp_raw, str):
+        try:
+            dt = datetime.fromisoformat(timestamp_raw.replace("Z", "+00:00"))
+        except ValueError:
+            msg = "Invalid timestamp format"
+            logger.error(msg)
+            raise EventError(msg)
+        timestamp_int = int(dt.timestamp())
+    else:
         msg = (
-            "Invalid type for 'timestamp': expected ISO 8601 string, "
+            "Invalid type for 'timestamp': expected int or ISO 8601 string, "
             f"got {type(timestamp_raw).__name__}"
         )
         logger.error(msg)
         raise EventError(msg)
-    try:
-        dt = datetime.fromisoformat(timestamp_raw.replace("Z", "+00:00"))
-    except ValueError:
-        msg = "Invalid timestamp format"
-        logger.error(msg)
-        raise EventError(msg)
-    timestamp_int = int(dt.timestamp())
 
     # Validate optional event_id type
     event_id_val = data.get("eventId")

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -9,7 +9,7 @@ from confluent_kafka import Consumer, KafkaException, KafkaError
 from jsonschema import ValidationError
 
 from ..config import settings
-from ..utils import ssl_config, event_to_snake
+from ..utils import ssl_config, event_to_snake, event_to_camel
 from ..event import parse_event, EventError, EventType
 from ..processing import apply_event_to_graph, ProcessingError
 from ..schema_utils import validate_event_dict
@@ -78,10 +78,6 @@ def run_graph_consumer(
             try:
                 data_camel = json.loads(msg.value().decode("utf-8"))
                 data = event_to_snake(data_camel)
-                validation_data = dict(data)
-                if "event_type" in validation_data:
-                    validation_data["eventType"] = validation_data.pop("event_type")
-                validate_event_dict(validation_data)
                 payload = data["event"] if "event" in data else data
                 event = parse_event(payload)
             except (json.JSONDecodeError, EventError) as exc:
@@ -90,7 +86,12 @@ def run_graph_consumer(
 
             if event.event_type not in VALID_EVENT_TYPES:
                 try:
-                    event_ledger.append(msg.offset(), payload)
+                    event_dict = {
+                        "event_type": event.event_type,
+                        "timestamp": event.timestamp,
+                        "payload": event.payload,
+                    }
+                    event_ledger.append(msg.offset(), event_to_camel(event_dict))
                 except ValueError as exc:  # pragma: no cover - unlikely duplicate offset
                     logger.error("Ledger append failed: %s", exc)
                 try:
@@ -100,8 +101,11 @@ def run_graph_consumer(
                 logger.warning("Unknown event type '%s' skipped", event.event_type)
                 continue
 
+            validation_data = dict(data)
+            if "event_type" in validation_data:
+                validation_data["eventType"] = validation_data.pop("event_type")
             try:
-                validate_event_dict(data)
+                validate_event_dict(validation_data)
             except ValidationError as exc:
                 logger.error("Invalid event skipped: %s", exc)
                 continue

--- a/src/ume/projection_engine.py
+++ b/src/ume/projection_engine.py
@@ -1,0 +1,96 @@
+"""Kafka consumer that projects sanitized events into the graph."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from confluent_kafka import Consumer, KafkaError, KafkaException
+
+from .config import settings
+from .utils import ssl_config, event_to_snake
+from .event import parse_event, EventError, EventType
+from .processing import apply_event_to_graph, ProcessingError
+from .graph_adapter import IGraphAdapter
+from .logging_utils import configure_logging
+
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
+TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
+GROUP_ID = settings.KAFKA_GROUP_ID
+
+VALID_EVENT_TYPES = {e.value for e in EventType}
+
+def run_projection_engine(
+    graph: IGraphAdapter,
+    *,
+    group_id: str | None = None,
+    consumer: Consumer | None = None,
+) -> None:
+    """Consume sanitized events and update ``graph`` accordingly."""
+    gid = group_id or GROUP_ID
+    owns_consumer = False
+    if consumer is None:
+        conf = {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "group.id": gid,
+            "auto.offset.reset": "earliest",
+        }
+        conf.update(ssl_config())
+        try:
+            consumer = Consumer(conf)
+            consumer.subscribe([TOPIC])
+        except KafkaException as exc:  # pragma: no cover - network errors
+            logger.error("Failed to start projection consumer: %s", exc)
+            return
+        owns_consumer = True
+
+    logger.info("Projection engine started with group_id %s", gid)
+    try:
+        while True:
+            try:
+                msg = consumer.poll(1.0)
+            except KafkaException as exc:  # pragma: no cover - network errors
+                logger.error("Poll failed: %s", exc)
+                continue
+            if msg is None:
+                continue
+            if msg.error():
+                if msg.error().code() != KafkaError._PARTITION_EOF:
+                    logger.error("Kafka error: %s", msg.error())
+                continue
+
+            try:
+                data_camel = json.loads(msg.value().decode("utf-8"))
+                data = event_to_snake(data_camel)
+                event = parse_event(data)
+            except (json.JSONDecodeError, EventError) as exc:
+                logger.error("Invalid event skipped: %s", exc)
+                continue
+
+            if event.event_type not in VALID_EVENT_TYPES:
+                logger.warning("Unknown event type '%s' skipped", event.event_type)
+                continue
+
+            try:
+                apply_event_to_graph(event, graph)
+            except ProcessingError as exc:
+                logger.error("Event processing failed: %s", exc)
+    except KeyboardInterrupt:  # pragma: no cover - manual interrupt
+        logger.info("Projection engine shutting down")
+    finally:
+        if owns_consumer:
+            consumer.close()
+
+def main() -> None:
+    from .resources import create_graph
+
+    graph = create_graph()
+    run_projection_engine(graph)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/integration/test_pipeline_end_to_end.py
+++ b/tests/integration/test_pipeline_end_to_end.py
@@ -156,7 +156,11 @@ def test_pipeline_end_to_end(tmp_path, monkeypatch):
 
 
 def test_generic_events_go_to_ledger(tmp_path, monkeypatch, caplog):
-    msg_data = {"eventType": "CUSTOM", "timestamp": 1, "payload": {"foo": "bar"}}
+    msg_data = {
+        "eventType": "CUSTOM",
+        "timestamp": "1970-01-01T00:00:01Z",
+        "payload": {"foo": "bar"},
+    }
     msg = DummyMessage(json.dumps(msg_data).encode("utf-8"), 0)
     consumer = DummyConsumer([msg])
     ledger = EventLedger(str(tmp_path / "ledger.db"))
@@ -180,7 +184,11 @@ def test_generic_events_go_to_ledger(tmp_path, monkeypatch, caplog):
 def test_generic_enveloped_events_go_to_ledger(tmp_path, monkeypatch, caplog):
     envelope = {
         "schema_version": "1.0.0",
-        "event": {"eventType": "CUSTOM", "timestamp": 1, "payload": {"foo": "bar"}},
+        "event": {
+            "eventType": "CUSTOM",
+            "timestamp": "1970-01-01T00:00:01Z",
+            "payload": {"foo": "bar"},
+        },
     }
     msg = DummyMessage(json.dumps(envelope).encode("utf-8"), 0)
     consumer = DummyConsumer([msg])


### PR DESCRIPTION
## Summary
- implement projection_engine to consume sanitized events and apply them to the graph
- expose `ume-projection` console script
- document projection engine and minimal Kafka settings
- update README with new module
- fix timestamp parsing and consumer validation
- adjust pipeline end-to-end tests for ISO timestamps

## Testing
- `ruff check src/ume/event.py src/ume/pipeline/graph_consumer.py`
- `mypy src/ume/event.py src/ume/pipeline/graph_consumer.py`
- `pytest tests/test_api_events.py::test_post_event_success tests/test_api_events.py::test_post_events_batch tests/test_api_events.py::test_store_event_success tests/test_api_events.py::test_store_events_batch tests/test_api_graph_history.py::test_graph_history_offset tests/test_api_graph_history.py::test_graph_history_timestamp tests/integration/test_integration_clients.py::test_integration_clients tests/integration/test_integration_clients.py::test_async_langgraph_and_letta tests/integration/test_pipeline_end_to_end.py::test_generic_events_go_to_ledger tests/integration/test_pipeline_end_to_end.py::test_generic_enveloped_events_go_to_ledger tests/test_api_ledger.py::test_replay_endpoint_sqlite tests/test_api_ledger.py::test_replay_endpoint_sqlite_timestamp tests/test_api_ledger.py::test_bookmark_persistence_and_replay tests/test_api.py::test_semantic_search tests/test_api.py::test_semantic_search_invalid_dimension tests/test_api.py::test_semantic_search_invalid_k -q`


------
https://chatgpt.com/codex/tasks/task_e_688d5f4f357c8326bc0c099b9de76b60