### PR TITLE
feat: extend calendar event model

### DIFF
--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -15,18 +15,28 @@ class CalendarEvent:
 
     id: str
     title: str
-    start: datetime
-    end: datetime | None = None
+    start_time: datetime
+    end_time: datetime | None = None
     description: str | None = None
+    is_all_day: bool = False
+    location: str | None = None
+    status: str | None = None
+    rrule: str | None = None
+    visibility: str | None = None
     schema_version: str = SCHEMA_VERSION
 
 
 def create_calendar_event(
     title: str,
-    start: datetime,
-    end: datetime | None = None,
+    start_time: datetime,
+    end_time: datetime | None = None,
     *,
     description: str | None = None,
+    is_all_day: bool = False,
+    location: str | None = None,
+    status: str | None = None,
+    rrule: str | None = None,
+    visibility: str | None = None,
     event_id: str | None = None,
 ) -> CalendarEvent:
     """Factory helper to build :class:`CalendarEvent` instances."""
@@ -34,7 +44,12 @@ def create_calendar_event(
     return CalendarEvent(
         id=event_id or str(uuid.uuid4()),
         title=title,
-        start=start,
-        end=end,
+        start_time=start_time,
+        end_time=end_time,
         description=description,
+        is_all_day=is_all_day,
+        location=location,
+        status=status,
+        rrule=rrule,
+        visibility=visibility,
     )

--- a/tests/models/test_calendar_event.py
+++ b/tests/models/test_calendar_event.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from ume.models.calendar import create_calendar_event
+
+def test_create_event_fields():
+    start = datetime(2024, 1, 1)
+    end = datetime(2024, 1, 2)
+    event = create_calendar_event(
+        "title",
+        start,
+        end,
+        description="desc",
+        is_all_day=True,
+        location="room",
+        status="confirmed",
+        rrule="FREQ=DAILY",
+        visibility="public",
+        event_id="abc",
+    )
+    assert event.id == "abc"
+    assert event.title == "title"
+    assert event.start_time == start
+    assert event.end_time == end
+    assert event.description == "desc"
+    assert event.is_all_day is True
+    assert event.location == "room"
+    assert event.status == "confirmed"
+    assert event.rrule == "FREQ=DAILY"
+    assert event.visibility == "public"


### PR DESCRIPTION
## Summary
- expand CalendarEvent to track is_all_day, location, status, rrule, and visibility
- rename start/end fields to start_time/end_time and update factory helper
- add unit test for create_calendar_event covering new fields

## Testing
- `ruff check tests/models/test_calendar_event.py src/ume/models/calendar.py`
- `PYTHONPATH=src pytest tests/models/test_calendar_event.py -q`
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: starlette_graphene3, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688fd2febfd083269260865879922a4a