### PR TITLE
Add schema version to DecisionAnalysis model

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -39,6 +39,7 @@ def _analysis_to_dict(analysis: DecisionAnalysis) -> dict[str, Any]:
         "analysis_id": analysis.analysis_id,
         "query": analysis.query,
         "created_at": int(analysis.created_at.timestamp()),
+        "schema_version": analysis.schema_version,
     }
 
 

--- a/src/ume/models/decision_analysis.py
+++ b/src/ume/models/decision_analysis.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from datetime import datetime
 import uuid
 
+SCHEMA_VERSION = "3.0.0"
+
 
 @dataclass
 class DecisionAnalysis:
@@ -14,6 +16,7 @@ class DecisionAnalysis:
     analysis_id: str
     query: str
     created_at: datetime
+    schema_version: str = SCHEMA_VERSION
 
 
 def create_decision_analysis(
@@ -27,4 +30,5 @@ def create_decision_analysis(
         analysis_id=analysis_id or str(uuid.uuid4()),
         query=query,
         created_at=datetime.utcnow(),
+        schema_version=SCHEMA_VERSION,
     )

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
+from ume.models.decision_analysis import SCHEMA_VERSION
 
 
 def _token(client: TestClient) -> str:
@@ -265,7 +266,9 @@ def test_decision_flow(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    analysis_id = res.json()["analysis_id"]
+    analysis_resp = res.json()
+    analysis_id = analysis_resp["analysis_id"]
+    assert analysis_resp["schema_version"] == SCHEMA_VERSION
     res = client.post(
         f"/v1/decisions/{analysis_id}/actions",
         json={"description": "Option A", "user_id": "user1"},
@@ -282,6 +285,7 @@ def test_decision_flow(client_and_graph) -> None:
     assert res.status_code == 200
     data = res.json()
     assert data["analysis"]["analysis_id"] == analysis_id
+    assert data["analysis"]["schema_version"] == SCHEMA_VERSION
     assert [a["action_id"] for a in data["actions"]] == [action_id]
 
     assert graph.get_node(analysis_id)["query"] == "Choose option"

--- a/tests/test_decision_analysis.py
+++ b/tests/test_decision_analysis.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from ume.models import create_decision_analysis
+from ume.models.decision_analysis import SCHEMA_VERSION
 
 
 def test_create_decision_analysis_sets_created_at() -> None:
@@ -10,3 +11,4 @@ def test_create_decision_analysis_sets_created_at() -> None:
     assert analysis.analysis_id
     assert analysis.created_at >= before
     assert analysis.created_at <= datetime.utcnow()
+    assert analysis.schema_version == SCHEMA_VERSION

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -4,6 +4,7 @@ import pytest
 from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
+from ume.models.decision_analysis import SCHEMA_VERSION
 
 
 def _token(client: TestClient) -> str:
@@ -33,6 +34,7 @@ def test_decision_flow(client_and_graph) -> None:
     assert res.status_code == 200
     analysis = res.json()
     analysis_id = analysis["analysis_id"]
+    assert analysis["schema_version"] == SCHEMA_VERSION
 
     res = client.post(
         f"/v1/decisions/{analysis_id}/actions",
@@ -51,6 +53,7 @@ def test_decision_flow(client_and_graph) -> None:
     assert res.status_code == 200
     data = res.json()
     assert data["analysis"]["analysis_id"] == analysis_id
+    assert data["analysis"]["schema_version"] == SCHEMA_VERSION
     assert len(data["actions"]) == 1
     assert data["actions"][0]["action_id"] == action_id
 

--- a/tests/test_mixed_access_api.py
+++ b/tests/test_mixed_access_api.py
@@ -13,6 +13,7 @@ import ume.api_deps as deps
 from ume.graph_adapter import IGraphAdapter
 from ume.permissions_adapter import PermissionsGraphAdapter
 from ume.models import create_financial_account
+from ume.models.decision_analysis import SCHEMA_VERSION
 
 # Register decision routes once for tests
 if not any(r.path.startswith("/v1/decisions") for r in app.router.routes):
@@ -170,7 +171,9 @@ def test_decision_mixed_access(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    analysis_id = res.json()["analysis_id"]
+    analysis_resp = res.json()
+    analysis_id = analysis_resp["analysis_id"]
+    assert analysis_resp["schema_version"] == SCHEMA_VERSION
 
     res = client.get(
         f"/v1/decisions/{analysis_id}",
@@ -185,6 +188,7 @@ def test_decision_mixed_access(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
+    assert res.json()["analysis"]["schema_version"] == SCHEMA_VERSION
 
     res = client.get(
         f"/v1/decisions/{analysis_id}",


### PR DESCRIPTION
## Summary
- track DecisionAnalysis schema version in model and API responses
- test DecisionAnalysis schema version propagation

## Testing
- `ruff check src/ume/models/decision_analysis.py src/ume/decisions_routes.py tests/test_decision_analysis.py tests/test_decisions_routes.py tests/test_calendar_decision_api.py tests/test_mixed_access_api.py`
- `pytest tests/test_decision_analysis.py tests/test_decisions_routes.py tests/test_calendar_decision_api.py tests/test_mixed_access_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4940b6688326bb161d0c833c41a1