### PR TITLE
feat: migrate legacy permission edges

### DIFF
--- a/src/ume/schema_manager.py
+++ b/src/ume/schema_manager.py
@@ -85,10 +85,19 @@ class GraphSchemaManager:
                         graph.delete_edge(src, tgt, label)
 
             if new_version == "3.0.0":
-                for src, tgt, label, *_ in list(graph.get_all_edges()):
+                for src, tgt, label, attrs in list(graph.get_all_edges()):
                     if label == "NEW_LABEL":
                         graph.delete_edge(src, tgt, label)
                         graph.add_edge(src, tgt, "TAGGED_AS")
+                    elif label == "HAS_PERMISSION":
+                        graph.delete_edge(src, tgt, label)
+                        perm_level = None
+                        if isinstance(attrs, dict):
+                            perm_level = attrs.get("permission_level")
+                        else:
+                            perm_level = attrs
+                        new_label = "OWNED_BY" if perm_level == "editor" else "SHARED_WITH"
+                        graph.add_edge(src, tgt, new_label, attrs)
                     elif label in {
                         "REMEMBERS",
                         "ASSOCIATED_WITH",

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -1,10 +1,9 @@
 import subprocess
 from pathlib import Path
 import sys
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 import pytest
 
-pytest.importorskip("sentence_transformers")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from ume import (
     GraphSchemaManager,
@@ -116,3 +115,25 @@ def test_upgrade_to_v3_transforms_graph(graph: PersistentGraph) -> None:
     assert all(
         lbl == "TAGGED_AS" for _, _, lbl, _ in edges
     )
+
+
+def test_upgrade_maps_has_permission_edges(
+    graph: PersistentGraph,
+) -> None:
+    graph.add_node("doc", {})
+    graph.add_node("user1", {})
+    graph.add_node("user2", {})
+    graph.add_edge(
+        "doc", "user1", "HAS_PERMISSION", {"permission_level": "editor"}
+    )
+    graph.add_edge(
+        "doc", "user2", "HAS_PERMISSION", {"permission_level": "viewer"}
+    )
+
+    manager = GraphSchemaManager()
+    manager.upgrade_schema("2.0.0", "3.0.0", graph)
+
+    edges = graph.get_all_edges()
+    assert ("doc", "user1", "OWNED_BY", {"permission_level": "editor"}) in edges
+    assert ("doc", "user2", "SHARED_WITH", {"permission_level": "viewer"}) in edges
+    assert all(lbl != "HAS_PERMISSION" for _, _, lbl, _ in edges)


### PR DESCRIPTION
## Summary
- migrate HAS_PERMISSION edges to OWNED_BY/SHARED_WITH on schema upgrade
- add migration test coverage for permission edge mapping
- allow schema manager tests to run without sentence_transformers

## Testing
- `pre-commit run --files tests/test_schema_manager.py`
- `pytest tests/test_schema_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_689bd33c21308326aa7299af5bec8690