### PR TITLE
feat: expand calendar events

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -19,6 +19,11 @@ class CalendarEventCreateRequest(BaseModel):
     start: datetime
     end: datetime | None = None
     description: str | None = None
+    is_all_day: bool = False
+    location: str | None = None
+    status: str | None = None
+    rrule: str | None = None
+    visibility: str | None = None
     user_id: str
     invitee_ids: List[str] | None = None
     layer_ids: List[str] | None = None
@@ -30,6 +35,11 @@ class CalendarEventResponse(BaseModel):
     start: int
     end: int | None = None
     description: str | None = None
+    is_all_day: bool
+    location: str | None = None
+    status: str | None = None
+    rrule: str | None = None
+    visibility: str | None = None
 
 
 @router.post("/events", response_model=CalendarEventResponse)
@@ -39,7 +49,15 @@ def create_event(
     _: str = Depends(deps.get_current_role),
 ) -> CalendarEventResponse:
     event = create_calendar_event(
-        req.title, req.start, req.end, description=req.description
+        req.title,
+        req.start,
+        req.end,
+        description=req.description,
+        is_all_day=req.is_all_day,
+        location=req.location,
+        status=req.status,
+        rrule=req.rrule,
+        visibility=req.visibility,
     )
     attrs = {
         "type": "CalendarEvent",
@@ -47,6 +65,11 @@ def create_event(
         "start": int(event.start.timestamp()),
         "end": int(event.end.timestamp()) if event.end else None,
         "description": event.description,
+        "is_all_day": event.is_all_day,
+        "location": event.location,
+        "status": event.status,
+        "rrule": event.rrule,
+        "visibility": event.visibility,
     }
     graph.add_node(event.id, attrs)
     graph.add_edge(event.id, req.user_id, "OWNED_BY")
@@ -69,6 +92,11 @@ def create_event(
         start=attrs["start"],
         end=attrs["end"],
         description=event.description,
+        is_all_day=event.is_all_day,
+        location=event.location,
+        status=event.status,
+        rrule=event.rrule,
+        visibility=event.visibility,
     )
 
 
@@ -104,6 +132,11 @@ def list_events(
                 start=start_ts,
                 end=attrs.get("end"),
                 description=attrs.get("description"),
+                is_all_day=attrs.get("is_all_day", False),
+                location=attrs.get("location"),
+                status=attrs.get("status"),
+                rrule=attrs.get("rrule"),
+                visibility=attrs.get("visibility"),
             )
         )
     return events

--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import uuid
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "3.0"
 
 
 @dataclass
@@ -18,6 +18,11 @@ class CalendarEvent:
     start: datetime
     end: datetime | None = None
     description: str | None = None
+    is_all_day: bool = False
+    location: str | None = None
+    status: str | None = None
+    rrule: str | None = None
+    visibility: str | None = None
     schema_version: str = SCHEMA_VERSION
 
 
@@ -28,6 +33,11 @@ def create_calendar_event(
     *,
     description: str | None = None,
     event_id: str | None = None,
+    is_all_day: bool = False,
+    location: str | None = None,
+    status: str | None = None,
+    rrule: str | None = None,
+    visibility: str | None = None,
 ) -> CalendarEvent:
     """Factory helper to build :class:`CalendarEvent` instances."""
 
@@ -37,4 +47,9 @@ def create_calendar_event(
         start=start,
         end=end,
         description=description,
+        is_all_day=is_all_day,
+        location=location,
+        status=status,
+        rrule=rrule,
+        visibility=visibility,
     )

--- a/src/ume/schemas/graph_schema_v3.yaml
+++ b/src/ume/schemas/graph_schema_v3.yaml
@@ -36,6 +36,16 @@ node_types:
         version: "3.0.0"
       description:
         version: "3.0.0"
+      is_all_day:
+        version: "3.0.0"
+      location:
+        version: "3.0.0"
+      status:
+        version: "3.0.0"
+      rrule:
+        version: "3.0.0"
+      visibility:
+        version: "3.0.0"
   CalendarLayer:
     version: "3.0.0"
     permission_level: "public"

--- a/tests/test_models_calendar_decision.py
+++ b/tests/test_models_calendar_decision.py
@@ -18,7 +18,12 @@ def test_create_calendar_event_defaults_and_schema_version() -> None:
     uuid.UUID(event.id)
     assert event.end is None
     assert event.description is None
-    assert event.schema_version == "1.0"
+    assert event.is_all_day is False
+    assert event.location is None
+    assert event.status is None
+    assert event.rrule is None
+    assert event.visibility is None
+    assert event.schema_version == "3.0"
     assert event.start == start
 
 


### PR DESCRIPTION
## Summary
- extend calendar event model with all-day, location, status, recurrence, and visibility fields
- expose new calendar event fields through API and schema
- bump calendar event schema version to 3.0

## Testing
- `pre-commit run --files src/ume/models/calendar.py src/ume/calendar_routes.py src/ume/schemas/graph_schema_v3.yaml tests/test_models_calendar_decision.py`
- `pytest tests/test_models_calendar_decision.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897bbeb806c8326b323d35682d623b4