### PR TITLE
Add ProposedAction model with ranking and outcome metrics

### DIFF
--- a/src/ume/arango_graph.py
+++ b/src/ume/arango_graph.py
@@ -120,7 +120,13 @@ class ArangoGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
         return f"{source}|{target}|{label}"
 
     # ---- Edge methods -------------------------------------------------------
-    def add_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def add_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         if not self.node_exists(source_node_id) or not self.node_exists(target_node_id):
             raise ProcessingError(
                 f"Both source node '{source_node_id}' and target node '{target_node_id}' must exist to add an edge."
@@ -128,26 +134,35 @@ class ArangoGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
         key = self._edge_key(source_node_id, target_node_id, label)
         if self._edges.has(key):
             raise ProcessingError(f"Edge ({source_node_id}, {target_node_id}, {label}) already exists.")
-        self._edges.insert({
+        doc = {
             "_key": key,
             "source": source_node_id,
             "target": target_node_id,
             "label": label,
             "redacted": False,
             "created_at": int(time.time()),
-        })
+        }
+        if attrs:
+            doc["attrs"] = attrs
+        self._edges.insert(doc)
 
-    def get_all_edges(self) -> List[Tuple[str, str, str]]:
-        result: List[Tuple[str, str, str]] = []
+    def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:
+        result: List[Tuple[str, str, str, Dict[str, Any]]] = []
         for e in cast(Iterable[Dict[str, Any]], self._edges.all()):
             if e.get("redacted"):
                 continue
             if not self.node_exists(e["source"]) or not self.node_exists(e["target"]):
                 continue
-            result.append((e["source"], e["target"], e["label"]))
+            result.append((e["source"], e["target"], e["label"], cast(Dict[str, Any], e.get("attrs", {}))))
         return result
 
-    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         key = self._edge_key(source_node_id, target_node_id, label)
         if not self._edges.has(key):
             raise ProcessingError(

--- a/src/ume/graph.py
+++ b/src/ume/graph.py
@@ -104,7 +104,7 @@ class MockGraph(GraphAlgorithmsMixin, IGraphAdapter):
         source_node_id: str,
         target_node_id: str,
         label: str,
-        **attrs: Any,
+        attrs: Dict[str, Any] | None = None,
     ) -> None:
         """
         Adds a directed, labeled edge between two existing nodes.
@@ -126,12 +126,12 @@ class MockGraph(GraphAlgorithmsMixin, IGraphAdapter):
 
         edge_def = DEFAULT_SCHEMA.edge_labels.get(label)
         permission_level = edge_def.permission_level if edge_def else None
-        attr_dict: Dict[str, Any] = dict(attrs)
+        attr_dict: Dict[str, Any] = dict(attrs or {})
         if permission_level is not None:
             attr_dict["permission_level"] = permission_level
         self._edges[source_node_id].append((target_node_id, label, attr_dict))
 
-    def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:  # type: ignore[override]
+    def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:
         """
         Retrieves a list of all edges currently in the graph.
 
@@ -153,7 +153,13 @@ class MockGraph(GraphAlgorithmsMixin, IGraphAdapter):
                     all_edges.append((src, tgt, lbl, attr.copy()))
         return all_edges
 
-    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         """
         Removes a specific directed, labeled edge from the graph.
 

--- a/src/ume/graph_algorithms.py
+++ b/src/ume/graph_algorithms.py
@@ -111,7 +111,7 @@ class GraphAlgorithmsMixin:
     ) -> List[str]:  # pragma: no cover - interface
         raise NotImplementedError
 
-    def get_all_edges(self) -> List[Tuple[str, str, str]]:  # pragma: no cover
+    def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:  # pragma: no cover
         raise NotImplementedError
 
     def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:  # pragma: no cover

--- a/src/ume/models/__init__.py
+++ b/src/ume/models/__init__.py
@@ -8,6 +8,7 @@ from .decisions import Decision, create_decision
 from .finance import Transaction, create_transaction
 from .financial_account import FinancialAccount, create_financial_account
 from .user_group import UserGroup, create_user_group
+from .proposed_action import ProposedAction, create_proposed_action
 
 
 __all__ = [
@@ -23,6 +24,9 @@ __all__ = [
     "create_decision_analysis",
     "FinancialAccount",
     "create_financial_account",
+
+    "ProposedAction",
+    "create_proposed_action",
 
     "Transaction",
     "create_transaction",

--- a/src/ume/models/proposed_action.py
+++ b/src/ume/models/proposed_action.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from datetime import datetime
 import uuid
 
 
@@ -13,19 +12,25 @@ class ProposedAction:
 
     action_id: str
     description: str
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    rank: int
+    is_optimal: bool = False
+    outcome_metrics: dict[str, float] = field(default_factory=dict)
 
 
 def create_proposed_action(
     description: str,
     *,
     action_id: str | None = None,
-    created_at: datetime | None = None,
+    rank: int = 0,
+    is_optimal: bool = False,
+    outcome_metrics: dict[str, float] | None = None,
 ) -> ProposedAction:
     """Factory helper to build :class:`ProposedAction` instances."""
 
     return ProposedAction(
         action_id=action_id or str(uuid.uuid4()),
         description=description,
-        created_at=created_at or datetime.utcnow(),
+        rank=rank,
+        is_optimal=is_optimal,
+        outcome_metrics=outcome_metrics or {},
     )

--- a/src/ume/neo4j_graph.py
+++ b/src/ume/neo4j_graph.py
@@ -132,7 +132,13 @@ class Neo4jGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
             return [record["id"] for record in result]
 
     # ---- Edge methods -------------------------------------------------
-    def add_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def add_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         schema = DEFAULT_SCHEMA_MANAGER.get_schema(DEFAULT_VERSION)
         schema.validate_edge_label(label)
         escaped_label = label.replace("`", "``")
@@ -157,23 +163,35 @@ class Neo4jGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
                 raise ProcessingError(
                     f"Edge ({source_node_id}, {target_node_id}, {label}) already exists."
                 )
+            props = {"redacted": False, "created_at": int(time.time())}
+            if attrs:
+                props.update(attrs)
             session.run(
-                f"MATCH (s {{id: $src}}), (t {{id: $tgt}}) CREATE (s)-[:`{escaped_label}` {{redacted:false, created_at:$ts}}]->(t)",
-                {"src": source_node_id, "tgt": target_node_id, "ts": int(time.time())},
+                f"MATCH (s {{id: $src}}), (t {{id: $tgt}}) CREATE (s)-[:`{escaped_label}` $props]->(t)",
+                {"src": source_node_id, "tgt": target_node_id, "props": props},
             )
 
-    def get_all_edges(self) -> List[tuple[str, str, str]]:
+    def get_all_edges(self) -> List[tuple[str, str, str, Dict[str, Any]]]:
         with self._driver.session() as session:
             result = session.run(
                 "MATCH (s)-[r]->(t) "
                 "WHERE coalesce(r.redacted, false) = false "
                 "AND coalesce(s.redacted, false) = false "
                 "AND coalesce(t.redacted, false) = false "
-                "RETURN s.id AS src, t.id AS tgt, type(r) AS label"
+                "RETURN s.id AS src, t.id AS tgt, type(r) AS label, properties(r) AS attrs"
             )
-            return [(rec["src"], rec["tgt"], rec["label"]) for rec in result]
+            return [
+                (rec["src"], rec["tgt"], rec["label"], cast(Dict[str, Any], rec["attrs"]))
+                for rec in result
+            ]
 
-    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         schema = DEFAULT_SCHEMA_MANAGER.get_schema(DEFAULT_VERSION)
         schema.validate_edge_label(label)
         escaped_label = label.replace("`", "``")

--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -119,11 +119,15 @@ class PermissionsGraphAdapter(IGraphAdapter):
         return self._filter_visible(connected)
 
     def add_edge(
-        self, source_node_id: str, target_node_id: str, label: str, **attrs: Any
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
     ) -> None:
         self._require_editor(source_node_id)
         self._require_editor(target_node_id)
-        self._adapter.add_edge(source_node_id, target_node_id, label, **attrs)
+        self._adapter.add_edge(source_node_id, target_node_id, label, attrs)
 
     def get_all_edges(self) -> List[tuple[str, str, str, Dict[str, Any]]]:
         edges = self._adapter.get_all_edges()
@@ -134,10 +138,16 @@ class PermissionsGraphAdapter(IGraphAdapter):
 
         ]
 
-    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         self._require_editor(source_node_id)
         self._require_editor(target_node_id)
-        self._adapter.delete_edge(source_node_id, target_node_id, label)
+        self._adapter.delete_edge(source_node_id, target_node_id, label, attrs)
 
     def redact_node(self, node_id: str) -> None:
         self._require_editor(node_id)

--- a/src/ume/persistent_graph.py
+++ b/src/ume/persistent_graph.py
@@ -126,9 +126,9 @@ class PersistentGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
         source_node_id: str,
         target_node_id: str,
         label: str,
+        attrs: Dict[str, Any] | None = None,
         *,
         created_at: int | None = None,
-        **attrs: Any,
     ) -> None:
         if not self.node_exists(source_node_id) or not self.node_exists(target_node_id):
             raise ProcessingError(
@@ -139,7 +139,7 @@ class PersistentGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
 
         edge_def = DEFAULT_SCHEMA.edge_labels.get(label)
         permission_level = edge_def.permission_level if edge_def else None
-        attr_dict: Dict[str, Any] = dict(attrs)
+        attr_dict: Dict[str, Any] = dict(attrs or {})
         if permission_level is not None:
             attr_dict["permission_level"] = permission_level
 
@@ -160,7 +160,7 @@ class PersistentGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
                 f"Edge ({source_node_id}, {target_node_id}, {label}) already exists."
             )
 
-    def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:  # type: ignore[override]
+    def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:
         cur = self.conn.execute(
             """
             SELECT e.source, e.target, e.label, e.attributes
@@ -180,7 +180,13 @@ class PersistentGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
             for row in cur.fetchall()
         ]
 
