### PR TITLE
Align decision ownership labels with user links

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -66,10 +66,11 @@ def create_decision(
     # Ensure subject nodes exist
     if not graph.node_exists(req.user_id):
         graph.add_node(req.user_id, {})
+    # Link analysis to the owning user
     graph.add_edge(
         analysis.analysis_id,
         req.user_id,
-        "SHARED_WITH",
+        "OWNED_BY",
         {"permission_level": "editor"},
     )
     if req.group_id:
@@ -107,10 +108,11 @@ def add_action(
     # Ensure subject nodes exist
     if not graph.node_exists(req.user_id):
         graph.add_node(req.user_id, {})
+    # Link action to the owning user
     graph.add_edge(
         action.action_id,
         req.user_id,
-        "SHARED_WITH",
+        "OWNED_BY",
         {"permission_level": "editor"},
     )
     if req.group_id:

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -229,12 +229,12 @@ def test_decision_flow(client_and_graph) -> None:
     assert (
         analysis_id,
         "user1",
-        "SHARED_WITH",
+        "OWNED_BY",
         {"permission_level": "editor"},
     ) in edges
     assert (
         action_id,
         "user1",
-        "SHARED_WITH",
+        "OWNED_BY",
         {"permission_level": "editor"},
     ) in edges

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -62,14 +62,14 @@ def test_decision_flow(client_and_graph) -> None:
     assert any(
         s == analysis_id
         and t == "user1"
-        and lbl == "SHARED_WITH"
+        and lbl == "OWNED_BY"
         and e.get("permission_level") == "editor"
         for s, t, lbl, e in edges
     )
     assert any(
         s == action_id
         and t == "user1"
-        and lbl == "SHARED_WITH"
+        and lbl == "OWNED_BY"
         and e.get("permission_level") == "editor"
         for s, t, lbl, e in edges
     )


### PR DESCRIPTION
## Summary
- Link decision analyses and actions to users with `OWNED_BY` while keeping `SHARED_WITH` for groups
- Adjust decision and calendar API tests to expect new ownership labels
- Document ownership edge creation in decision routes

## Testing
- `ruff check src/ume/decisions_routes.py tests/test_decisions_routes.py tests/test_calendar_decision_api.py`
- `pytest tests/test_decisions_routes.py tests/test_calendar_decision_api.py -q`
- `pytest -q` *(fails: missing async client support, networkx pagerank, notebook kernel, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e04b5ed348326abc672dee2dd0189