### PR TITLE
Add node property metadata to graph schema

### DIFF
--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -10,12 +10,22 @@ import yaml
 
 
 @dataclass
+class Property:
+    """Representation of a property within a node type."""
+
+    name: str
+    version: str
+    permission_level: str | None = None
+
+
+@dataclass
 class NodeType:
     """Representation of a node type within the graph schema."""
 
     name: str
     version: str
     permission_level: str | None = None
+    properties: Dict[str, Property] = field(default_factory=dict)
 
 
 @dataclass
@@ -43,14 +53,22 @@ class GraphSchema:
                 data = yaml.safe_load(f)
             else:
                 data = json.load(f)
-        node_types = {
-            name: NodeType(
+        node_types = {}
+        for name, info in data.get("node_types", {}).items():
+            properties = {
+                prop_name: Property(
+                    name=prop_name,
+                    version=str(prop_info.get("version", "0.0.0")),
+                    permission_level=prop_info.get("permission_level"),
+                )
+                for prop_name, prop_info in info.get("properties", {}).items()
+            }
+            node_types[name] = NodeType(
                 name=name,
                 version=str(info.get("version", "0.0.0")),
                 permission_level=info.get("permission_level"),
+                properties=properties,
             )
-            for name, info in data.get("node_types", {}).items()
-        }
         edge_labels = {
             label: EdgeLabel(
                 label=label,
@@ -83,6 +101,16 @@ class GraphSchema:
             from .processing import ProcessingError
 
             raise ProcessingError(f"Unknown edge label '{label}'")
+
+    def validate_node_property(self, node_type: str, property_name: str) -> None:
+        """Validate that a property exists for a given node type."""
+        self.validate_node_type(node_type)
+        if property_name not in self.node_types[node_type].properties:
+            from .processing import ProcessingError
+
+            raise ProcessingError(
+                f"Unknown property '{property_name}' for node type '{node_type}'"
+            )
 
 
 def load_default_schema() -> GraphSchema:

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -30,3 +30,44 @@ def test_validate_unknown_edge_label():
     with pytest.raises(ProcessingError):
         schema.validate_edge_label("UnknownLabel")
 
+
+def test_load_node_properties(tmp_path):
+    schema_yaml = {
+        "version": "1.0.0",
+        "node_types": {
+            "User": {
+                "version": "1.0.0",
+                "properties": {
+                    "id": {"version": "1.0.0"},
+                    "name": {"version": "1.0.0"},
+                },
+            }
+        },
+        "edge_labels": {},
+    }
+    path = tmp_path / "schema.yaml"
+    path.write_text(yaml.safe_dump(schema_yaml))
+    schema = GraphSchema.load(str(path))
+    user = schema.node_types["User"]
+    assert "id" in user.properties
+    assert user.properties["id"].version == "1.0.0"
+
+
+def test_validate_node_property(tmp_path):
+    schema_yaml = {
+        "version": "1.0.0",
+        "node_types": {
+            "User": {
+                "version": "1.0.0",
+                "properties": {"id": {"version": "1.0.0"}},
+            }
+        },
+        "edge_labels": {},
+    }
+    path = tmp_path / "schema.yaml"
+    path.write_text(yaml.safe_dump(schema_yaml))
+    schema = GraphSchema.load(str(path))
+    schema.validate_node_property("User", "id")
+    with pytest.raises(ProcessingError):
+        schema.validate_node_property("User", "missing")
+


### PR DESCRIPTION
## Summary
- extend graph schema dataclasses to track per-property metadata
- parse property blocks from YAML and expose property validators
- test property loading and validation in graph schema

## Testing
- `ruff check src/ume/graph_schema.py tests/test_graph_schema.py`
- `pytest tests/test_graph_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_689ccca926148326b1f430f32c49e15c