### PR TITLE
Add UserGroup model and factory

### DIFF
--- a/src/ume/models/__init__.py
+++ b/src/ume/models/__init__.py
@@ -4,6 +4,7 @@ from .users import User, create_user
 from .calendar import CalendarEvent, create_calendar_event
 from .decisions import Decision, create_decision
 from .finance import Transaction, create_transaction
+from .user_group import UserGroup, create_user_group
 
 __all__ = [
     "User",
@@ -14,4 +15,6 @@ __all__ = [
     "create_decision",
     "Transaction",
     "create_transaction",
+    "UserGroup",
+    "create_user_group",
 ]

--- a/src/ume/models/user_group.py
+++ b/src/ume/models/user_group.py
@@ -1,0 +1,30 @@
+"""User group node model and factory helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import uuid
+
+
+@dataclass
+class UserGroup:
+    """Represents a group of users."""
+
+    group_id: str
+    name: str
+    members: list[str] = field(default_factory=list)
+
+
+def create_user_group(
+    name: str,
+    members: list[str] | None = None,
+    *,
+    group_id: str | None = None,
+) -> UserGroup:
+    """Factory helper to build :class:`UserGroup` instances."""
+
+    return UserGroup(
+        group_id=group_id or str(uuid.uuid4()),
+        name=name,
+        members=members or [],
+    )

--- a/tests/test_user_group.py
+++ b/tests/test_user_group.py
@@ -1,0 +1,18 @@
+from ume.models.user_group import create_user_group
+import uuid
+
+
+def test_create_user_group_generates_id_and_defaults_members():
+    group = create_user_group(name="Admins")
+    # Ensure generated ID is valid UUID
+    uuid.UUID(group.group_id)
+    assert group.name == "Admins"
+    assert group.members == []
+
+
+def test_create_user_group_accepts_members_and_id():
+    members = ["alice", "bob"]
+    custom_id = "custom-id"
+    group = create_user_group(name="Team", members=members, group_id=custom_id)
+    assert group.group_id == custom_id
+    assert group.members == members


### PR DESCRIPTION
## Summary
- add `UserGroup` dataclass and factory for building groups with generated IDs
- expose `UserGroup` via models package
- test `create_user_group` defaults and custom params

## Testing
- `pre-commit run --files src/ume/models/user_group.py src/ume/models/__init__.py tests/test_user_group.py`
- `pytest tests/test_user_group.py`

------
https://chatgpt.com/codex/tasks/task_e_688fd2ff678083268f3572f8c8ced40b