### PR TITLE
Add ranking and metrics fields to ProposedAction

### DIFF
--- a/src/ume/models/proposed_action.py
+++ b/src/ume/models/proposed_action.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 import uuid
 
 
-SCHEMA_VERSION = "3.0"
+SCHEMA_VERSION = "3.0.0"
 
 
 @dataclass

--- a/src/ume/schemas/graph_schema_v3.yaml
+++ b/src/ume/schemas/graph_schema_v3.yaml
@@ -74,6 +74,12 @@ node_types:
         version: "3.0.0"
       description:
         version: "3.0.0"
+      rank:
+        version: "3.0.0"
+      is_optimal:
+        version: "3.0.0"
+      outcome_metrics:
+        version: "3.0.0"
   FinancialAccount:
     version: "3.0.0"
     permission_level: "public"

--- a/tests/test_proposed_action_model.py
+++ b/tests/test_proposed_action_model.py
@@ -8,3 +8,17 @@ def test_create_proposed_action_defaults() -> None:
     assert action.rank == 0
     assert action.is_optimal is False
     assert action.outcome_metrics == {}
+    assert action.schema_version == "3.0.0"
+
+
+def test_create_proposed_action_custom_values() -> None:
+    metrics = {"accuracy": 0.95, "speed": 1.2}
+    action = create_proposed_action(
+        "run tests",
+        rank=1,
+        is_optimal=True,
+        outcome_metrics=metrics,
+    )
+    assert action.rank == 1
+    assert action.is_optimal is True
+    assert action.outcome_metrics == metrics


### PR DESCRIPTION
## Summary
- extend graph schema to include `rank`, `is_optimal`, and `outcome_metrics` on ProposedAction nodes
- expose new fields and schema version in ProposedAction model
- test default and custom ProposedAction attributes

## Testing
- `pre-commit run --files src/ume/schemas/graph_schema_v3.yaml src/ume/models/proposed_action.py tests/test_proposed_action_model.py`
- `pytest tests/test_proposed_action_model.py`

------
https://chatgpt.com/codex/tasks/task_e_689ccca9dc208326b6e3bed91b77de9b