### PR TITLE
feat: add tino-storm classifier

### DIFF
--- a/src/ume/classification/service.py
+++ b/src/ume/classification/service.py
@@ -10,6 +10,7 @@ import logging
 from ..event import Event
 from .plugins import Classifier, get_classifier, register_classifier
 from .finance_client import FinanceClient, FinanceClientError
+from .tino_storm import TinoStormClassifier, TinoStormError
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +21,9 @@ class TagResult:
 
     tag: str
     confidence: float
+    domain: str | None = None
+    subdomain: str | None = None
+    sensitivity: str | None = None
 
 
 class KeywordClassifier:
@@ -54,8 +58,9 @@ class KeywordClassifier:
         return results
 
 
-# Register the default classifier for generic use
+# Register built-in classifiers
 register_classifier("default", KeywordClassifier())
+register_classifier("tino_storm", TinoStormClassifier())
 
 
 def classify_event(event: Event) -> List[TagResult]:
@@ -66,7 +71,14 @@ def classify_event(event: Event) -> List[TagResult]:
         classifier = get_classifier("default")
     results: List[TagResult] = []
     if classifier is not None:
-        results = classifier.classify(event.payload)
+        results.extend(classifier.classify(event.payload))
+
+    tino_classifier = get_classifier("tino_storm")
+    if tino_classifier is not None:
+        try:
+            results.extend(tino_classifier.classify(event.payload))
+        except TinoStormError as exc:  # pragma: no cover - network failures
+            logger.warning("Tino-storm classification failed: %s", exc)
 
     # Detect financial transactions and categorise via finance-engine
     payload = event.payload

