### PR TITLE
feat: add calendar layer schema version

### DIFF
--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -24,6 +24,7 @@ class CalendarLayerResponse(BaseModel):
     layer_id: str
     layer_name: str
     color: str
+    schema_version: str
 
 
 @router.post("/layers", response_model=CalendarLayerResponse)
@@ -39,6 +40,7 @@ def create_layer(
         "type": "CalendarLayer",
         "layer_name": layer.layer_name,
         "color": layer.color,
+        "schema_version": layer.schema_version,
     }
     graph.add_node(layer.layer_id, attrs)
     graph.add_edge(
@@ -59,4 +61,5 @@ def create_layer(
         layer_id=layer.layer_id,
         layer_name=layer.layer_name,
         color=layer.color,
+        schema_version=layer.schema_version,
     )

--- a/src/ume/models/calendar_layer.py
+++ b/src/ume/models/calendar_layer.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 from uuid import uuid4
 
 
+SCHEMA_VERSION = "3.0.0"
+
+
 @dataclass
 class CalendarLayer:
     """Represents a calendar layer in the graph."""
@@ -13,6 +16,7 @@ class CalendarLayer:
     layer_id: str
     layer_name: str
     color: str
+    schema_version: str = SCHEMA_VERSION
 
 
 def create_calendar_layer(
@@ -27,4 +31,5 @@ def create_calendar_layer(
         layer_id=layer_id or str(uuid4()),
         layer_name=layer_name,
         color=color,
+        schema_version=SCHEMA_VERSION,
     )

--- a/tests/test_calendar_layer_model.py
+++ b/tests/test_calendar_layer_model.py
@@ -1,4 +1,5 @@
 from ume.models import CalendarLayer, create_calendar_layer
+from ume.models.calendar_layer import SCHEMA_VERSION
 import uuid
 
 
@@ -7,6 +8,7 @@ def test_create_calendar_layer_generates_id() -> None:
     assert isinstance(layer, CalendarLayer)
     assert layer.layer_name == "Work"
     assert layer.color == "blue"
+    assert layer.schema_version == SCHEMA_VERSION
     uuid.UUID(layer.layer_id)
 
 
@@ -14,3 +16,4 @@ def test_create_calendar_layer_with_provided_id() -> None:
     custom_id = "123"
     layer = create_calendar_layer("Personal", "red", layer_id=custom_id)
     assert layer.layer_id == custom_id
+    assert layer.schema_version == SCHEMA_VERSION

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
+from ume.models.calendar_layer import SCHEMA_VERSION
 
 
 def _token(client: TestClient) -> str:
@@ -42,12 +43,14 @@ def test_create_calendar_layer(client_and_graph) -> None:
         "layer_id": layer_id,
         "layer_name": "Work",
         "color": "blue",
+        "schema_version": SCHEMA_VERSION,
     }
     attrs = graph.get_node(layer_id)
     assert attrs == {
         "type": "CalendarLayer",
         "layer_name": "Work",
         "color": "blue",
+        "schema_version": SCHEMA_VERSION,
     }
     edges = graph.get_all_edges()
     assert (


### PR DESCRIPTION
## Summary
- add `SCHEMA_VERSION` constant and `schema_version` field to calendar layer model
- return and persist calendar layer schema version via API
- update calendar layer tests for schema version

## Testing
- `pre-commit run --files src/ume/models/calendar_layer.py src/ume/calendar_layer_routes.py tests/test_calendar_layer_model.py tests/test_calendar_layer_routes.py`
- `pytest tests/test_calendar_layer_model.py tests/test_calendar_layer_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_689f494297f48326984cb665d7905f9c