-    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         with self.conn:
             cur = self.conn.execute(
                 "DELETE FROM edges WHERE source=? AND target=? AND label=?",

--- a/src/ume/postgres_graph.py
+++ b/src/ume/postgres_graph.py
@@ -130,7 +130,13 @@ class PostgresGraph(GraphAlgorithmsMixin, IGraphAdapter):
             cur.execute("TRUNCATE nodes")
 
     # ---- Edge methods -------------------------------------------------------
-    def add_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def add_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         if not self.node_exists(source_node_id) or not self.node_exists(target_node_id):
             raise ProcessingError(
                 f"Both source node '{source_node_id}' and target node '{target_node_id}' must exist to add an edge."
@@ -149,7 +155,7 @@ class PostgresGraph(GraphAlgorithmsMixin, IGraphAdapter):
                 (source_node_id, target_node_id, label, int(time.time())),
             )
 
-    def get_all_edges(self) -> List[Tuple[str, str, str]]:
+    def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:
         with self._conn.cursor() as cur:
             cur.execute(
                 """
@@ -160,9 +166,15 @@ class PostgresGraph(GraphAlgorithmsMixin, IGraphAdapter):
                 WHERE e.redacted=false AND s.redacted=false AND t.redacted=false
                 """
             )
-            return [(row[0], row[1], row[2]) for row in cur.fetchall()]
+            return [(row[0], row[1], row[2], {}) for row in cur.fetchall()]
 
-    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         with self._conn.cursor() as cur:
             cur.execute(
                 "DELETE FROM edges WHERE source=%s AND target=%s AND label=%s",

--- a/src/ume/rbac_adapter.py
+++ b/src/ume/rbac_adapter.py
@@ -60,15 +60,25 @@ class RoleBasedGraphAdapter(IGraphAdapter):
         return self._adapter.find_connected_nodes(node_id, edge_label)
 
     def add_edge(
-        self, source_node_id: str, target_node_id: str, label: str, **attrs: Any
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
     ) -> None:
-        self._adapter.add_edge(source_node_id, target_node_id, label, **attrs)
+        self._adapter.add_edge(source_node_id, target_node_id, label, attrs)
 
-    def get_all_edges(self) -> list[tuple[str, str, str]]:
+    def get_all_edges(self) -> list[tuple[str, str, str, Dict[str, Any]]]:
         return self._adapter.get_all_edges()
 
-    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
-        self._adapter.delete_edge(source_node_id, target_node_id, label)
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
+        self._adapter.delete_edge(source_node_id, target_node_id, label, attrs)
 
     def redact_node(self, node_id: str) -> None:
         self._require_analytics_role()

--- a/src/ume/redis_graph_adapter.py
+++ b/src/ume/redis_graph_adapter.py
@@ -106,7 +106,13 @@ class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
     def _edge_member(self, source: str, target: str, label: str) -> str:
         return f"{source}|{target}|{label}"
 
-    def add_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def add_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         if not self.node_exists(source_node_id) or not self.node_exists(target_node_id):
             raise ProcessingError(
                 f"Both source node '{source_node_id}' and target node '{target_node_id}' must exist to add an edge."
@@ -118,8 +124,8 @@ class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
             )
         self._client.sadd(self.EDGE_SET_KEY, member)
 
-    def get_all_edges(self) -> List[Tuple[str, str, str]]:
-        result = []
+    def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:
+        result: List[Tuple[str, str, str, Dict[str, Any]]] = []
         for b in self._client.smembers(self.EDGE_SET_KEY):
             member = b.decode()
             if self._client.sismember(self.REDACTED_EDGES_KEY, member):
@@ -130,10 +136,16 @@ class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
                 tgt,
             ):
                 continue
-            result.append((src, tgt, lbl))
+            result.append((src, tgt, lbl, {}))
         return result
 
-    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         member = self._edge_member(source_node_id, target_node_id, label)
         if self._client.srem(self.EDGE_SET_KEY, member) == 0:
             raise ProcessingError(

--- a/src/ume/tracing.py
+++ b/src/ume/tracing.py
@@ -96,18 +96,28 @@ class TracingGraphAdapter(IGraphAdapter):
             return self._adapter.find_connected_nodes(node_id, edge_label)
 
     def add_edge(
-        self, source_node_id: str, target_node_id: str, label: str, **attrs: Any
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
     ) -> None:
         with self._tracer.start_as_current_span("graph.add_edge"):
-            self._adapter.add_edge(source_node_id, target_node_id, label, **attrs)
+            self._adapter.add_edge(source_node_id, target_node_id, label, attrs)
 
     def get_all_edges(self) -> List[tuple[str, str, str, Dict[str, Any]]]:
         with self._tracer.start_as_current_span("graph.get_all_edges"):
             return self._adapter.get_all_edges()
 
-    def delete_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
         with self._tracer.start_as_current_span("graph.delete_edge"):
-            self._adapter.delete_edge(source_node_id, target_node_id, label)
+            self._adapter.delete_edge(source_node_id, target_node_id, label, attrs)
 
     def redact_node(self, node_id: str) -> None:
         with self._tracer.start_as_current_span("graph.redact_node"):

--- a/tests/test_proposed_action_model.py
+++ b/tests/test_proposed_action_model.py
@@ -1,0 +1,10 @@
+from ume.models import create_proposed_action
+
+
+def test_create_proposed_action_defaults() -> None:
+    action = create_proposed_action("take a nap")
+    assert action.description == "take a nap"
+    assert action.action_id
+    assert action.rank == 0
+    assert action.is_optimal is False
+    assert action.outcome_metrics == {}


### PR DESCRIPTION
## Summary
- expand `ProposedAction` model to include rank, optimality flag, and outcome metrics
- provide factory with UUID and rank defaults
- expose `ProposedAction` via models package and test its defaults
- standardize edge methods across graph adapters to accept optional attributes and satisfy type checks

## Testing
- `pre-commit run --files src/ume/models/proposed_action.py src/ume/models/__init__.py tests/test_proposed_action_model.py`
- `pytest tests/test_proposed_action_model.py`


------
https://chatgpt.com/codex/tasks/task_e_6894b914ec308326b6003e1d520cba21