### PR TITLE
Enforce editor permissions for sharing routes

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -76,13 +76,14 @@ def create_event(
     graph.add_edge(
         event.id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
     )
+    perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     for uid in req.invitee_ids or []:
-        graph.add_edge(event.id, uid, "INVITES")
-        graph.add_edge(
+        perm_graph.add_edge(event.id, uid, "INVITES")
+        perm_graph.add_edge(
             event.id, uid, "SHARED_WITH", {"permission_level": "viewer"}
         )
     if req.group_id:
-        graph.add_edge(
+        perm_graph.add_edge(
             event.id,
             req.group_id,
             "SHARED_WITH",
@@ -91,7 +92,9 @@ def create_event(
     for lid in req.layer_ids or []:
         layer_attrs = graph.get_node(lid)
         if not layer_attrs or layer_attrs.get("type") != "CalendarLayer":
-            raise HTTPException(status_code=400, detail=f"Invalid layer_id: {lid}")
+            raise HTTPException(
+                status_code=400, detail=f"Invalid layer_id: {lid}"
+            )
         graph.add_edge(event.id, lid, "TAGGED_AS")
     return CalendarEventResponse(
         id=event.id,

--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
+from .permissions_adapter import PermissionsGraphAdapter
 from .models import create_financial_account
 
 router = APIRouter(prefix="/v1/accounts")
@@ -48,10 +49,14 @@ def create_account(
     }
     graph.add_node(account.account_id, attrs)
     graph.add_edge(
-        account.account_id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
+        account.account_id,
+        req.user_id,
+        "OWNED_BY",
+        {"permission_level": "editor"},
     )
+    perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     if req.group_id:
-        graph.add_edge(
+        perm_graph.add_edge(
             account.account_id,
             req.group_id,
             "SHARED_WITH",

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -34,6 +34,9 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     graph.add_node("user1", {})
     graph.add_node("user2", {})
     graph.add_node("user3", {})
+    graph.add_edge(
+        "user2", "user1", "SHARED_WITH", {"permission_level": "editor"}
+    )
 
     start_dt = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
     end_dt = datetime(2024, 1, 1, 13, 0, tzinfo=timezone.utc)
@@ -114,8 +117,18 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert attrs["visibility"] == "public"
 
     edges = graph.get_all_edges()
-    assert (event_id, "user1", "OWNED_BY", {"permission_level": "editor"}) in edges
-    assert (event_id, "user2", "SHARED_WITH", {"permission_level": "viewer"}) in edges
+    assert (
+        event_id,
+        "user1",
+        "OWNED_BY",
+        {"permission_level": "editor"},
+    ) in edges
+    assert (
+        event_id,
+        "user2",
+        "SHARED_WITH",
+        {"permission_level": "viewer"},
+    ) in edges
 
 
 def test_calendar_event_group_permissions(client_and_graph) -> None:
@@ -126,12 +139,20 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     graph.add_node("user1", {})
     graph.add_node("user2", {})
     graph.add_node("group1", {})
+    graph.add_edge(
+        "group1", "user1", "SHARED_WITH", {"permission_level": "editor"}
+    )
 
     start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
 
     res = client.post(
         "/v1/calendar/events",
-        json={"title": "Standup", "start": start, "user_id": "user1", "group_id": "group1"},
+        json={
+            "title": "Standup",
+            "start": start,
+            "user_id": "user1",
+            "group_id": "group1",
+        },
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
@@ -168,7 +189,56 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     )
 
     edges = graph.get_all_edges()
-    assert (event_id, "group1", "SHARED_WITH", {"permission_level": "viewer"}) in edges
+    assert (
+        event_id,
+        "group1",
+        "SHARED_WITH",
+        {"permission_level": "viewer"},
+    ) in edges
+
+
+def test_calendar_event_invite_requires_editor(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+    graph.add_node("user2", {})
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Meeting",
+            "start": start,
+            "user_id": "user1",
+            "invitee_ids": ["user2"],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
+
+
+def test_calendar_event_group_share_requires_editor(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+    graph.add_node("group1", {})
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Standup",
+            "start": start,
+            "user_id": "user1",
+            "group_id": "group1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
 
 
 def test_calendar_event_unauthorized_access(client_and_graph) -> None:
@@ -223,7 +293,10 @@ def test_decision_flow(client_and_graph) -> None:
 
     assert graph.get_node(analysis_id)["query"] == "Choose option"
     assert graph.get_node(action_id)["description"] == "Option A"
-    assert graph.find_connected_nodes(analysis_id, edge_label="CONSIDERS") == [action_id]
+    assert (
+        graph.find_connected_nodes(analysis_id, edge_label="CONSIDERS")
+        == [action_id]
+    )
 
     edges = graph.get_all_edges()
     assert (

--- a/tests/test_financial_account_model.py
+++ b/tests/test_financial_account_model.py
@@ -41,6 +41,9 @@ def test_create_financial_account_edges(client_and_graph) -> None:
 
     graph.add_node("user1", {})
     graph.add_node("group1", {})
+    graph.add_edge(
+        "group1", "user1", "SHARED_WITH", {"permission_level": "editor"}
+    )
 
     res = client.post(
         "/v1/accounts",
@@ -65,5 +68,37 @@ def test_create_financial_account_edges(client_and_graph) -> None:
         "currency": "USD",
     }
     edges = graph.get_all_edges()
-    assert (account_id, "user1", "OWNED_BY", {"permission_level": "editor"}) in edges
-    assert (account_id, "group1", "SHARED_WITH", {"permission_level": "viewer"}) in edges
+    assert (
+        account_id,
+        "user1",
+        "OWNED_BY",
+        {"permission_level": "editor"},
+    ) in edges
+    assert (
+        account_id,
+        "group1",
+        "SHARED_WITH",
+        {"permission_level": "viewer"},
+    ) in edges
+
+
+def test_financial_account_group_requires_editor(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+    graph.add_node("group1", {})
+
+    res = client.post(
+        "/v1/accounts",
+        json={
+            "account_type": "checking",
+            "institution": "ACME Bank",
+            "balance": 100.0,
+            "currency": "USD",
+            "user_id": "user1",
+            "group_id": "group1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- wrap calendar event sharing with `PermissionsGraphAdapter` so adding invitee and group edges requires editor rights
- guard financial account group sharing with permission checks
- test that unauthorized invites and group shares return 403

## Testing
- `flake8 src/ume/calendar_routes.py src/ume/financial_account_routes.py tests/test_calendar_decision_api.py tests/test_financial_account_model.py`
- `pytest tests/test_calendar_decision_api.py tests/test_financial_account_model.py`

------
https://chatgpt.com/codex/tasks/task_e_689f36eee79c8326920ff86eea5ac441