### PR TITLE
Use permission edges for calendar events

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -26,6 +26,7 @@ class CalendarEventCreateRequest(BaseModel):
     visibility: str | None = None
     user_id: str
     invitee_ids: List[str] | None = None
+    group_ids: List[str] | None = None
     layer_ids: List[str] | None = None
 
 
@@ -72,17 +73,19 @@ def create_event(
         "visibility": event.visibility,
     }
     graph.add_node(event.id, attrs)
-    graph.add_edge(event.id, req.user_id, "OWNED_BY")
     graph.add_edge(
         event.id,
         req.user_id,
-        "HAS_PERMISSION",
+        "OWNED_BY",
         {"permission_level": "editor"},
     )
     for uid in req.invitee_ids or []:
-        graph.add_edge(event.id, uid, "INVITES")
         graph.add_edge(
-            event.id, uid, "HAS_PERMISSION", {"permission_level": "viewer"}
+            event.id, uid, "INVITES", {"permission_level": "viewer"}
+        )
+    for gid in req.group_ids or []:
+        graph.add_edge(
+            event.id, gid, "SHARED_WITH", {"permission_level": "viewer"}
         )
     for lid in req.layer_ids or []:
         graph.add_edge(event.id, lid, "TAGGED_AS")

--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -27,9 +27,11 @@ class PermissionsGraphAdapter(IGraphAdapter):
     def _subjects(self) -> list[str]:
         return [s for s in [self.user_id, self.group_id] if s]
 
+    _perm_labels = {"OWNED_BY", "SHARED_WITH", "INVITES"}
+
     def _has_permission_edge(self, node_id: str, subject: str, perm: str) -> bool:
         for src, tgt, lbl, attrs in self._adapter.get_all_edges():
-            if src == node_id and tgt == subject and lbl == "HAS_PERMISSION":
+            if src == node_id and tgt == subject and lbl in self._perm_labels:
                 perm_level = None
                 if isinstance(attrs, dict):
                     perm_level = attrs.get("permission_level")
@@ -96,7 +98,7 @@ class PermissionsGraphAdapter(IGraphAdapter):
         nodes: set[str] = set()
         for edge in self._adapter.get_all_edges():
             src, tgt, lbl, *rest = edge
-            if lbl != "HAS_PERMISSION" or tgt != subject_id:
+            if lbl not in self._perm_labels or tgt != subject_id:
                 continue
             perm_level = None
             if rest:

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -54,10 +54,6 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert res.status_code == 200
     event_id = res.json()["id"]
 
-    # Additional edges to satisfy PermissionsGraphAdapter's checks
-    graph.add_edge(event_id, "user1", "editor")
-    graph.add_edge(event_id, "user2", "viewer")
-
     # Owner sees the event
     res = client.get(
         "/v1/calendar/events",
@@ -86,8 +82,8 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert res.json() == []
 
     edges = graph.get_all_edges()
-    assert (event_id, "user1", "HAS_PERMISSION", {"permission_level": "editor"}) in edges
-    assert (event_id, "user2", "HAS_PERMISSION", {"permission_level": "viewer"}) in edges
+    assert (event_id, "user1", "OWNED_BY", {"permission_level": "editor"}) in edges
+    assert (event_id, "user2", "INVITES", {"permission_level": "viewer"}) in edges
 
 
 def test_decision_flow(client_and_graph) -> None:

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -8,7 +8,9 @@ def build_graph() -> MockGraph:
     g.add_node("User.u1", {})
     g.add_node("Document.d1", {"title": "doc1"})
     g.add_node("Document.d2", {"title": "doc2"})
-    g._edges["Document.d1"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
+    g._edges["Document.d1"].append(
+        ("User.u1", "OWNED_BY", {"permission_level": "editor"})
+    )
     return g
 
 
@@ -34,7 +36,9 @@ def test_group_viewer_allows_read_not_edit() -> None:
     g = MockGraph()
     g.add_node("Group.g1", {})
     g.add_node("Document.d1", {})
-    g._edges["Document.d1"].append(("Group.g1", "HAS_PERMISSION", {"permission_level": "viewer"}))
+    g._edges["Document.d1"].append(
+        ("Group.g1", "SHARED_WITH", {"permission_level": "viewer"})
+    )
     adapter = PermissionsGraphAdapter(g, group_id="Group.g1")
     assert adapter.get_node("Document.d1") == {}
     with pytest.raises(AccessDeniedError):
@@ -47,8 +51,12 @@ def test_get_nodes_by_user_and_group() -> None:
     g.add_node("Group.g1", {})
     g.add_node("Document.d1", {})
     g.add_node("Document.d2", {})
-    g._edges["Document.d1"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
-    g._edges["Document.d2"].append(("Group.g1", "HAS_PERMISSION", {"permission_level": "viewer"}))
+    g._edges["Document.d1"].append(
+        ("User.u1", "OWNED_BY", {"permission_level": "editor"})
+    )
+    g._edges["Document.d2"].append(
+        ("Group.g1", "SHARED_WITH", {"permission_level": "viewer"})
+    )
     adapter = PermissionsGraphAdapter(g, user_id="User.u1", group_id="Group.g1")
     assert set(adapter.get_nodes_by_user("User.u1")) == {"Document.d1"}
     assert set(adapter.get_nodes_shared_with("Group.g1")) == {"Document.d2"}
@@ -59,11 +67,15 @@ def test_add_edge_requires_editor_and_preserves_attrs() -> None:
     g.add_node("User.u1", {})
     g.add_node("Document.d1", {})
     g.add_node("Document.d2", {})
-    g._edges["Document.d1"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
+    g._edges["Document.d1"].append(
+        ("User.u1", "OWNED_BY", {"permission_level": "editor"})
+    )
     adapter = PermissionsGraphAdapter(g, user_id="User.u1")
     with pytest.raises(AccessDeniedError):
         adapter.add_edge("Document.d1", "Document.d2", "RELATED", {"weight": 1})
-    g._edges["Document.d2"].append(("User.u1", "HAS_PERMISSION", {"permission_level": "editor"}))
+    g._edges["Document.d2"].append(
+        ("User.u1", "OWNED_BY", {"permission_level": "editor"})
+    )
     adapter.add_edge("Document.d1", "Document.d2", "RELATED", {"weight": 1})
     assert adapter.get_all_edges() == [
         ("Document.d1", "Document.d2", "RELATED", {"weight": 1})
@@ -76,7 +88,7 @@ def test_find_connected_nodes_filters_by_permissions() -> None:
     g.add_edge("Document.d1", "Document.d2", "RELATED")
     g.add_edge("Document.d1", "Document.d3", "RELATED")
     g._edges["Document.d3"].append(
-        ("User.u1", "HAS_PERMISSION", {"permission_level": "viewer"})
+        ("User.u1", "SHARED_WITH", {"permission_level": "viewer"})
     )
     adapter = PermissionsGraphAdapter(g, user_id="User.u1")
     assert adapter.find_connected_nodes("Document.d1") == ["Document.d3"]


### PR DESCRIPTION
## Summary
- create calendar event permissions via OWNED_BY, INVITES and SHARED_WITH edges with levels
- track these edges in `PermissionsGraphAdapter`
- add tests for updated calendar event permissions

## Testing
- `pre-commit run --files src/ume/calendar_routes.py src/ume/permissions_adapter.py tests/test_calendar_decision_api.py tests/test_permissions_adapter.py`
- `pytest tests/test_calendar_decision_api.py::test_calendar_event_permissions tests/test_permissions_adapter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6897fcd37a74832698caac646e49de82