### PR TITLE
Add graph schema v3 and upgrade logic

### DIFF
--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -15,6 +15,7 @@ class NodeType:
 
     name: str
     version: str
+    permission_level: str | None = None
 
 
 @dataclass
@@ -23,6 +24,7 @@ class EdgeLabel:
 
     label: str
     version: str
+    permission_level: str | None = None
 
 
 @dataclass
@@ -42,11 +44,19 @@ class GraphSchema:
             else:
                 data = json.load(f)
         node_types = {
-            name: NodeType(name=name, version=str(info.get("version", "0.0.0")))
+            name: NodeType(
+                name=name,
+                version=str(info.get("version", "0.0.0")),
+                permission_level=info.get("permission_level"),
+            )
             for name, info in data.get("node_types", {}).items()
         }
         edge_labels = {
-            label: EdgeLabel(label=label, version=str(info.get("version", "0.0.0")))
+            label: EdgeLabel(
+                label=label,
+                version=str(info.get("version", "0.0.0")),
+                permission_level=info.get("permission_level"),
+            )
             for label, info in data.get("edge_labels", {}).items()
         }
         version = str(data.get("version", "0.0.0"))

--- a/src/ume/protos/__init__.py
+++ b/src/ume/protos/__init__.py
@@ -5,6 +5,7 @@ from . import graph_v1_pb2, graph_v2_pb2
 PROTO_MAP = {
     "1.0.0": graph_v1_pb2,
     "2.0.0": graph_v2_pb2,
+    "3.0.0": graph_v2_pb2,
 }
 
 __all__ = ["PROTO_MAP"]

--- a/src/ume/schema_manager.py
+++ b/src/ume/schema_manager.py
@@ -75,13 +75,29 @@ class GraphSchemaManager:
         self.get_schema(old_version)  # validate versions exist
         new_schema = self.get_schema(new_version)
 
-        if graph is not None and old_version == "1.0.0" and new_version == "2.0.0":
-            for src, tgt, label in list(graph.get_all_edges()):
-                if label == "L":
-                    graph.delete_edge(src, tgt, label)
-                    graph.add_edge(src, tgt, "LINKS_TO")
-                elif label == "TO_DELETE":
-                    graph.delete_edge(src, tgt, label)
+        if graph is not None:
+            if old_version == "1.0.0":
+                for src, tgt, label in list(graph.get_all_edges()):
+                    if label == "L":
+                        graph.delete_edge(src, tgt, label)
+                        graph.add_edge(src, tgt, "LINKS_TO")
+                    elif label == "TO_DELETE":
+                        graph.delete_edge(src, tgt, label)
+
+            if new_version == "3.0.0":
+                for src, tgt, label in list(graph.get_all_edges()):
+                    if label == "NEW_LABEL":
+                        graph.delete_edge(src, tgt, label)
+                        graph.add_edge(src, tgt, "TAGGED_AS")
+                    elif label in {
+                        "REMEMBERS",
+                        "ASSOCIATED_WITH",
+                        "CAUSES",
+                        "LINKS_TO",
+                        "CONNECTS_TO",
+                        "RELATES_TO",
+                    }:
+                        graph.delete_edge(src, tgt, label)
 
         return new_schema
 

--- a/src/ume/schemas/graph_schema_v3.yaml
+++ b/src/ume/schemas/graph_schema_v3.yaml
@@ -1,0 +1,39 @@
+version: "3.0.0"
+node_types:
+  User:
+    version: "3.0.0"
+    permission_level: "public"
+  UserGroup:
+    version: "3.0.0"
+    permission_level: "public"
+  CalendarEvent:
+    version: "3.0.0"
+    permission_level: "public"
+  CalendarLayer:
+    version: "3.0.0"
+    permission_level: "public"
+  DecisionAnalysis:
+    version: "3.0.0"
+    permission_level: "public"
+  ProposedAction:
+    version: "3.0.0"
+    permission_level: "public"
+  FinancialAccount:
+    version: "3.0.0"
+    permission_level: "public"
+edge_labels:
+  OWNED_BY:
+    version: "3.0.0"
+    permission_level: "public"
+  SHARED_WITH:
+    version: "3.0.0"
+    permission_level: "public"
+  INVITES:
+    version: "3.0.0"
+    permission_level: "public"
+  TAGGED_AS:
+    version: "3.0.0"
+    permission_level: "public"
+  CONSIDERS:
+    version: "3.0.0"
+    permission_level: "public"

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -27,6 +27,7 @@ def test_schema_manager_loads_versions():
     versions = set(manager.available_versions())
     assert "1.0.0" in versions
     assert "2.0.0" in versions
+    assert "3.0.0" in versions
 
 
 def test_get_schema_returns_correct_version():
@@ -47,6 +48,8 @@ def test_proto_lookup():
     manager = GraphSchemaManager()
     proto = manager.get_proto("1.0.0")
     assert hasattr(proto, "Graph")
+    proto3 = manager.get_proto("3.0.0")
+    assert hasattr(proto3, "Graph")
 
 
 def test_register_schema(tmp_path: Path):
@@ -95,3 +98,21 @@ def test_upgrade_transforms_graph(graph: PersistentGraph) -> None:
     assert ("a", "b", "LINKS_TO") in edges
     assert all(lbl != "L" for _, _, lbl in edges)
     assert all(lbl != "TO_DELETE" for _, _, lbl in edges)
+
+
+def test_upgrade_to_v3_transforms_graph(graph: PersistentGraph) -> None:
+    graph.add_node("a", {})
+    graph.add_node("b", {})
+    graph.add_edge("a", "b", "L")
+    graph.add_edge("b", "a", "TO_DELETE")
+    graph.add_edge("a", "b", "NEW_LABEL")
+    graph.add_edge("b", "a", "REMEMBERS")
+
+    manager = GraphSchemaManager()
+    manager.upgrade_schema("1.0.0", "3.0.0", graph)
+
+    edges = graph.get_all_edges()
+    assert ("a", "b", "TAGGED_AS") in edges
+    assert all(
+        lbl == "TAGGED_AS" for _, _, lbl in edges
+    )


### PR DESCRIPTION
## Summary
- add graph schema v3 with new node and edge types including permission levels
- track permission levels in NodeType and EdgeLabel and parse them when loading schemas
- support upgrading graphs to schema v3 and register v3 in proto map
- test schema manager upgrades to v3

## Testing
- `ruff check src/ume/graph_schema.py src/ume/schema_manager.py src/ume/protos/__init__.py tests/test_schema_manager.py`
- `pytest tests/test_schema_manager.py -q` *(skipped: sentence_transformers)*
- `pytest tests/test_graph_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688f90bfa14c8326b6bd21bac11665fd