### PR TITLE
Use SHARED_WITH edges for decision routes

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -63,14 +63,18 @@ def create_decision(
     analysis = create_decision_analysis(req.query)
     attrs = _analysis_to_dict(analysis)
     perm_graph.add_node(analysis.analysis_id, attrs)
-    # Establish ownership and sharing with permission levels
+    # Ensure subject nodes exist
+    if not graph.node_exists(req.user_id):
+        graph.add_node(req.user_id, {})
     graph.add_edge(
         analysis.analysis_id,
         req.user_id,
-        "OWNED_BY",
+        "SHARED_WITH",
         {"permission_level": "editor"},
     )
     if req.group_id:
+        if not graph.node_exists(req.group_id):
+            graph.add_node(req.group_id, {})
         graph.add_edge(
             analysis.analysis_id,
             req.group_id,
@@ -100,14 +104,18 @@ def add_action(
     )
     action_attrs = _action_to_dict(action)
     perm_graph.add_node(action.action_id, action_attrs)
-    # Ownership and sharing for the action
+    # Ensure subject nodes exist
+    if not graph.node_exists(req.user_id):
+        graph.add_node(req.user_id, {})
     graph.add_edge(
         action.action_id,
         req.user_id,
-        "OWNED_BY",
+        "SHARED_WITH",
         {"permission_level": "editor"},
     )
     if req.group_id:
+        if not graph.node_exists(req.group_id):
+            graph.add_node(req.group_id, {})
         graph.add_edge(
             action.action_id,
             req.group_id,

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -27,9 +27,6 @@ def test_decision_flow(client_and_graph) -> None:
     client, g = client_and_graph
     token = _token(client)
 
-    # Pre-create user node for permission edges
-    g.add_node("user1", {})
-
     res = client.post(
         "/v1/decisions",
         json={"query": "Choose option", "user_id": "user1"},
@@ -62,3 +59,19 @@ def test_decision_flow(client_and_graph) -> None:
     assert g.get_node(analysis_id)["query"] == "Choose option"
     assert g.get_node(action_id)["description"] == "Option A"
     assert g.find_connected_nodes(analysis_id, edge_label="CONSIDERS") == [action_id]
+    # Permission edges created
+    edges = g.get_all_edges()
+    assert any(
+        s == analysis_id
+        and t == "user1"
+        and lbl == "SHARED_WITH"
+        and e.get("permission_level") == "editor"
+        for s, t, lbl, e in edges
+    )
+    assert any(
+        s == action_id
+        and t == "user1"
+        and lbl == "SHARED_WITH"
+        and e.get("permission_level") == "editor"
+        for s, t, lbl, e in edges
+    )


### PR DESCRIPTION
## Summary
- record decision sharing via `SHARED_WITH` edges that carry a permission level
- drop test monkeypatches and assert permission edges for decisions

## Testing
- `ruff check src/ume/decisions_routes.py tests/test_decisions_routes.py`
- `pytest tests/test_decisions_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cd73900a88326b2f1692f67918714