### PR TITLE
Include decisions routes in API

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -67,6 +67,7 @@ from .snapshot_routes import router as snapshot_router
 from .ledger_routes import router as ledger_router
 from .dossier_routes import router as dossier_router
 from .calendar_routes import router as calendar_router
+from .decisions_routes import router as decisions_router
 
 from .consent_ledger import consent_ledger  # noqa: F401
 try:  # pragma: no cover - optional dependency
@@ -118,6 +119,7 @@ app.include_router(snapshot_router)
 app.include_router(ledger_router)
 app.include_router(dossier_router)
 app.include_router(calendar_router)
+app.include_router(decisions_router)
 
 # Some unit tests replace ``fastapi.FastAPI`` with a minimal stub that lacks
 # ``add_route``. Guard the GraphQL route registration so those tests can import
@@ -277,8 +279,10 @@ async def metrics_middleware(
 # These can be configured by the embedding application or tests
 
 class _DefaultQueryEngine:
-    def execute_cypher(self, cypher: str) -> list[dict[str, Any]]:
-        return [{"q": cypher}]
+    def execute_cypher(
+        self, cypher: str, parameters: dict[str, Any] | None = None
+    ) -> list[dict[str, Any]]:
+        return [{"q": cypher, "parameters": parameters or {}}]
 
 app.state.query_engine = cast(Any, _DefaultQueryEngine())
 app.state.graph = cast(Any, None)


### PR DESCRIPTION
## Summary
- expose decision-making and calendar routes via FastAPI
- allow default query engine to accept optional parameters

## Testing
- `pre-commit run --files src/ume/api.py`
- `pytest tests/test_decisions_routes.py tests/test_api_events.py::test_get_events_with_tag tests/test_api_reference.py::test_documented_routes_exist -q`


------
https://chatgpt.com/codex/tasks/task_e_68969b5095ec83268f0ac760e433a107