### PR TITLE
feat: introduce classifier plugin system

### DIFF
--- a/src/ume/classification/__init__.py
+++ b/src/ume/classification/__init__.py
@@ -1,5 +1,6 @@
 """Classification utilities."""
 
+from .plugins import Classifier, register_classifier
 from .service import classify_event, TagResult
 
-__all__ = ["classify_event", "TagResult"]
+__all__ = ["classify_event", "TagResult", "Classifier", "register_classifier"]

--- a/src/ume/classification/plugins.py
+++ b/src/ume/classification/plugins.py
@@ -1,0 +1,34 @@
+"""Plugin utilities for event classification."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Protocol, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from .service import TagResult
+
+
+class Classifier(Protocol):
+    """Protocol for classification plugins."""
+
+    def classify(self, payload: dict[str, Any]) -> List["TagResult"]:
+        """Return classification results for the provided payload."""
+
+
+_registry: Dict[str, Classifier] = {}
+
+
+def register_classifier(event_type: str, classifier: Classifier) -> None:
+    """Register a classifier for a specific event type."""
+
+    _registry[event_type] = classifier
+
+
+def get_classifier(event_type: str) -> Optional[Classifier]:
+    """Retrieve the classifier registered for ``event_type`` if any."""
+
+    return _registry.get(event_type)
+
+
+__all__ = ["Classifier", "register_classifier", "get_classifier"]
+

--- a/src/ume/classification/service.py
+++ b/src/ume/classification/service.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import Any, List
 
 from ..event import Event
+from .plugins import Classifier, get_classifier, register_classifier
 
 
 @dataclass
@@ -16,37 +17,48 @@ class TagResult:
     confidence: float
 
 
-def classify_event(event: Event) -> List[TagResult]:
-    """Classify an event and return tag results.
+class KeywordClassifier:
+    """Classifier that tags events based on keyword matches in string values."""
 
-    This rudimentary implementation looks for specific keywords in any
-    string values found in the event's payload or attribute dictionary.
-    If a keyword is present, a tag is emitted with a confidence score of 1.0.
-    """
+    def __init__(self) -> None:
+        self.keywords = {
+            "malware": "malware",
+            "phishing": "phishing",
+            "threat": "threat",
+        }
 
-    keywords = {
-        "malware": "malware",
-        "phishing": "phishing",
-        "threat": "threat",
-    }
+    def classify(self, payload: dict[str, Any]) -> List[TagResult]:
+        results: List[TagResult] = []
 
-    results: List[TagResult] = []
+        def check_text(text: str) -> None:
+            lower = text.lower()
+            for key, tag in self.keywords.items():
+                if key in lower:
+                    results.append(TagResult(tag=tag, confidence=1.0))
 
-    def check_text(text: str) -> None:
-        lower = text.lower()
-        for key, tag in keywords.items():
-            if key in lower:
-                results.append(TagResult(tag=tag, confidence=1.0))
-
-    payload = event.payload
-    for value in payload.values():
-        if isinstance(value, str):
-            check_text(value)
-
-    attrs = payload.get("attributes")
-    if isinstance(attrs, dict):
-        for value in attrs.values():
+        for value in payload.values():
             if isinstance(value, str):
                 check_text(value)
 
-    return results
+        attrs = payload.get("attributes")
+        if isinstance(attrs, dict):
+            for value in attrs.values():
+                if isinstance(value, str):
+                    check_text(value)
+
+        return results
+
+
+# Register the default classifier for generic use
+register_classifier("default", KeywordClassifier())
+
+
+def classify_event(event: Event) -> List[TagResult]:
+    """Classify an event and return tag results using registered classifiers."""
+
+    classifier: Classifier | None = get_classifier(event.event_type)
+    if classifier is None:
+        classifier = get_classifier("default")
+    if classifier is None:
+        return []
+    return classifier.classify(event.payload)


### PR DESCRIPTION
## Summary
- add classification plugin protocol and registry
- use registry in classify_event with a default keyword classifier
- expose hooks for registering custom classifiers

## Testing
- `pre-commit run --files src/ume/classification/service.py src/ume/classification/plugins.py src/ume/classification/__init__.py`
- `pytest` *(fails: 66 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688e5bf8c0dc8326ad9197dfd39c97ef