### PR TITLE
Use ownership and sharing edges for permission checks

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -72,17 +72,13 @@ def create_event(
         "visibility": event.visibility,
     }
     graph.add_node(event.id, attrs)
-    graph.add_edge(event.id, req.user_id, "OWNED_BY")
     graph.add_edge(
-        event.id,
-        req.user_id,
-        "HAS_PERMISSION",
-        {"permission_level": "editor"},
+        event.id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
     )
     for uid in req.invitee_ids or []:
         graph.add_edge(event.id, uid, "INVITES")
         graph.add_edge(
-            event.id, uid, "HAS_PERMISSION", {"permission_level": "viewer"}
+            event.id, uid, "SHARED_WITH", {"permission_level": "viewer"}
         )
     for lid in req.layer_ids or []:
         graph.add_edge(event.id, lid, "TAGGED_AS")

--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -29,7 +29,7 @@ class PermissionsGraphAdapter(IGraphAdapter):
 
     def _has_permission_edge(self, node_id: str, subject: str, perm: str) -> bool:
         for src, tgt, lbl, attrs in self._adapter.get_all_edges():
-            if src == node_id and tgt == subject and lbl == "HAS_PERMISSION":
+            if src == node_id and tgt == subject and lbl in {"OWNED_BY", "SHARED_WITH"}:
                 perm_level = None
                 if isinstance(attrs, dict):
                     perm_level = attrs.get("permission_level")
@@ -92,11 +92,11 @@ class PermissionsGraphAdapter(IGraphAdapter):
     def get_all_node_ids(self) -> List[str]:
         return self._filter_visible(self._adapter.get_all_node_ids())
 
-    def _get_nodes_for_subject(self, subject_id: str) -> List[str]:
+    def _get_nodes_for_subject(self, subject_id: str, labels: List[str]) -> List[str]:
         nodes: set[str] = set()
         for edge in self._adapter.get_all_edges():
             src, tgt, lbl, *rest = edge
-            if lbl != "HAS_PERMISSION" or tgt != subject_id:
+            if lbl not in labels or tgt != subject_id:
                 continue
             perm_level = None
             if rest:
@@ -110,10 +110,14 @@ class PermissionsGraphAdapter(IGraphAdapter):
         return list(nodes)
 
     def get_nodes_by_user(self, user_id: str) -> List[str]:
-        return self._filter_visible(self._get_nodes_for_subject(user_id))
+        return self._filter_visible(
+            self._get_nodes_for_subject(user_id, ["OWNED_BY", "SHARED_WITH"])
+        )
 
     def get_nodes_shared_with(self, group_id: str) -> List[str]:
-        return self._filter_visible(self._get_nodes_for_subject(group_id))
+        return self._filter_visible(
+            self._get_nodes_for_subject(group_id, ["SHARED_WITH"])
+        )
 
     def find_connected_nodes(
         self, node_id: str, edge_label: Optional[str] = None

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -54,10 +54,6 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert res.status_code == 200
     event_id = res.json()["id"]
 
-    # Additional edges to satisfy PermissionsGraphAdapter's checks
-    graph.add_edge(event_id, "user1", "editor")
-    graph.add_edge(event_id, "user2", "viewer")
-
     # Owner sees the event
     res = client.get(
         "/v1/calendar/events",
@@ -86,8 +82,8 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert res.json() == []
 
     edges = graph.get_all_edges()
-    assert (event_id, "user1", "HAS_PERMISSION", {"permission_level": "editor"}) in edges
-    assert (event_id, "user2", "HAS_PERMISSION", {"permission_level": "viewer"}) in edges
+    assert (event_id, "user1", "OWNED_BY", {"permission_level": "editor"}) in edges
+    assert (event_id, "user2", "SHARED_WITH", {"permission_level": "viewer"}) in edges
 
 
 def test_decision_flow(client_and_graph) -> None:

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -8,7 +8,7 @@ def build_graph() -> MockGraph:
     g.add_node("User.u1", {})
     g.add_node("Document.d1", {"title": "doc1"})
     g.add_node("Document.d2", {"title": "doc2"})
-    g._edges["Document.d1"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
+    g._edges["Document.d1"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
     return g
 
 
@@ -34,7 +34,7 @@ def test_group_viewer_allows_read_not_edit() -> None:
     g = MockGraph()
     g.add_node("Group.g1", {})
     g.add_node("Document.d1", {})
-    g._edges["Document.d1"].append(("Group.g1", "HAS_PERMISSION", {"permission_level": "viewer"}))
+    g._edges["Document.d1"].append(("Group.g1", "SHARED_WITH", {"permission_level": "viewer"}))
     adapter = PermissionsGraphAdapter(g, group_id="Group.g1")
     assert adapter.get_node("Document.d1") == {}
     with pytest.raises(AccessDeniedError):
@@ -47,8 +47,8 @@ def test_get_nodes_by_user_and_group() -> None:
     g.add_node("Group.g1", {})
     g.add_node("Document.d1", {})
     g.add_node("Document.d2", {})
-    g._edges["Document.d1"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
-    g._edges["Document.d2"].append(("Group.g1", "HAS_PERMISSION", {"permission_level": "viewer"}))
+    g._edges["Document.d1"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
+    g._edges["Document.d2"].append(("Group.g1", "SHARED_WITH", {"permission_level": "viewer"}))
     adapter = PermissionsGraphAdapter(g, user_id="User.u1", group_id="Group.g1")
     assert set(adapter.get_nodes_by_user("User.u1")) == {"Document.d1"}
     assert set(adapter.get_nodes_shared_with("Group.g1")) == {"Document.d2"}
@@ -59,11 +59,11 @@ def test_add_edge_requires_editor_and_preserves_attrs() -> None:
     g.add_node("User.u1", {})
     g.add_node("Document.d1", {})
     g.add_node("Document.d2", {})
-    g._edges["Document.d1"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
+    g._edges["Document.d1"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
     adapter = PermissionsGraphAdapter(g, user_id="User.u1")
     with pytest.raises(AccessDeniedError):
         adapter.add_edge("Document.d1", "Document.d2", "RELATED", {"weight": 1})
-    g._edges["Document.d2"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
+    g._edges["Document.d2"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
     adapter.add_edge("Document.d1", "Document.d2", "RELATED", {"weight": 1})
     assert adapter.get_all_edges() == [
         ("Document.d1", "Document.d2", "RELATED", {"weight": 1})
@@ -76,7 +76,7 @@ def test_find_connected_nodes_filters_by_permissions() -> None:
     g.add_edge("Document.d1", "Document.d2", "RELATED")
     g.add_edge("Document.d1", "Document.d3", "RELATED")
     g._edges["Document.d3"].append(
-        ("User.u1", "HAS_PERMISSION", {"permission_level": "viewer"})
+        ("User.u1", "SHARED_WITH", {"permission_level": "viewer"})
     )
     adapter = PermissionsGraphAdapter(g, user_id="User.u1")
     assert adapter.find_connected_nodes("Document.d1") == ["Document.d3"]


### PR DESCRIPTION
## Summary
- switch permission logic to read `OWNED_BY` and `SHARED_WITH` edges with `permission_level`
- expose helpers to find nodes from these edges
- store permission levels on calendar event ownership and sharing edges

## Testing
- `ruff check src/ume/permissions_adapter.py src/ume/calendar_routes.py tests/test_calendar_decision_api.py tests/test_permissions_adapter.py`
- `pytest tests/test_permissions_adapter.py tests/test_calendar_decision_api.py`


------
https://chatgpt.com/codex/tasks/task_e_6897fcd30d488326816f03055fd223b4