### PR TITLE
Ensure financial account edges respect group permissions

### DIFF
--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
+from .rbac_adapter import AccessDeniedError
 from .models import create_financial_account
 
 router = APIRouter(prefix="/v1/accounts")
@@ -48,6 +49,10 @@ def create_account(
         "currency": account.currency,
     }
     graph.add_node(account.account_id, attrs)
+    if not graph.node_exists(req.user_id):
+        graph.add_node(req.user_id, {})
+    if req.group_id and not graph.node_exists(req.group_id):
+        graph.add_node(req.group_id, {})
     graph.add_edge(
         account.account_id,
         req.user_id,
@@ -56,12 +61,15 @@ def create_account(
     )
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     if req.group_id:
-        perm_graph.add_edge(
-            account.account_id,
-            req.group_id,
-            "SHARED_WITH",
-            {"permission_level": "viewer"},
-        )
+        try:
+            perm_graph.add_edge(
+                account.account_id,
+                req.group_id,
+                "SHARED_WITH",
+                {"permission_level": "viewer"},
+            )
+        except AccessDeniedError:
+            raise HTTPException(status_code=403, detail="Forbidden")
     return FinancialAccountResponse(
         id=account.account_id,
         account_type=account.account_type,

--- a/tests/test_financial_account_model.py
+++ b/tests/test_financial_account_model.py
@@ -86,9 +86,6 @@ def test_financial_account_group_requires_editor(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)
 
-    graph.add_node("user1", {})
-    graph.add_node("group1", {})
-
     res = client.post(
         "/v1/accounts",
         json={
@@ -102,3 +99,32 @@ def test_financial_account_group_requires_editor(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 403
+    assert graph.node_exists("user1")
+    assert graph.node_exists("group1")
+
+
+def test_create_financial_account_creates_user_node(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    res = client.post(
+        "/v1/accounts",
+        json={
+            "account_type": "savings",
+            "institution": "ACME Bank",
+            "balance": 50.0,
+            "currency": "USD",
+            "user_id": "user2",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    account_id = res.json()["id"]
+    assert graph.node_exists("user2")
+    edges = graph.get_all_edges()
+    assert (
+        account_id,
+        "user2",
+        "OWNED_BY",
+        {"permission_level": "editor"},
+    ) in edges


### PR DESCRIPTION
## Summary
- create user and group nodes on account creation when missing
- enforce editor rights when sharing financial accounts with groups
- test user and group node creation and group editor requirement

## Testing
- `ruff check src/ume/financial_account_routes.py tests/test_financial_account_model.py`
- `pytest tests/test_financial_account_model.py`
- `pytest` *(fails: Form data requires "python-multipart" to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689f3d7706c0832687112bdb24cc49de