--- a/src/ume/classification/tino_storm.py
+++ b/src/ume/classification/tino_storm.py
@@ -1,0 +1,111 @@
+"""Classifier integration for the tino-storm service or a local NLP model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Optional, TYPE_CHECKING
+
+import httpx
+
+from ..config import settings
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .service import TagResult
+
+
+class TinoStormError(Exception):
+    """Errors raised when communicating with tino-storm."""
+
+
+@dataclass
+class _LocalRule:
+    keyword: str
+    domain: str
+    subdomain: str
+    sensitivity: str
+
+
+class TinoStormClassifier:
+    """Classifier calling tino-storm remotely or a simple local NLP model."""
+
+    def __init__(
+        self,
+        base_url: Optional[str] = None,
+        local_model: Optional[str] = None,
+    ) -> None:
+        self.base_url = (base_url or getattr(settings, "TINO_STORM_URL", None))
+        self.local_model = local_model or getattr(settings, "TINO_STORM_LOCAL_MODEL", None)
+        if self.base_url:
+            self.base_url = self.base_url.rstrip("/")
+            self._client: Optional[httpx.Client] = httpx.Client(timeout=5.0)
+        else:
+            self._client = None
+        # Very small rule-based model for local classification
+        self._rules = [
+            _LocalRule("password", "credentials", "password", "high"),
+            _LocalRule("email", "contact", "email", "medium"),
+        ]
+
+    def classify(self, payload: dict[str, Any]) -> List["TagResult"]:
+        text = self._extract_text(payload)
+        if not text:
+            return []
+
+        if self._client and self.base_url:
+            url = f"{self.base_url}/classify"
+            try:
+                from .service import TagResult
+
+                resp = self._client.post(url, json={"text": text})
+                resp.raise_for_status()
+                data = resp.json()
+                domain = data.get("domain")
+                subdomain = data.get("subdomain")
+                sensitivity = data.get("sensitivity")
+                confidence = float(data.get("confidence", 1.0))
+                if domain and subdomain and sensitivity:
+                    tag = f"{domain}:{subdomain}:{sensitivity}"
+                    return [
+                        TagResult(
+                            tag=tag,
+                            confidence=confidence,
+                            domain=domain,
+                            subdomain=subdomain,
+                            sensitivity=sensitivity,
+                        )
+                    ]
+                return []
+            except Exception as exc:  # pragma: no cover - network errors
+                raise TinoStormError(str(exc)) from exc
+
+        # Local rule-based classification
+        from .service import TagResult
+
+        lower = text.lower()
+        for rule in self._rules:
+            if rule.keyword in lower:
+                tag = f"{rule.domain}:{rule.subdomain}:{rule.sensitivity}"
+                return [
+                    TagResult(
+                        tag=tag,
+                        confidence=1.0,
+                        domain=rule.domain,
+                        subdomain=rule.subdomain,
+                        sensitivity=rule.sensitivity,
+                    )
+                ]
+        return []
+
+    @staticmethod
+    def _extract_text(payload: dict[str, Any]) -> str | None:
+        for key, value in payload.items():
+            if key == "node_id":
+                continue
+            if isinstance(value, str):
+                return value
+        attrs = payload.get("attributes")
+        if isinstance(attrs, dict):
+            for value in attrs.values():
+                if isinstance(value, str):
+                    return value
+        return None

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -112,6 +112,10 @@ class Settings(BaseSettings):  # type: ignore[misc]
     # Finance engine
     FINANCE_ENGINE_URL: str = "http://finance-engine:8000"
 
+    # Tino-storm classifier
+    TINO_STORM_URL: str | None = None
+    TINO_STORM_LOCAL_MODEL: str | None = None
+
     # Angel Bridge
     ANGEL_BRIDGE_LOOKBACK_HOURS: int = 24
 

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -48,12 +48,26 @@ def ingest_event(data: Dict[str, Any], graph: IGraphAdapter) -> None:
 
     tag_results = classify_event(event)
     event.payload["classification"] = [
-        {"tag": r.tag, "confidence": r.confidence} for r in tag_results
+        {
+            "tag": r.tag,
+            "confidence": r.confidence,
+            "domain": r.domain,
+            "subdomain": r.subdomain,
+            "sensitivity": r.sensitivity,
+        }
+        for r in tag_results
     ]
     if tag_results:
         attributes = event.payload.setdefault("attributes", {})
         attributes["tags"] = [r.tag for r in tag_results]
         attributes["tag_confidence"] = [r.confidence for r in tag_results]
+        for r in tag_results:
+            if r.domain and "domain" not in attributes:
+                attributes["domain"] = r.domain
+            if r.subdomain and "subdomain" not in attributes:
+                attributes["subdomain"] = r.subdomain
+            if r.sensitivity and "sensitivity" not in attributes:
+                attributes["sensitivity"] = r.sensitivity
 
     apply_event(event, graph)
 

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -32,5 +32,11 @@ def test_ingest_event_classifies_and_persists_tags(monkeypatch) -> None:
 
     event = captured["event"]
     assert event.payload["classification"] == [
-        {"tag": "malware", "confidence": 1.0}
+        {
+            "tag": "malware",
+            "confidence": 1.0,
+            "domain": None,
+            "subdomain": None,
+            "sensitivity": None,
+        }
     ]

--- a/tests/test_tino_storm_classifier.py
+++ b/tests/test_tino_storm_classifier.py
@@ -1,0 +1,51 @@
+import httpx
+import respx
+
+from ume.classification.tino_storm import TinoStormClassifier
+from ume.services import ingest_event
+from ume.graph import MockGraph
+from ume.classification.plugins import register_classifier
+
+
+def _make_event(text: str) -> dict[str, object]:
+    return {
+        "event_type": "CREATE_NODE",
+        "timestamp": 0,
+        "node_id": "node1",
+        "payload": {"node_id": "node1", "attributes": {"content": text}},
+    }
+
+
+def test_tino_storm_local_classification(monkeypatch) -> None:
+    graph = MockGraph()
+    classifier = TinoStormClassifier(base_url=None)
+    register_classifier("tino_storm", classifier)
+    ingest_event(_make_event("This contains a password."), graph)
+    stored = graph.get_node("node1")
+    assert stored["domain"] == "credentials"
+    assert stored["subdomain"] == "password"
+    assert stored["sensitivity"] == "high"
+
+
+@respx.mock
+def test_tino_storm_remote_classification(monkeypatch) -> None:
+    url = "http://tino/api"
+    respx.post(f"{url}/classify").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "domain": "finance",
+                "subdomain": "bank",
+                "sensitivity": "high",
+                "confidence": 0.9,
+            },
+        )
+    )
+    classifier = TinoStormClassifier(base_url=url)
+    register_classifier("tino_storm", classifier)
+    graph = MockGraph()
+    ingest_event(_make_event("some text"), graph)
+    stored = graph.get_node("node1")
+    assert stored["domain"] == "finance"
+    assert stored["subdomain"] == "bank"
+    assert stored["sensitivity"] == "high"


### PR DESCRIPTION
## Summary
- add `TinoStormClassifier` that can call a remote tino-storm service or use a local rule-based model
- enrich TagResult and ingestion to persist domain, subdomain, and sensitivity on nodes
- expose configuration for remote URL or local model selection

## Testing
- `pre-commit run --files src/ume/classification/service.py src/ume/config/__init__.py src/ume/services/ingest.py src/ume/classification/tino_storm.py tests/test_classification.py tests/test_tino_storm_classifier.py`
- `pytest tests/test_classification.py tests/test_finance_classification.py tests/test_tino_storm_classifier.py`


------
https://chatgpt.com/codex/tasks/task_e_688e88d57a908326a38cceb1cf8cc2f0