### PR TITLE
Add tests for permissions adapter edge queries

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -27,11 +27,16 @@ class PermissionsGraphAdapter(IGraphAdapter):
     def _subjects(self) -> list[str]:
         return [s for s in [self.user_id, self.group_id] if s]
 
-    def _has_permission_edge(self, subject: str, node_id: str, label: str) -> bool:
-        for src, tgt, lbl, _ in self._adapter.get_all_edges():
-            if src == subject and tgt == node_id and lbl == label:
-
-                return True
+    def _has_permission_edge(self, node_id: str, subject: str, perm: str) -> bool:
+        for src, tgt, lbl, attrs in self._adapter.get_all_edges():
+            if src == node_id and tgt == subject and lbl == "HAS_PERMISSION":
+                perm_level = None
+                if isinstance(attrs, dict):
+                    perm_level = attrs.get("permission_level")
+                else:
+                    perm_level = attrs
+                if perm_level == perm:
+                    return True
         return False
 
     def _has_permission(self, node_id: str, perm: str) -> bool:

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -52,3 +52,33 @@ def test_get_nodes_by_user_and_group() -> None:
     adapter = PermissionsGraphAdapter(g, user_id="User.u1", group_id="Group.g1")
     assert set(adapter.get_nodes_by_user("User.u1")) == {"Document.d1"}
     assert set(adapter.get_nodes_shared_with("Group.g1")) == {"Document.d2"}
+
+
+def test_add_edge_requires_editor_and_preserves_attrs() -> None:
+    g = MockGraph()
+    g.add_node("User.u1", {})
+    g.add_node("Document.d1", {})
+    g.add_node("Document.d2", {})
+    g._edges["Document.d1"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
+    adapter = PermissionsGraphAdapter(g, user_id="User.u1")
+    with pytest.raises(AccessDeniedError):
+        adapter.add_edge("Document.d1", "Document.d2", "RELATED", {"weight": 1})
+    g._edges["Document.d2"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
+    adapter.add_edge("Document.d1", "Document.d2", "RELATED", {"weight": 1})
+    assert adapter.get_all_edges() == [
+        ("Document.d1", "Document.d2", "RELATED", {"weight": 1})
+    ]
+
+
+def test_find_connected_nodes_filters_by_permissions() -> None:
+    g = build_graph()
+    g.add_node("Document.d3", {})
+    g.add_edge("Document.d1", "Document.d2", "RELATED")
+    g.add_edge("Document.d1", "Document.d3", "RELATED")
+    g._edges["Document.d3"].append(
+        ("User.u1", "HAS_PERMISSION", {"permission_level": "viewer"})
+    )
+    adapter = PermissionsGraphAdapter(g, user_id="User.u1")
+    assert adapter.find_connected_nodes("Document.d1") == ["Document.d3"]
+    with pytest.raises(AccessDeniedError):
+        adapter.find_connected_nodes("Document.d2")


### PR DESCRIPTION
## Summary
- extend permissions adapter with attribute-aware permission checks
- cover edge addition and connected node queries in tests

## Testing
- `pre-commit run --files tests/test_permissions_adapter.py src/ume/permissions_adapter.py`
- `pytest tests/test_permissions_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_6896ba5a1d008326bc09805a26bff820