### PR TITLE
Add decision analysis API with action management

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: mypy
         args: ["--config-file", "mypy.ini", "--strict"]
-        additional_dependencies: ["types-PyYAML"]
+        additional_dependencies: ["types-PyYAML", "fastapi", "pydantic"]
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -66,6 +66,7 @@ from .feedback_routes import router as feedback_router
 from .snapshot_routes import router as snapshot_router
 from .ledger_routes import router as ledger_router
 from .dossier_routes import router as dossier_router
+from .decisions_routes import router as decisions_router
 from .consent_ledger import consent_ledger  # noqa: F401
 try:  # pragma: no cover - optional dependency
     from .graphql_api import schema as graphql_schema
@@ -115,6 +116,7 @@ app.include_router(feedback_router)
 app.include_router(snapshot_router)
 app.include_router(ledger_router)
 app.include_router(dossier_router)
+app.include_router(decisions_router)
 # Some unit tests replace ``fastapi.FastAPI`` with a minimal stub that lacks
 # ``add_route``. Guard the GraphQL route registration so those tests can import
 # this module without the real FastAPI implementation.

--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from . import api_deps as deps
+from .graph_adapter import IGraphAdapter
+from .models import (
+    DecisionAnalysis,
+    ProposedAction,
+    create_decision_analysis,
+    create_proposed_action,
+)
+
+router = APIRouter(prefix="/v1/decisions")
+
+
+class DecisionCreateRequest(BaseModel):
+    query: str
+
+
+class ActionCreateRequest(BaseModel):
+    description: str
+    rank: int = 0
+    is_optimal: bool = False
+    outcome_metrics: dict[str, float] | None = None
+
+
+def _analysis_to_dict(analysis: DecisionAnalysis) -> dict[str, Any]:
+    return {
+        "analysis_id": analysis.analysis_id,
+        "query": analysis.query,
+        "created_at": int(analysis.created_at.timestamp()),
+    }
+
+
+def _action_to_dict(action: ProposedAction) -> dict[str, Any]:
+    return {
+        "action_id": action.action_id,
+        "description": action.description,
+        "rank": action.rank,
+        "is_optimal": action.is_optimal,
+        "outcome_metrics": action.outcome_metrics,
+    }
+
+
+@router.post("")
+def create_decision(
+    req: DecisionCreateRequest,
+    _: str = Depends(deps.get_current_role),
+    graph: IGraphAdapter = Depends(deps.get_graph),
+) -> dict[str, Any]:
+    analysis = create_decision_analysis(req.query)
+    attrs = _analysis_to_dict(analysis)
+    graph.add_node(analysis.analysis_id, attrs)
+    return attrs
+
+
+@router.post("/{analysis_id}/actions")
+def add_action(
+    analysis_id: str,
+    req: ActionCreateRequest,
+    _: str = Depends(deps.get_current_role),
+    graph: IGraphAdapter = Depends(deps.get_graph),
+) -> dict[str, Any]:
+    if not graph.node_exists(analysis_id):
+        raise HTTPException(status_code=404, detail="Analysis not found")
+    action = create_proposed_action(
+        req.description,
+        rank=req.rank,
+        is_optimal=req.is_optimal,
+        outcome_metrics=req.outcome_metrics or {},
+    )
+    action_attrs = _action_to_dict(action)
+    graph.add_node(action.action_id, action_attrs)
+    graph.add_edge(analysis_id, action.action_id, "CONSIDERS")
+    return action_attrs
+
+
+@router.get("/{analysis_id}")
+def get_decision(
+    analysis_id: str,
+    _: str = Depends(deps.get_current_role),
+    graph: IGraphAdapter = Depends(deps.get_graph),
+) -> dict[str, Any]:
+    attrs = graph.get_node(analysis_id)
+    if attrs is None:
+        raise HTTPException(status_code=404, detail="Analysis not found")
+    analysis = {"analysis_id": analysis_id, **attrs}
+    action_ids = graph.find_connected_nodes(analysis_id, edge_label="CONSIDERS")
+    actions = []
+    for aid in action_ids:
+        a_attrs = graph.get_node(aid)
+        if a_attrs:
+            actions.append({"action_id": aid, **a_attrs})
+    return {"analysis": analysis, "actions": actions}

--- a/src/ume/metrics.py
+++ b/src/ume/metrics.py
@@ -13,19 +13,19 @@ try:  # pragma: no cover - exercised indirectly
     from prometheus_client import Counter, Histogram, Gauge
 except Exception:  # pragma: no cover - library missing or incompatible
     class _Metric:  # minimal stub used during tests
-        def __init__(self, *args, **kwargs):
+        def __init__(self, *args: object, **kwargs: object) -> None:
             pass
 
-        def labels(self, *args, **kwargs):
+        def labels(self, *args: object, **kwargs: object) -> "_Metric":
             return self
 
-        def observe(self, *args, **kwargs) -> None:
+        def observe(self, *args: object, **kwargs: object) -> None:
             pass
 
-        def inc(self, *args, **kwargs) -> None:
+        def inc(self, *args: object, **kwargs: object) -> None:
             pass
 
-        def set(self, *args, **kwargs) -> None:
+        def set(self, *args: object, **kwargs: object) -> None:
             pass
 
     Counter = Histogram = Gauge = _Metric

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -1,0 +1,58 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return res.json()["access_token"]
+
+
+@pytest.fixture
+def client_and_graph():
+    g = MockGraph()
+    configure_graph(g)
+    return TestClient(app), g
+
+
+def test_decision_flow(client_and_graph) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+
+    res = client.post(
+        "/v1/decisions",
+        json={"query": "Choose option"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    analysis = res.json()
+    analysis_id = analysis["analysis_id"]
+
+    res = client.post(
+        f"/v1/decisions/{analysis_id}/actions",
+        json={"description": "Option A"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    action = res.json()
+    action_id = action["action_id"]
+
+    res = client.get(
+        f"/v1/decisions/{analysis_id}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["analysis"]["analysis_id"] == analysis_id
+    assert len(data["actions"]) == 1
+    assert data["actions"][0]["action_id"] == action_id
+
+    assert g.get_node(analysis_id)["query"] == "Choose option"
+    assert g.get_node(action_id)["description"] == "Option A"
+    assert g.find_connected_nodes(analysis_id, edge_label="CONSIDERS") == [action_id]


### PR DESCRIPTION
## Summary
- add `/v1/decisions` endpoints to create decision analyses, attach actions, and retrieve analyses with their actions
- wire decision routes into the main FastAPI application
- include test coverage for decision analysis workflow

## Testing
- `pre-commit run --files src/ume/decisions_routes.py src/ume/api.py src/ume/metrics.py tests/test_decisions_routes.py .pre-commit-config.yaml`
- `pytest tests/test_decisions_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_689647d5b5948326a62e3df7a033c8a4