### PR TITLE
feat: support group-based calendar events

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -25,6 +25,7 @@ class CalendarEventCreateRequest(BaseModel):
     rrule: str | None = None
     visibility: str | None = None
     user_id: str
+    group_id: str | None = None
     invitee_ids: List[str] | None = None
     layer_ids: List[str] | None = None
 
@@ -80,6 +81,13 @@ def create_event(
         graph.add_edge(
             event.id, uid, "SHARED_WITH", {"permission_level": "viewer"}
         )
+    if req.group_id:
+        graph.add_edge(
+            event.id,
+            req.group_id,
+            "SHARED_WITH",
+            {"permission_level": "viewer"},
+        )
     for lid in req.layer_ids or []:
         graph.add_edge(event.id, lid, "TAGGED_AS")
     return CalendarEventResponse(
@@ -99,13 +107,18 @@ def create_event(
 @router.get("/events", response_model=List[CalendarEventResponse])
 def list_events(
     user_id: str = Query(...),
+    group_id: str | None = Query(None),
     layer_id: str | None = Query(None),
     since: int | None = Query(None, ge=0),
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> List[CalendarEventResponse]:
-    perm_graph = PermissionsGraphAdapter(graph, user_id=user_id)
+    perm_graph = PermissionsGraphAdapter(
+        graph, user_id=user_id, group_id=group_id
+    )
     event_ids = set(perm_graph.get_nodes_by_user(user_id))
+    if group_id is not None:
+        event_ids |= set(perm_graph.get_nodes_shared_with(group_id))
     if layer_id is not None:
         layer_events = {
             src

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -122,6 +122,48 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert (event_id, "user2", "SHARED_WITH", {"permission_level": "viewer"}) in edges
 
 
+def test_calendar_event_group_permissions(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    # Pre-create user and group nodes
+    graph.add_node("user1", {})
+    graph.add_node("user2", {})
+    graph.add_node("group1", {})
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+
+    res = client.post(
+        "/v1/calendar/events",
+        json={"title": "Standup", "start": start, "user_id": "user1", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    event_data = res.json()
+    event_id = event_data["id"]
+
+    # Unrelated user without group access cannot see the event
+    res = client.get(
+        "/v1/calendar/events",
+        params={"user_id": "user2"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == []
+
+    # Group-scoped retrieval returns the event
+    res = client.get(
+        "/v1/calendar/events",
+        params={"user_id": "user2", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == [event_data]
+
+    edges = graph.get_all_edges()
+    assert (event_id, "group1", "SHARED_WITH", {"permission_level": "viewer"}) in edges
+
+
 def test_calendar_event_unauthorized_access(client_and_graph) -> None:
     client, _ = client_and_graph
 


### PR DESCRIPTION
## Summary
- allow calendar events to be shared with a group
- fetch calendar events by group scope
- test group-scoped calendar event creation and retrieval

## Testing
- `pre-commit run --files src/ume/calendar_routes.py tests/test_calendar_decision_api.py`
- `pytest tests/test_calendar_decision_api.py`


------
https://chatgpt.com/codex/tasks/task_e_689c94dcb40083268a9c2f6b48dfd83f