### PR TITLE
Add dataclass models for core node types

### DIFF
--- a/src/ume/models/__init__.py
+++ b/src/ume/models/__init__.py
@@ -1,0 +1,17 @@
+"""Dataclass models representing various graph node types."""
+
+from .users import User, create_user
+from .calendar import CalendarEvent, create_calendar_event
+from .decisions import Decision, create_decision
+from .finance import Transaction, create_transaction
+
+__all__ = [
+    "User",
+    "create_user",
+    "CalendarEvent",
+    "create_calendar_event",
+    "Decision",
+    "create_decision",
+    "Transaction",
+    "create_transaction",
+]

--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -1,0 +1,40 @@
+"""Calendar event node model and factory helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import uuid
+
+SCHEMA_VERSION = "1.0"
+
+
+@dataclass
+class CalendarEvent:
+    """Represents a calendar event in the graph."""
+
+    id: str
+    title: str
+    start: datetime
+    end: datetime | None = None
+    description: str | None = None
+    schema_version: str = SCHEMA_VERSION
+
+
+def create_calendar_event(
+    title: str,
+    start: datetime,
+    end: datetime | None = None,
+    *,
+    description: str | None = None,
+    event_id: str | None = None,
+) -> CalendarEvent:
+    """Factory helper to build :class:`CalendarEvent` instances."""
+
+    return CalendarEvent(
+        id=event_id or str(uuid.uuid4()),
+        title=title,
+        start=start,
+        end=end,
+        description=description,
+    )

--- a/src/ume/models/decisions.py
+++ b/src/ume/models/decisions.py
@@ -1,0 +1,37 @@
+"""Decision node model and factory helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import uuid
+
+SCHEMA_VERSION = "1.0"
+
+
+@dataclass
+class Decision:
+    """Represents a decision in the graph."""
+
+    id: str
+    description: str
+    made_by: str | None = None
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    schema_version: str = SCHEMA_VERSION
+
+
+def create_decision(
+    description: str,
+    *,
+    made_by: str | None = None,
+    decision_id: str | None = None,
+    timestamp: datetime | None = None,
+) -> Decision:
+    """Factory helper to build :class:`Decision` instances."""
+
+    return Decision(
+        id=decision_id or str(uuid.uuid4()),
+        description=description,
+        made_by=made_by,
+        timestamp=timestamp or datetime.utcnow(),
+    )

--- a/src/ume/models/finance.py
+++ b/src/ume/models/finance.py
@@ -1,0 +1,40 @@
+"""Finance transaction node model and factory helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import uuid
+
+SCHEMA_VERSION = "1.0"
+
+
+@dataclass
+class Transaction:
+    """Represents a financial transaction in the graph."""
+
+    id: str
+    amount: float
+    currency: str = "USD"
+    description: str | None = None
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+    schema_version: str = SCHEMA_VERSION
+
+
+def create_transaction(
+    amount: float,
+    *,
+    currency: str = "USD",
+    description: str | None = None,
+    transaction_id: str | None = None,
+    timestamp: datetime | None = None,
+) -> Transaction:
+    """Factory helper to build :class:`Transaction` instances."""
+
+    return Transaction(
+        id=transaction_id or str(uuid.uuid4()),
+        amount=amount,
+        currency=currency,
+        description=description,
+        timestamp=timestamp or datetime.utcnow(),
+    )

--- a/src/ume/models/users.py
+++ b/src/ume/models/users.py
@@ -1,0 +1,37 @@
+"""User node model and factory helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import uuid
+
+SCHEMA_VERSION = "1.0"
+
+
+@dataclass
+class User:
+    """Represents a user in the graph."""
+
+    id: str
+    name: str
+    email: str | None = None
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    schema_version: str = SCHEMA_VERSION
+
+
+def create_user(
+    name: str,
+    email: str | None = None,
+    *,
+    user_id: str | None = None,
+    created_at: datetime | None = None,
+) -> User:
+    """Factory helper to build :class:`User` instances."""
+
+    return User(
+        id=user_id or str(uuid.uuid4()),
+        name=name,
+        email=email,
+        created_at=created_at or datetime.utcnow(),
+    )


### PR DESCRIPTION
## Summary
- add dataclass models for users, calendar events, decisions, and transactions
- provide factory helpers for event producers

## Testing
- `pre-commit run --files src/ume/models/__init__.py src/ume/models/users.py src/ume/models/calendar.py src/ume/models/decisions.py src/ume/models/finance.py`
- `pytest` *(fails: 67 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688f90c0a9e08326a83c6a6cf98f28fb