### PR TITLE
Add finance-engine transaction classification

### DIFF
--- a/src/ume/classification/finance_client.py
+++ b/src/ume/classification/finance_client.py
@@ -1,0 +1,52 @@
+"""Client for the external finance-engine service."""
+
+from __future__ import annotations
+
+from typing import Any, List
+from types import TracebackType
+
+import httpx
+
+from ..config import settings
+
+
+class FinanceClientError(Exception):
+    """Errors raised when communicating with the finance engine."""
+
+
+class FinanceClient:
+    """Simple HTTP wrapper around the finance-engine categorisation endpoint."""
+
+    def __init__(self, base_url: str | None = None, timeout: float = 5.0) -> None:
+        resolved = base_url or getattr(settings, "FINANCE_ENGINE_URL", "http://finance-engine:8000")
+        self.base_url = str(resolved).rstrip("/")
+        self._client = httpx.Client(timeout=timeout)
+
+    def categorize(self, transaction: dict[str, Any]) -> List[str]:
+        """Return a list of categories for ``transaction``."""
+
+        url = f"{self.base_url}/categorize"
+        try:
+            resp = self._client.post(url, json={"transaction": transaction})
+            resp.raise_for_status()
+            data = resp.json()
+            cats = data.get("categories")
+            if isinstance(cats, list):
+                return [str(c) for c in cats]
+            return []
+        except Exception as exc:  # pragma: no cover - network failures
+            raise FinanceClientError(str(exc)) from exc
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "FinanceClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/src/ume/classification/service.py
+++ b/src/ume/classification/service.py
@@ -5,8 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, List
 
+import logging
+
 from ..event import Event
 from .plugins import Classifier, get_classifier, register_classifier
+from .finance_client import FinanceClient, FinanceClientError
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -59,6 +64,26 @@ def classify_event(event: Event) -> List[TagResult]:
     classifier: Classifier | None = get_classifier(event.event_type)
     if classifier is None:
         classifier = get_classifier("default")
-    if classifier is None:
-        return []
-    return classifier.classify(event.payload)
+    results: List[TagResult] = []
+    if classifier is not None:
+        results = classifier.classify(event.payload)
+
+    # Detect financial transactions and categorise via finance-engine
+    payload = event.payload
+    transaction = payload.get("transaction")
+    if not transaction:
+        attrs = payload.get("attributes")
+        if isinstance(attrs, dict):
+            transaction = attrs.get("transaction")
+    if isinstance(transaction, dict):
+        try:
+            with FinanceClient() as client:
+                categories = client.categorize(transaction)
+            results.extend(
+                TagResult(tag=f"finance:{c.lower().replace(' ', '_')}", confidence=1.0)
+                for c in categories
+            )
+        except FinanceClientError as exc:  # pragma: no cover - network failures
+            logger.warning("Finance engine categorisation failed: %s", exc)
+
+    return results

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -109,6 +109,9 @@ class Settings(BaseSettings):  # type: ignore[misc]
     # Tweet bot
     TWITTER_BEARER_TOKEN: str | None = None
 
+    # Finance engine
+    FINANCE_ENGINE_URL: str = "http://finance-engine:8000"
+
     # Angel Bridge
     ANGEL_BRIDGE_LOOKBACK_HOURS: int = 24
 

--- a/tests/test_finance_classification.py
+++ b/tests/test_finance_classification.py
@@ -1,0 +1,29 @@
+import httpx
+import pytest
+
+from ume.event import Event
+from ume.classification.service import classify_event
+
+respx = pytest.importorskip("respx")
+
+
+def make_event() -> Event:
+    return Event(event_type="CREATE_NODE", timestamp=0, payload={"transaction": {"amount": 1}})
+
+
+def test_classify_event_finance_categories() -> None:
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post("http://finance-engine:8000/categorize").mock(
+            return_value=httpx.Response(200, json={"categories": ["Food", "Rent"]})
+        )
+        results = classify_event(make_event())
+        assert [r.tag for r in results] == ["finance:food", "finance:rent"]
+
+
+def test_classify_event_finance_error() -> None:
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post("http://finance-engine:8000/categorize").mock(
+            side_effect=httpx.ConnectError("boom")
+        )
+        results = classify_event(make_event())
+        assert results == []


### PR DESCRIPTION
## Summary
- categorize transaction events via external finance-engine
- add finance client and setting to contact finance-engine
- classify transaction categories into finance tags

## Testing
- `pre-commit run --files src/ume/classification/service.py src/ume/config/__init__.py src/ume/classification/finance_client.py tests/test_finance_classification.py`
- `pytest tests/test_finance_classification.py`


------
https://chatgpt.com/codex/tasks/task_e_688e609293d08326b1b17bd49f99b4ff