### PR TITLE
Add financial account routes with ownership and sharing

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -68,6 +68,7 @@ from .ledger_routes import router as ledger_router
 from .dossier_routes import router as dossier_router
 from .calendar_routes import router as calendar_router
 from .permissions_routes import router as permissions_router
+from .financial_account_routes import router as account_router
 
 
 from .consent_ledger import consent_ledger  # noqa: F401
@@ -120,6 +121,7 @@ app.include_router(snapshot_router)
 app.include_router(ledger_router)
 app.include_router(dossier_router)
 app.include_router(calendar_router)
+app.include_router(account_router)
 app.include_router(permissions_router)
 
 

--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from . import api_deps as deps
+from .graph_adapter import IGraphAdapter
+from .models import create_financial_account
+
+router = APIRouter(prefix="/v1/accounts")
+
+
+class FinancialAccountCreateRequest(BaseModel):
+    account_type: str
+    institution: str
+    balance: float
+    currency: str = "USD"
+    user_id: str
+    group_id: str | None = None
+
+
+class FinancialAccountResponse(BaseModel):
+    id: str
+    account_type: str
+    institution: str
+    balance: float
+    currency: str
+
+
+@router.post("", response_model=FinancialAccountResponse)
+def create_account(
+    req: FinancialAccountCreateRequest,
+    graph: IGraphAdapter = Depends(deps.get_graph),
+    _: str = Depends(deps.get_current_role),
+) -> FinancialAccountResponse:
+    account = create_financial_account(
+        req.account_type,
+        req.institution,
+        req.balance,
+        currency=req.currency,
+    )
+    attrs = {
+        "type": "FinancialAccount",
+        "account_type": account.account_type,
+        "institution": account.institution,
+        "balance": account.balance,
+        "currency": account.currency,
+    }
+    graph.add_node(account.account_id, attrs)
+    graph.add_edge(
+        account.account_id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
+    )
+    if req.group_id:
+        graph.add_edge(
+            account.account_id,
+            req.group_id,
+            "SHARED_WITH",
+            {"permission_level": "viewer"},
+        )
+    return FinancialAccountResponse(
+        id=account.account_id,
+        account_type=account.account_type,
+        institution=account.institution,
+        balance=account.balance,
+        currency=account.currency,
+    )

--- a/tests/test_financial_account_model.py
+++ b/tests/test_financial_account_model.py
@@ -1,4 +1,10 @@
+import pytest
+from fastapi.testclient import TestClient
+
 from ume.models import FinancialAccount, create_financial_account
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
 
 
 def test_create_financial_account() -> None:
@@ -9,3 +15,55 @@ def test_create_financial_account() -> None:
     assert account.balance == 100.0
     assert account.currency == "USD"
     assert account.account_id
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/auth/token",
+        data={
+            "username": settings.UME_OAUTH_USERNAME,
+            "password": settings.UME_OAUTH_PASSWORD,
+        },
+    )
+    return res.json()["access_token"]
+
+
+@pytest.fixture
+def client_and_graph():
+    graph = MockGraph()
+    configure_graph(graph)
+    return TestClient(app), graph
+
+
+def test_create_financial_account_edges(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+    graph.add_node("group1", {})
+
+    res = client.post(
+        "/v1/accounts",
+        json={
+            "account_type": "checking",
+            "institution": "ACME Bank",
+            "balance": 100.0,
+            "currency": "USD",
+            "user_id": "user1",
+            "group_id": "group1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    account_id = data["id"]
+    assert data == {
+        "id": account_id,
+        "account_type": "checking",
+        "institution": "ACME Bank",
+        "balance": 100.0,
+        "currency": "USD",
+    }
+    edges = graph.get_all_edges()
+    assert (account_id, "user1", "OWNED_BY", {"permission_level": "editor"}) in edges
+    assert (account_id, "group1", "SHARED_WITH", {"permission_level": "viewer"}) in edges


### PR DESCRIPTION
## Summary
- add financial account creation endpoint that stores account nodes and sets ownership and sharing edges
- wire financial account router into main API
- test account creation to ensure OWNED_BY and SHARED_WITH edges are created

## Testing
- `ruff check src/ume/financial_account_routes.py src/ume/api.py tests/test_financial_account_model.py`
- `pytest tests/test_financial_account_model.py`


------
https://chatgpt.com/codex/tasks/task_e_689d00f8ec3883269f01a50fe38e655a