### PR TITLE
Add decision analysis model

### DIFF
--- a/src/ume/models/__init__.py
+++ b/src/ume/models/__init__.py
@@ -4,6 +4,7 @@ from .users import User, create_user
 from .calendar import CalendarEvent, create_calendar_event
 from .decisions import Decision, create_decision
 from .finance import Transaction, create_transaction
+from .decision_analysis import DecisionAnalysis, create_decision_analysis
 
 __all__ = [
     "User",
@@ -12,6 +13,8 @@ __all__ = [
     "create_calendar_event",
     "Decision",
     "create_decision",
+    "DecisionAnalysis",
+    "create_decision_analysis",
     "Transaction",
     "create_transaction",
 ]

--- a/src/ume/models/decision_analysis.py
+++ b/src/ume/models/decision_analysis.py
@@ -1,0 +1,31 @@
+"""Decision analysis model and factory helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import uuid
+
+
+@dataclass
+class DecisionAnalysis:
+    """Represents the analysis of a decision query."""
+
+    analysis_id: str
+    query: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+def create_decision_analysis(
+    query: str,
+    *,
+    analysis_id: str | None = None,
+    created_at: datetime | None = None,
+) -> DecisionAnalysis:
+    """Factory helper to build :class:`DecisionAnalysis` instances."""
+
+    return DecisionAnalysis(
+        analysis_id=analysis_id or str(uuid.uuid4()),
+        query=query,
+        created_at=created_at or datetime.utcnow(),
+    )

--- a/tests/test_decision_analysis.py
+++ b/tests/test_decision_analysis.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+
+from ume.models import create_decision_analysis
+
+
+def test_create_decision_analysis_sets_created_at() -> None:
+    before = datetime.utcnow()
+    analysis = create_decision_analysis("how many decisions?")
+    assert analysis.query == "how many decisions?"
+    assert analysis.analysis_id
+    assert analysis.created_at >= before
+    assert analysis.created_at <= datetime.utcnow()


### PR DESCRIPTION
## Summary
- add `DecisionAnalysis` dataclass and factory
- expose decision analysis model in `ume.models`
- test creation of decision analysis instances

## Testing
- `pre-commit run --files src/ume/models/decision_analysis.py src/ume/models/__init__.py tests/test_decision_analysis.py`
- `pytest tests/test_decision_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd300503083268b492aea5753b571