### PR TITLE
feat(models): introduce CalendarLayer dataclass and factory

### DIFF
--- a/src/ume/models/__init__.py
+++ b/src/ume/models/__init__.py
@@ -2,6 +2,7 @@
 
 from .users import User, create_user
 from .calendar import CalendarEvent, create_calendar_event
+from .calendar_layer import CalendarLayer, create_calendar_layer
 from .decisions import Decision, create_decision
 from .finance import Transaction, create_transaction
 
@@ -10,6 +11,8 @@ __all__ = [
     "create_user",
     "CalendarEvent",
     "create_calendar_event",
+    "CalendarLayer",
+    "create_calendar_layer",
     "Decision",
     "create_decision",
     "Transaction",

--- a/src/ume/models/calendar_layer.py
+++ b/src/ume/models/calendar_layer.py
@@ -1,0 +1,30 @@
+"""Calendar layer model and factory helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import uuid
+
+
+@dataclass
+class CalendarLayer:
+    """Represents a calendar layer in the graph."""
+
+    layer_id: str
+    layer_name: str
+    color: str
+
+
+def create_calendar_layer(
+    layer_name: str,
+    color: str,
+    *,
+    layer_id: str | None = None,
+) -> CalendarLayer:
+    """Factory helper to build :class:`CalendarLayer` instances."""
+
+    return CalendarLayer(
+        layer_id=layer_id or str(uuid.uuid4()),
+        layer_name=layer_name,
+        color=color,
+    )

--- a/tests/test_calendar_layer_model.py
+++ b/tests/test_calendar_layer_model.py
@@ -1,0 +1,16 @@
+from ume.models import CalendarLayer, create_calendar_layer
+import uuid
+
+
+def test_create_calendar_layer_generates_id() -> None:
+    layer = create_calendar_layer("Work", "blue")
+    assert isinstance(layer, CalendarLayer)
+    assert layer.layer_name == "Work"
+    assert layer.color == "blue"
+    uuid.UUID(layer.layer_id)
+
+
+def test_create_calendar_layer_with_provided_id() -> None:
+    custom_id = "123"
+    layer = create_calendar_layer("Personal", "red", layer_id=custom_id)
+    assert layer.layer_id == custom_id


### PR DESCRIPTION
## Summary
- expose CalendarLayer in models package
- add CalendarLayer dataclass and helper factory
- cover CalendarLayer creation with tests

## Testing
- `pre-commit run --files src/ume/models/calendar_layer.py src/ume/models/__init__.py tests/test_calendar_layer_model.py`
- `pytest tests/test_calendar_layer_model.py`


------
https://chatgpt.com/codex/tasks/task_e_688fd2ffea3083268c85d08943d08f45