### PR TITLE
Document event tagging and anomaly detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,41 @@ When nodes include textual attributes, the consumer generates vector embeddings 
 
 This pipeline demonstrates how UME transforms incoming events into a persistent knowledge graph.
 
+## Event Tags and Anomaly Detection
+
+Ingested events are passed through the classification service which attaches one or more **tags** to the event's `classification` field. Tags are assigned by registered classifiers and can later be used to filter or analyze events.
+
+To retrieve events carrying a specific tag:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  "http://localhost:8000/events?tag=phishing"
+```
+
+The `AnomalyDetector` tracks how often each tag appears for a given entity. If the frequency of a tag changes more than the configured threshold, an `ANOMALY_DETECTED` event is emitted.
+
+### Registering a classifier
+
+```python
+from ume.classification.plugins import register_classifier, Classifier, TagResult
+
+class MyClassifier(Classifier):
+    def classify(self, payload: dict) -> list[TagResult]:
+        return [TagResult(tag="custom", confidence=1.0)]
+
+register_classifier("MY_EVENT", MyClassifier())
+```
+
+### Adjusting anomaly thresholds
+
+```python
+from ume.anomaly_detection import AnomalyDetector
+
+detector = AnomalyDetector(threshold=0.2)
+```
+
+For more details see [docs/TAGS_AND_ANOMALIES.md](docs/TAGS_AND_ANOMALIES.md).
+
 ## UME Graph Model
 
 A core aspect of the Universal Memory Engine (UME) is its ability to construct a knowledge graph from the events it processes. This graph serves as the dynamic, queryable memory for agents and automations.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -176,6 +176,13 @@ Query events or nodes stored in the graph.
   - `node_id` – optionally restrict results to a specific node.
   - `limit` – maximum number of results (default `100`).
 
+Example:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  "http://localhost:8000/events?tag=phishing"
+```
+
 ### POST `/events`
 Validate and apply an event to the graph. This endpoint is also available as
 `/store`.

--- a/docs/TAGS_AND_ANOMALIES.md
+++ b/docs/TAGS_AND_ANOMALIES.md
@@ -1,0 +1,63 @@
+# Event Tags and Anomalies
+
+## Event Tags
+
+UME classifies each ingested event and appends the resulting tags to the event's `classification` field. Tags originate from registered classifiers. Built‑in classifiers include a keyword matcher and optional external services such as `tino_storm`.
+
+## Querying by Tag
+
+Tags can be used to filter event history:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  "http://localhost:8000/events?tag=phishing"
+```
+
+## Registering Custom Classifiers
+
+```python
+from ume.classification.plugins import register_classifier, Classifier, TagResult
+
+class MyClassifier(Classifier):
+    def classify(self, payload: dict) -> list[TagResult]:
+        # inspect payload and return tag results
+        return [TagResult(tag="custom", confidence=1.0)]
+
+register_classifier("MY_EVENT", MyClassifier())
+```
+
+## Anomaly Detection
+
+The `AnomalyDetector` keeps tag statistics per entity (based on `source` or `subject_entity`). If a tag's frequency shifts beyond the configured threshold, the detector emits an `ANOMALY_DETECTED` event:
+
+```json
+{
+  "event_type": "ANOMALY_DETECTED",
+  "timestamp": 1713275452,
+  "payload": {"entity_id": "agent_42", "tags": ["phishing"]},
+  "source": "agent_42"
+}
+```
+
+## Configuration Examples
+
+### Register a new classifier
+
+The previous Python snippet can be placed in your service startup code to register a classifier. Alternatively, you can load classifiers conditionally using environment variables.
+
+### Adjust anomaly threshold
+
+```python
+from ume.anomaly_detection import AnomalyDetector
+
+threshold = 0.2  # more sensitive
+# threshold = float(os.environ.get("ANOMALY_THRESHOLD", 0.4))
+
+detector = AnomalyDetector(threshold=threshold)
+```
+
+```dotenv
+ANOMALY_THRESHOLD=0.2
+```
+
+Setting a lower threshold makes the detector more sensitive to changes in tag frequencies.


### PR DESCRIPTION
## Summary
- document how events are tagged and filtered
- describe anomaly detection and classifier configuration
- add API example for querying events by tag

## Testing
- no tests were run; docs only

------
https://chatgpt.com/codex/tasks/task_e_688eb4fec8cc83268c165e6d91f0a442