### PR TITLE
Use perm_graph for group action sharing

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
+from .rbac_adapter import AccessDeniedError
 from .models import (
     DecisionAnalysis,
     ProposedAction,
@@ -118,12 +119,18 @@ def add_action(
     if req.group_id:
         if not graph.node_exists(req.group_id):
             graph.add_node(req.group_id, {})
-        graph.add_edge(
-            action.action_id,
-            req.group_id,
-            "SHARED_WITH",
-            {"permission_level": "editor"},
-        )
+        try:
+            perm_graph.add_edge(
+                action.action_id,
+                req.group_id,
+                "SHARED_WITH",
+                {"permission_level": "viewer"},
+            )
+        except AccessDeniedError:
+            raise HTTPException(
+                status_code=403,
+                detail="Editor permission required for target group",
+            )
     perm_graph.add_edge(analysis_id, action.action_id, "CONSIDERS")
     return action_attrs
 


### PR DESCRIPTION
## Summary
- add AccessDeniedError handling when adding SHARED_WITH edges in decisions routes
- require editor permission on target group for action sharing and use viewer permissions

## Testing
- `ruff check src/ume/decisions_routes.py`
- `pre-commit run --files src/ume/decisions_routes.py`
- `pytest tests/test_decisions_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f3d7602f083268d560782e275e911