### PR TITLE
Add calendar layer routes and validation

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -67,6 +67,7 @@ from .snapshot_routes import router as snapshot_router
 from .ledger_routes import router as ledger_router
 from .dossier_routes import router as dossier_router
 from .calendar_routes import router as calendar_router
+from .calendar_layer_routes import router as calendar_layer_router
 from .decisions_routes import router as decisions_router
 from .permissions_routes import router as permissions_router
 from .financial_account_routes import router as account_router
@@ -122,6 +123,7 @@ app.include_router(snapshot_router)
 app.include_router(ledger_router)
 app.include_router(dossier_router)
 app.include_router(calendar_router)
+app.include_router(calendar_layer_router)
 app.include_router(decisions_router)
 app.include_router(account_router)
 app.include_router(permissions_router)

--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from . import api_deps as deps
+from .graph_adapter import IGraphAdapter
+from .models import create_calendar_layer
+
+router = APIRouter(prefix="/v1/calendar")
+
+
+class CalendarLayerCreateRequest(BaseModel):
+    layer_name: str
+    color: str
+    layer_id: str | None = None
+
+
+class CalendarLayerResponse(BaseModel):
+    layer_id: str
+    layer_name: str
+    color: str
+
+
+@router.post("/layers", response_model=CalendarLayerResponse)
+def create_layer(
+    req: CalendarLayerCreateRequest,
+    graph: IGraphAdapter = Depends(deps.get_graph),
+    _: str = Depends(deps.get_current_role),
+) -> CalendarLayerResponse:
+    layer = create_calendar_layer(
+        req.layer_name, req.color, layer_id=req.layer_id
+    )
+    attrs = {
+        "type": "CalendarLayer",
+        "layer_name": layer.layer_name,
+        "color": layer.color,
+    }
+    graph.add_node(layer.layer_id, attrs)
+    return CalendarLayerResponse(
+        layer_id=layer.layer_id,
+        layer_name=layer.layer_name,
+        color=layer.color,
+    )

--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, HTTPException
 from pydantic import BaseModel
 
 from . import api_deps as deps
@@ -89,6 +89,9 @@ def create_event(
             {"permission_level": "viewer"},
         )
     for lid in req.layer_ids or []:
+        layer_attrs = graph.get_node(lid)
+        if not layer_attrs or layer_attrs.get("type") != "CalendarLayer":
+            raise HTTPException(status_code=400, detail=f"Invalid layer_id: {lid}")
         graph.add_edge(event.id, lid, "TAGGED_AS")
     return CalendarEventResponse(
         id=event.id,

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/auth/token",
+        data={
+            "username": settings.UME_OAUTH_USERNAME,
+            "password": settings.UME_OAUTH_PASSWORD,
+        },
+    )
+    return res.json()["access_token"]
+
+
+@pytest.fixture
+def client_and_graph():
+    graph = MockGraph()
+    configure_graph(graph)
+    return TestClient(app), graph
+
+
+def test_create_calendar_layer(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    res = client.post(
+        "/v1/calendar/layers",
+        json={"layer_name": "Work", "color": "blue"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    layer_id = data["layer_id"]
+    assert data == {"layer_id": layer_id, "layer_name": "Work", "color": "blue"}
+    attrs = graph.get_node(layer_id)
+    assert attrs == {"type": "CalendarLayer", "layer_name": "Work", "color": "blue"}
+
+
+def test_event_layer_validation(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    graph.add_node("user1", {})
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Meeting",
+            "start": start,
+            "user_id": "user1",
+            "layer_ids": ["missing"],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400
+
+
+def test_event_with_existing_layer(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    graph.add_node("user1", {})
+    layer_res = client.post(
+        "/v1/calendar/layers",
+        json={"layer_name": "Work", "color": "blue"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    layer_id = layer_res.json()["layer_id"]
+    start_dt = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    start = start_dt.isoformat()
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Meeting",
+            "start": start,
+            "user_id": "user1",
+            "layer_ids": [layer_id],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    event_id = res.json()["id"]
+    edges = graph.get_all_edges()
+    assert (event_id, layer_id, "TAGGED_AS", {"permission_level": "public"}) in edges


### PR DESCRIPTION
## Summary
- add POST /v1/calendar/layers endpoint for creating calendar layers
- validate CalendarLayer IDs when creating events
- register calendar layer routes and cover with tests

## Testing
- `pre-commit run --files src/ume/calendar_layer_routes.py src/ume/calendar_routes.py src/ume/api.py tests/test_calendar_layer_routes.py`
- `pytest tests/test_calendar_layer_routes.py tests/test_calendar_layer_model.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f32f4d2208326ac3c439a9329cfa0