### PR TITLE
Integrate event classification into ingestion pipeline

### DIFF
--- a/src/ume/classification/__init__.py
+++ b/src/ume/classification/__init__.py
@@ -1,0 +1,5 @@
+"""Classification utilities."""
+
+from .service import classify_event, TagResult
+
+__all__ = ["classify_event", "TagResult"]

--- a/src/ume/classification/service.py
+++ b/src/ume/classification/service.py
@@ -1,0 +1,52 @@
+"""Simple event classification utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from ..event import Event
+
+
+@dataclass
+class TagResult:
+    """Represents a classification tag with an associated confidence."""
+
+    tag: str
+    confidence: float
+
+
+def classify_event(event: Event) -> List[TagResult]:
+    """Classify an event and return tag results.
+
+    This rudimentary implementation looks for specific keywords in any
+    string values found in the event's payload or attribute dictionary.
+    If a keyword is present, a tag is emitted with a confidence score of 1.0.
+    """
+
+    keywords = {
+        "malware": "malware",
+        "phishing": "phishing",
+        "threat": "threat",
+    }
+
+    results: List[TagResult] = []
+
+    def check_text(text: str) -> None:
+        lower = text.lower()
+        for key, tag in keywords.items():
+            if key in lower:
+                results.append(TagResult(tag=tag, confidence=1.0))
+
+    payload = event.payload
+    for value in payload.values():
+        if isinstance(value, str):
+            check_text(value)
+
+    attrs = payload.get("attributes")
+    if isinstance(attrs, dict):
+        for value in attrs.values():
+            if isinstance(value, str):
+                check_text(value)
+
+    return results

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -11,6 +11,7 @@ from ..event import Event, EventError, EventType, parse_event
 from ..processing import apply_event_to_graph
 from ..graph_adapter import IGraphAdapter
 from ..async_graph_adapter import IAsyncGraphAdapter, ingest_event_async
+from ..classification import classify_event
 
 if TYPE_CHECKING:  # pragma: no cover - typing import for mypy
     from ume_client import events_pb2 as events_pb2_type
@@ -42,8 +43,18 @@ def apply_event(event: Event, graph: IGraphAdapter) -> None:
 
 
 def ingest_event(data: Dict[str, Any], graph: IGraphAdapter) -> None:
-    """Validate ``data`` and apply the resulting event to ``graph``."""
+    """Validate ``data``, classify it, and apply the resulting event to ``graph``."""
     event = validate_event(data)
+
+    tag_results = classify_event(event)
+    event.payload["classification"] = [
+        {"tag": r.tag, "confidence": r.confidence} for r in tag_results
+    ]
+    if tag_results:
+        attributes = event.payload.setdefault("attributes", {})
+        attributes["tags"] = [r.tag for r in tag_results]
+        attributes["tag_confidence"] = [r.confidence for r in tag_results]
+
     apply_event(event, graph)
 
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -1,0 +1,36 @@
+import ume.services.ingest as ingest_module
+from ume.graph import MockGraph
+from ume.services import ingest_event
+from ume.processing import apply_event_to_graph
+
+
+def test_ingest_event_classifies_and_persists_tags(monkeypatch) -> None:
+    graph = MockGraph()
+    captured: dict[str, object] = {}
+
+    def fake_apply_event(event, g):
+        captured["event"] = event
+        apply_event_to_graph(event, g)
+
+    monkeypatch.setattr(ingest_module, "apply_event", fake_apply_event)
+
+    data = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 0,
+        "node_id": "node1",
+        "payload": {
+            "node_id": "node1",
+            "attributes": {"content": "This text mentions malware."},
+        },
+    }
+
+    ingest_event(data, graph)
+
+    stored = graph.get_node("node1")
+    assert stored["tags"] == ["malware"]
+    assert stored["tag_confidence"] == [1.0]
+
+    event = captured["event"]
+    assert event.payload["classification"] == [
+        {"tag": "malware", "confidence": 1.0}
+    ]


### PR DESCRIPTION
## Summary
- add TagResult dataclass and keyword-based classify_event helper
- classify events during ingest and persist tags and confidences on nodes
- test that ingestion saves classification metadata

## Testing
- `pre-commit run --files src/ume/classification/service.py src/ume/classification/__init__.py src/ume/services/ingest.py tests/test_classification.py`
- `pytest tests/test_classification.py`
- `pytest tests/test_async_graph_adapter.py::test_ingest_event_async_creates_node`
- `pytest tests/test_metrics.py` *(fails: ImportError: cannot import name 'FastAPILimiter')*


------
https://chatgpt.com/codex/tasks/task_e_688e56285ebc83268c9fcbdbdd68e5c3