### PR TITLE
Add financial account model and helper

### DIFF
--- a/src/ume/models/__init__.py
+++ b/src/ume/models/__init__.py
@@ -4,6 +4,7 @@ from .users import User, create_user
 from .calendar import CalendarEvent, create_calendar_event
 from .decisions import Decision, create_decision
 from .finance import Transaction, create_transaction
+from .financial_account import FinancialAccount, create_financial_account
 
 __all__ = [
     "User",
@@ -14,4 +15,6 @@ __all__ = [
     "create_decision",
     "Transaction",
     "create_transaction",
+    "FinancialAccount",
+    "create_financial_account",
 ]

--- a/src/ume/models/financial_account.py
+++ b/src/ume/models/financial_account.py
@@ -1,0 +1,36 @@
+"""Financial account node model and factory helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import uuid
+
+
+@dataclass
+class FinancialAccount:
+    """Represents a financial account in the graph."""
+
+    account_id: str
+    account_type: str
+    institution: str
+    balance: float
+    currency: str = "USD"
+
+
+def create_financial_account(
+    account_type: str,
+    institution: str,
+    balance: float,
+    *,
+    currency: str = "USD",
+    account_id: str | None = None,
+) -> FinancialAccount:
+    """Factory helper to build :class:`FinancialAccount` instances."""
+
+    return FinancialAccount(
+        account_id=account_id or str(uuid.uuid4()),
+        account_type=account_type,
+        institution=institution,
+        balance=balance,
+        currency=currency,
+    )

--- a/tests/test_financial_account_model.py
+++ b/tests/test_financial_account_model.py
@@ -1,0 +1,11 @@
+from ume.models import FinancialAccount, create_financial_account
+
+
+def test_create_financial_account() -> None:
+    account = create_financial_account("checking", "ACME Bank", 100.0)
+    assert isinstance(account, FinancialAccount)
+    assert account.account_type == "checking"
+    assert account.institution == "ACME Bank"
+    assert account.balance == 100.0
+    assert account.currency == "USD"
+    assert account.account_id


### PR DESCRIPTION
## Summary
- add FinancialAccount dataclass and factory helper
- expose FinancialAccount through models package
- test financial account creation helper

## Testing
- `pre-commit run --files src/ume/models/financial_account.py src/ume/models/__init__.py tests/test_financial_account_model.py`
- `pytest tests/test_financial_account_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd30167e08326bf0d9bf044bdcd4b