### PR TITLE
feat: expand tokenizer fallbacks

### DIFF
--- a/src/ume/tokenization.py
+++ b/src/ume/tokenization.py
@@ -3,8 +3,18 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - type hints only
+    import unitok as _unitok
+    import tatitok as _tatitok
     import tiktoken as _tiktoken
-else:  # pragma: no cover - optional dependency
+else:  # pragma: no cover - optional dependencies
+    try:
+        import unitok as _unitok
+    except ModuleNotFoundError:  # pragma: no cover - allow missing dep
+        _unitok = None  # type: ignore[assignment]
+    try:
+        import tatitok as _tatitok
+    except ModuleNotFoundError:  # pragma: no cover - allow missing dep
+        _tatitok = None  # type: ignore[assignment]
     try:
         import tiktoken as _tiktoken
     except ModuleNotFoundError:  # pragma: no cover - allow missing dep
@@ -12,9 +22,13 @@ else:  # pragma: no cover - optional dependency
 
 
 def tokenize(text: str) -> list[str]:
-    """Return a list of tokens for ``text`` using ``tiktoken`` if available."""
-    if _tiktoken is None:
-        return text.split()
-    encoding = _tiktoken.get_encoding("cl100k_base")
-    token_ids = encoding.encode(text)
-    return [encoding.decode([tid]) for tid in token_ids]
+    """Return a list of tokens for ``text`` using available tokenizers."""
+    if _unitok is not None and hasattr(_unitok, "tokenize"):
+        return list(_unitok.tokenize(text))
+    if _tatitok is not None and hasattr(_tatitok, "tokenize"):
+        return list(_tatitok.tokenize(text))
+    if _tiktoken is not None:
+        encoding = _tiktoken.get_encoding("cl100k_base")
+        token_ids = encoding.encode(text)
+        return [encoding.decode([tid]) for tid in token_ids]
+    return text.split()

--- a/tests/test_tokenization.py
+++ b/tests/test_tokenization.py
@@ -9,9 +9,33 @@ tokenization = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = tokenization
 spec.loader.exec_module(tokenization)
 
-def test_tokenize_without_tiktoken(monkeypatch):
+def test_tokenize_plain_split(monkeypatch):
+    monkeypatch.setattr(tokenization, "_unitok", None, raising=False)
+    monkeypatch.setattr(tokenization, "_tatitok", None, raising=False)
     monkeypatch.setattr(tokenization, "_tiktoken", None, raising=False)
     assert tokenization.tokenize("Foo bar") == ["Foo", "bar"]
+
+
+def test_tokenize_with_unitok(monkeypatch):
+    class FakeUniTok:
+        def tokenize(self, text):
+            return ["u", text]
+
+    monkeypatch.setattr(tokenization, "_unitok", FakeUniTok(), raising=False)
+    monkeypatch.setattr(tokenization, "_tatitok", None, raising=False)
+    monkeypatch.setattr(tokenization, "_tiktoken", None, raising=False)
+    assert tokenization.tokenize("hello") == ["u", "hello"]
+
+
+def test_tokenize_with_tatitok(monkeypatch):
+    class FakeTaTiTok:
+        def tokenize(self, text):
+            return ["ta", text]
+
+    monkeypatch.setattr(tokenization, "_unitok", None, raising=False)
+    monkeypatch.setattr(tokenization, "_tatitok", FakeTaTiTok(), raising=False)
+    monkeypatch.setattr(tokenization, "_tiktoken", None, raising=False)
+    assert tokenization.tokenize("hello") == ["ta", "hello"]
 
 def test_tokenize_with_tiktoken(monkeypatch):
     calls = {}
@@ -29,6 +53,8 @@ def test_tokenize_with_tiktoken(monkeypatch):
             calls["get_encoding"] = name
             return FakeEncoding()
 
+    monkeypatch.setattr(tokenization, "_unitok", None, raising=False)
+    monkeypatch.setattr(tokenization, "_tatitok", None, raising=False)
     monkeypatch.setattr(tokenization, "_tiktoken", FakeTiktoken(), raising=False)
     tokens = tokenization.tokenize("hello")
     assert tokens == ["foo", "bar"]


### PR DESCRIPTION
## Summary
- attempt UniTok or TA-TiTok tokenizers when available
- add tests for UniTok, TA-TiTok, tiktoken, and plain split fallbacks

## Testing
- `pre-commit run --files src/ume/tokenization.py tests/test_tokenization.py`
- `pytest tests/test_tokenization.py`


------
https://chatgpt.com/codex/tasks/task_e_688e2bbb2b888326821abd84b6e3f1de