### PR TITLE
Bump calendar schema version to 3.0.0

### DIFF
--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import uuid
 
-SCHEMA_VERSION = "3.0"
+SCHEMA_VERSION = "3.0.0"
 
 
 @dataclass

--- a/tests/test_models_calendar_decision.py
+++ b/tests/test_models_calendar_decision.py
@@ -23,7 +23,7 @@ def test_create_calendar_event_defaults_and_schema_version() -> None:
     assert event.status is None
     assert event.rrule is None
     assert event.visibility is None
-    assert event.schema_version == "3.0"
+    assert event.schema_version == "3.0.0"
     assert event.start == start
 
 


### PR DESCRIPTION
## Summary
- update calendar event schema version to 3.0.0
- adjust calendar decision tests for new schema version

## Testing
- `pre-commit run --files src/ume/models/calendar.py tests/test_models_calendar_decision.py`
- `pytest tests/test_models_calendar_decision.py`


------
https://chatgpt.com/codex/tasks/task_e_689d3b835bb083268b83fc719a6841ae