### PR TITLE
Replace HAS_PERMISSION edges in decisions routes

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -63,20 +63,18 @@ def create_decision(
     analysis = create_decision_analysis(req.query)
     attrs = _analysis_to_dict(analysis)
     perm_graph.add_node(analysis.analysis_id, attrs)
-    # Establish ownership and permissions
-    graph.add_edge(analysis.analysis_id, req.user_id, "OWNED_BY")
+    # Establish ownership and sharing with permission levels
     graph.add_edge(
         analysis.analysis_id,
         req.user_id,
-        "HAS_PERMISSION",
+        "OWNED_BY",
         {"permission_level": "editor"},
     )
     if req.group_id:
-        graph.add_edge(analysis.analysis_id, req.group_id, "OWNED_BY")
         graph.add_edge(
             analysis.analysis_id,
             req.group_id,
-            "HAS_PERMISSION",
+            "SHARED_WITH",
             {"permission_level": "editor"},
         )
     return attrs
@@ -102,20 +100,18 @@ def add_action(
     )
     action_attrs = _action_to_dict(action)
     perm_graph.add_node(action.action_id, action_attrs)
-    # Ownership and permissions for the action
-    graph.add_edge(action.action_id, req.user_id, "OWNED_BY")
+    # Ownership and sharing for the action
     graph.add_edge(
         action.action_id,
         req.user_id,
-        "HAS_PERMISSION",
+        "OWNED_BY",
         {"permission_level": "editor"},
     )
     if req.group_id:
-        graph.add_edge(action.action_id, req.group_id, "OWNED_BY")
         graph.add_edge(
             action.action_id,
             req.group_id,
-            "HAS_PERMISSION",
+            "SHARED_WITH",
             {"permission_level": "editor"},
         )
     perm_graph.add_edge(analysis_id, action.action_id, "CONSIDERS")

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -154,43 +154,28 @@ def test_decision_flow(client_and_graph) -> None:
     )
     assert res.status_code == 200
     analysis_id = res.json()["analysis_id"]
+    res = client.post(
+        f"/v1/decisions/{analysis_id}/actions",
+        json={"description": "Option A", "user_id": "user1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    action_id = res.json()["action_id"]
 
-    from unittest.mock import patch
+    res = client.get(
+        f"/v1/decisions/{analysis_id}",
+        params={"user_id": "user1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    assert data["analysis"]["analysis_id"] == analysis_id
+    assert [a["action_id"] for a in data["actions"]] == [action_id]
 
-    def patched_has_permission_edge(self, node_id, subject, perm):
-        for src, tgt, lbl, attrs in self._adapter.get_all_edges():
-            if src == node_id and tgt == subject and lbl in {"OWNED_BY", "SHARED_WITH", "HAS_PERMISSION"}:
-                perm_level = None
-                if isinstance(attrs, dict):
-                    perm_level = attrs.get("permission_level")
-                else:
-                    perm_level = attrs
-                if perm_level == perm:
-                    return True
-        return False
+    assert graph.get_node(analysis_id)["query"] == "Choose option"
+    assert graph.get_node(action_id)["description"] == "Option A"
+    assert graph.find_connected_nodes(analysis_id, edge_label="CONSIDERS") == [action_id]
 
-    with patch(
-        "ume.permissions_adapter.PermissionsGraphAdapter._has_permission_edge",
-        patched_has_permission_edge,
-    ):
-        res = client.post(
-            f"/v1/decisions/{analysis_id}/actions",
-            json={"description": "Option A", "user_id": "user1"},
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        assert res.status_code == 200
-        action_id = res.json()["action_id"]
-
-        res = client.get(
-            f"/v1/decisions/{analysis_id}",
-            params={"user_id": "user1"},
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        assert res.status_code == 200
-        data = res.json()
-        assert data["analysis"]["analysis_id"] == analysis_id
-        assert [a["action_id"] for a in data["actions"]] == [action_id]
-
-        assert graph.get_node(analysis_id)["query"] == "Choose option"
-        assert graph.get_node(action_id)["description"] == "Option A"
-        assert graph.find_connected_nodes(analysis_id, edge_label="CONSIDERS") == [action_id]
+    edges = graph.get_all_edges()
+    assert (analysis_id, "user1", "OWNED_BY", {"permission_level": "editor"}) in edges
+    assert (action_id, "user1", "OWNED_BY", {"permission_level": "editor"}) in edges

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -4,6 +4,7 @@ import pytest
 from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
+from ume.decisions_routes import router as decisions_router
 
 
 def _token(client: TestClient) -> str:
@@ -18,6 +19,7 @@ def _token(client: TestClient) -> str:
 def client_and_graph():
     g = MockGraph()
     configure_graph(g)
+    app.include_router(decisions_router)
     return TestClient(app), g
 
 


### PR DESCRIPTION
## Summary
- replace decision edge `HAS_PERMISSION` with `OWNED_BY`/`SHARED_WITH` carrying `permission_level`
- remove temporary permission patches and assert new edges in calendar decision tests
- include decisions router in dedicated decision route tests

## Testing
- `ruff check src/ume/decisions_routes.py tests/test_calendar_decision_api.py tests/test_decisions_routes.py`
- `pytest tests/test_calendar_decision_api.py -q`
- `pytest tests/test_decisions_routes.py::test_decision_flow -q`


------
https://chatgpt.com/codex/tasks/task_e_689c94dbad008326a33fb626eaabb1d4