### PR TITLE
docs: document permission model and schema migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,8 +739,10 @@ curl -X POST http://localhost:8000/graphql \
 ```
 
 ### Migrate Events to the New Schema
-Existing events can be rewritten using the latest schema version. Run the
-migration helper and redirect the output to a file:
+UME's graph schema follows semantic versioning (`MAJOR.MINOR.PATCH`) and each
+event envelope records its `schema_version`. When a new schema release adds
+types or properties, historical events should be rewritten to keep the ledger
+consistent. Run the migration helper and redirect the output to a file:
 
 ```bash
 poetry run python -m ume.migrate_events --source ledger > migrated_events.json

--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -52,6 +52,33 @@ UME_ROLE=UserService ume new_node UserProfile.123 '{}'
 
 Without the `UserService` role the command raises `AccessDeniedError`.
 
+## Permission Graph Model
+
+Permissions are stored within the graph using dedicated node and edge types
+introduced in schema version `3.0.0`.
+
+- `User` nodes represent individual actors.
+- `UserGroup` nodes collect users for shared access.
+- Resources link to owners via `OWNED_BY` edges.
+- `SHARED_WITH` edges grant group access and may include a `permission_level`
+  property such as `viewer` or `editor`.
+
+### Sample Requests
+
+Retrieve nodes owned by a user:
+
+```bash
+curl "http://localhost:8000/v1/nodes?user_id=User.u1"
+```
+
+Retrieve nodes shared with a group:
+
+```bash
+curl "http://localhost:8000/v1/nodes/shared?group_id=Group.g1"
+```
+
+Both endpoints require an authenticated role as described above.
+
 ## Dossier Endpoint RBAC
 
 API routes under `/dossier` use their own role checks. Three roles are

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -39,6 +39,22 @@ Properties:
 - `type_id` *(string, required)*: Unique identifier for the new entity.
 - Other attributes depend on the producer.
 
+### User
+Represents an individual actor within UME.
+
+Properties:
+- `user_id` *(string, required)*: Stable identifier for the user.
+- `name` *(string)*: Display name.
+- `email` *(string)*: Contact address.
+
+### UserGroup
+Collects users for shared permissions and collaboration.
+
+Properties:
+- `group_id` *(string, required)*: Stable identifier for the group.
+- `name` *(string)*: Human friendly label.
+- `members` *(array)*: List of `user_id` values belonging to the group.
+
 ## Edge Labels
 
 - `REMEMBERS`: connects a `UserMemory` node to an `AgentIntent` that created it.
@@ -48,6 +64,9 @@ Properties:
 - `CONNECTS_TO`: Used for network-style associations.
 - `RELATES_TO`: Indicates a topical relationship.
 - `NEW_LABEL`: Links research job nodes to the documents they discover.
+- `OWNED_BY`: Links a resource node to the `User` or `UserGroup` that owns it.
+- `SHARED_WITH`: Grants a `UserGroup` access to a resource. Optional
+  `permission_level` property describes viewer/editor rights.
 
 Example edge creation event:
 
@@ -180,6 +199,19 @@ Version numbers follow `MAJOR.MINOR.PATCH` semantics.  Adding a new optional
 property bumps the MINOR version.  Changing required fields or the meaning of an
 existing property increments MAJOR.  The PATCH component is reserved for
 documentation fixes or clarifications that do not alter validation rules.
+
+### Migration Notes
+
+Historical event ledgers can be upgraded after a schema change using the
+`ume.migrate_events` utility:
+
+```bash
+poetry run python -m ume.migrate_events --source ledger > migrated_events.json
+```
+
+This command reads stored event envelopes and re-emits them with the latest
+`schema_version`, ensuring new node and edge definitions like `User` or
+`SHARED_WITH` are applied consistently.
 
 ## Programmatic Schema Loading
 


### PR DESCRIPTION
## Summary
- document new `User` and `UserGroup` nodes along with `OWNED_BY`/`SHARED_WITH` edges
- explain permission graph model with sample `user_id`/`group_id` requests
- highlight schema versioning strategy and how to migrate event logs

## Testing
- ⚠️ no tests were run; documentation-only changes

------
https://chatgpt.com/codex/tasks/task_e_689bd33cac0483269fe0005b7a374deb