### PR TITLE
test: verify calendar and decision defaults

### DIFF
--- a/tests/test_models_calendar_decision.py
+++ b/tests/test_models_calendar_decision.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+import uuid
+
+from ume.models import (
+    CalendarEvent,
+    Decision,
+    create_calendar_event,
+    create_decision,
+)
+
+
+
+def test_create_calendar_event_defaults_and_schema_version() -> None:
+    start = datetime.utcnow()
+    event = create_calendar_event("Meeting", start)
+
+    assert isinstance(event, CalendarEvent)
+    uuid.UUID(event.id)
+    assert event.end is None
+    assert event.description is None
+    assert event.schema_version == "1.0"
+    assert event.start == start
+
+
+def test_create_decision_defaults_and_schema_version() -> None:
+    decision = create_decision("Approve budget")
+
+    assert isinstance(decision, Decision)
+    uuid.UUID(decision.id)
+    assert decision.made_by is None
+    assert isinstance(decision.timestamp, datetime)
+    assert decision.schema_version == "1.0"


### PR DESCRIPTION
## Summary
- add tests ensuring calendar and decision factories set defaults and schema version

## Testing
- `ruff check tests/test_models_calendar_decision.py`
- `pytest tests/test_models_calendar_decision.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ba598a408326b202d883b3fe0dab