### PR TITLE
feat: add events query endpoint with tag filter

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -169,6 +169,13 @@ Return basic graph and vector index statistics.
 Return recent audit log entries, newest first.
 - **Query parameters**: optional `limit` (default `10`).
 
+### GET `/events`
+Query events or nodes stored in the graph.
+- **Query parameters**:
+  - `tag` – return only entries whose `tags` list contains this value.
+  - `node_id` – optionally restrict results to a specific node.
+  - `limit` – maximum number of results (default `100`).
+
 ### POST `/events`
 Validate and apply an event to the graph. This endpoint is also available as
 `/store`.

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -17,7 +17,7 @@ from .reliability import filter_low_confidence
 import inspect
 from .graph_adapter import IGraphAdapter
 from .async_graph_adapter import IAsyncGraphAdapter, ingest_event_async
-from .query import Neo4jQueryEngine
+from .query import Neo4jQueryEngine, build_events_query
 from .event import EventError
 from .processing import ProcessingError
 from ume.services.ingest import ingest_event, ingest_events_batch
@@ -363,6 +363,20 @@ async def api_get_entity(
 ) -> Dict[str, Any]:
     """Return node ``id`` if its ``type`` matches the path parameter."""
     return {"id": id, "attributes": entity}
+
+
+@router.get("/events")
+def api_get_events(
+    tag: str | None = Query(None),
+    node_id: str | None = Query(None),
+    limit: int = Query(100, ge=1),
+    _: str = Depends(deps.get_current_role),
+    engine: Neo4jQueryEngine = Depends(deps.get_query_engine),
+) -> List[Dict[str, Any]]:
+    """Query events filtered by optional ``tag`` or ``node_id``."""
+
+    cypher, params = build_events_query(tag=tag, node_id=node_id, limit=limit)
+    return engine.execute_cypher(cypher, params)
 
 
 @router.post("/events")

--- a/src/ume/query.py
+++ b/src/ume/query.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
-from neo4j import GraphDatabase, Driver
+from neo4j import Driver, GraphDatabase
 
 
 class Neo4jQueryEngine:
@@ -43,3 +43,32 @@ class Neo4jQueryEngine:
         with self._driver.session() as session:
             result = session.run(query, parameters or {})
             return [record.data() for record in result]
+
+
+def build_events_query(
+    *,
+    tag: str | None = None,
+    node_id: str | None = None,
+    limit: int = 100,
+) -> Tuple[str, Dict[str, Any]]:
+    """Return Cypher and parameters to fetch events filtered by ``tag``.
+
+    The returned statement matches nodes in the graph and optionally restricts
+    results to those whose ``tags`` list contains ``tag`` or whose ``id``
+    matches ``node_id``. Results are limited by ``limit``.
+    """
+
+    params: Dict[str, Any] = {"limit": limit}
+    clauses: List[str] = []
+    if tag is not None:
+        params["tag"] = tag
+        clauses.append("$tag IN n.tags")
+    if node_id is not None:
+        params["node_id"] = node_id
+        clauses.append("n.id = $node_id")
+
+    query = "MATCH (n)"
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
+    query += " RETURN n LIMIT $limit"
+    return query, params

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -77,6 +77,32 @@ def test_post_event_requires_auth(client_and_graph):
     assert res.status_code == 401
 
 
+def test_get_events_with_tag(client_and_graph):
+    client, _ = client_and_graph
+    token = _token(client)
+
+    class QE:
+        def __init__(self) -> None:
+            self.last: tuple[str, dict[str, object]] | None = None
+
+        def execute_cypher(self, query, parameters=None):
+            self.last = (query, parameters or {})
+            return [{"id": "n1"}]
+
+    app.state.query_engine = QE()
+
+    res = client.get(
+        "/events",
+        params={"tag": "malware"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert res.status_code == 200
+    assert res.json() == [{"id": "n1"}]
+    qe = app.state.query_engine
+    assert qe.last is not None and qe.last[1]["tag"] == "malware"
+
+
 def test_post_events_batch(client_and_graph) -> None:
     client, g = client_and_graph
     token = _token(client)


### PR DESCRIPTION
## Summary
- add `/events` GET endpoint to query events by optional tag or node ID
- support building tag-based Cypher queries
- document `/events` query parameters and test filtering

## Testing
- `pre-commit run --files docs/API_REFERENCE.md src/ume/graph_routes.py src/ume/query.py tests/test_api_events.py`
- `pytest tests/test_api_events.py tests/test_query.py`


------
https://chatgpt.com/codex/tasks/task_e_688eaa3e0f7c83268824c0f472745e97