### PR TITLE
Add deterministic classification and anomaly tests

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -133,7 +133,7 @@
         "filename": "tests/conftest.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 180
+        "line_number": 216
       }
     ],
     "tests/test_anonymizer.py": [
@@ -146,5 +146,5 @@
       }
     ]
   },
-  "generated_at": "2025-07-22T01:24:18Z"
+  "generated_at": "2025-08-03T00:51:38Z"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,6 +132,8 @@ for _package in _OPTIONAL_PACKAGES:
         if _package == "neo4j":
             module.GraphDatabase = object
             module.Driver = object
+        if _package == "grpc":
+            module.__version__ = "0"
         if _package == "structlog":
             proc = type("P", (), {})
             module.contextvars = types.SimpleNamespace(
@@ -282,4 +284,40 @@ def _restore_env() -> Generator[None, None, None]:
         return
     if getattr(pkg, "__path__", None):
         importlib.reload(module)
+
+
+@pytest.fixture
+def finance_engine_mock():
+    httpx = pytest.importorskip("httpx")
+    respx = pytest.importorskip("respx")
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post("http://finance-engine:8000/categorize").mock(
+            return_value=httpx.Response(200, json={"categories": ["Food"]})
+        )
+        yield mock
+
+
+@pytest.fixture
+def tino_storm_mock():
+    httpx = pytest.importorskip("httpx")
+    respx = pytest.importorskip("respx")
+    from ume.classification.tino_storm import TinoStormClassifier
+    from ume.classification.plugins import register_classifier
+
+    url = "http://tino"
+    with respx.mock(assert_all_called=True) as mock:
+        mock.post(f"{url}/classify").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "domain": "research",
+                    "subdomain": "ml",
+                    "sensitivity": "low",
+                    "confidence": 1.0,
+                },
+            )
+        )
+        register_classifier("tino_storm", TinoStormClassifier(base_url=url))
+        yield mock
+    register_classifier("tino_storm", TinoStormClassifier())
 

--- a/tests/test_anomaly_detection.py
+++ b/tests/test_anomaly_detection.py
@@ -1,34 +1,38 @@
-from ume.event import EventType
-from ume.graph import MockGraph
-from ume.services import ingest as ingest_module
+from dataclasses import asdict
+
+from ume.event import Event, EventType
+from ume.classification.service import classify_event
+from ume.anomaly_detection import AnomalyDetector
 
 
-def test_ingest_emits_anomaly_event(monkeypatch):
-    events: list[str] = []
+def _make_event(source: str, payload: dict[str, object]) -> Event:
+    return Event(event_type=EventType.CREATE_NODE, timestamp=0, payload=payload, source=source)
 
-    def fake_apply_event(event, graph):
-        events.append(event.event_type)
 
-    monkeypatch.setattr(ingest_module, "apply_event", fake_apply_event)
+def test_no_anomaly_within_threshold(finance_engine_mock) -> None:
+    detector = AnomalyDetector(threshold=0.5)
+    e1 = _make_event("entity", {"transaction": {"amount": 1}})
+    e1.payload["classification"] = [asdict(r) for r in classify_event(e1)]
+    assert detector.process_event(e1) is None
+    e2 = _make_event("entity", {"transaction": {"amount": 2}})
+    e2.payload["classification"] = [asdict(r) for r in classify_event(e2)]
+    assert detector.process_event(e2) is None
 
-    graph = MockGraph()
 
-    data1 = {
-        "eventType": EventType.CREATE_NODE.value,
-        "timestamp": 0,
-        "node_id": "n1",
-        "payload": {"node_id": "n1", "attributes": {"name": "malware incident"}},
-        "sourceService": "user1",
-    }
-    ingest_module.ingest_event(data1, graph)
+def test_emits_anomaly_when_threshold_exceeded(
+    finance_engine_mock, tino_storm_mock
+) -> None:
+    detector = AnomalyDetector(threshold=0.1)
+    e1 = _make_event("entity", {"transaction": {"amount": 1}})
+    e1.payload["classification"] = [asdict(r) for r in classify_event(e1)]
+    detector.process_event(e1)
+    e2 = _make_event("entity", {"transaction": {"amount": 2}})
+    e2.payload["classification"] = [asdict(r) for r in classify_event(e2)]
+    detector.process_event(e2)
+    e3 = _make_event("entity", {"attributes": {"content": "some text"}})
+    e3.payload["classification"] = [asdict(r) for r in classify_event(e3)]
+    anomaly = detector.process_event(e3)
+    assert anomaly is not None
+    assert anomaly.event_type == EventType.ANOMALY_DETECTED
+    assert anomaly.payload["tags"] == ["research:ml:low"]
 
-    data2 = {
-        "eventType": EventType.CREATE_NODE.value,
-        "timestamp": 1,
-        "node_id": "n2",
-        "payload": {"node_id": "n2", "attributes": {"name": "phishing attempt"}},
-        "sourceService": "user1",
-    }
-    ingest_module.ingest_event(data2, graph)
-
-    assert EventType.ANOMALY_DETECTED.value in events

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -2,6 +2,8 @@ import ume.services.ingest as ingest_module
 from ume.graph import MockGraph
 from ume.services import ingest_event
 from ume.processing import apply_event_to_graph
+from ume.event import Event
+from ume.classification.service import classify_event
 
 
 def test_ingest_event_classifies_and_persists_tags(monkeypatch) -> None:
@@ -40,3 +42,20 @@ def test_ingest_event_classifies_and_persists_tags(monkeypatch) -> None:
             "sensitivity": None,
         }
     ]
+
+
+def test_finance_tag_generation(finance_engine_mock) -> None:
+    event = Event(event_type="CREATE_NODE", timestamp=0, payload={"transaction": {"amount": 1}})
+    results = classify_event(event)
+    assert [r.tag for r in results] == ["finance:food"]
+
+
+def test_research_tag_generation(tino_storm_mock) -> None:
+    event = Event(
+        event_type="CREATE_NODE",
+        timestamp=0,
+        payload={"attributes": {"content": "some text"}},
+    )
+    results = classify_event(event)
+    assert [r.tag for r in results] == ["research:ml:low"]
+    assert results[0].domain == "research"


### PR DESCRIPTION
## Summary
- add fixtures for finance-engine and tino-storm mocks
- test finance and research tag generation
- test anomaly detection threshold and event emission

## Testing
- `pre-commit run --files tests/conftest.py tests/test_classification.py tests/test_anomaly_detection.py .secrets.baseline`
- `pytest tests/test_classification.py tests/test_anomaly_detection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688eb129f02c8326918cdd1d1c192d76