### PR TITLE
feat: add schema version to financial accounts

### DIFF
--- a/src/ume/models/financial_account.py
+++ b/src/ume/models/financial_account.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass
 import uuid
 
 
+SCHEMA_VERSION = "1.0"
+
+
 @dataclass
 class FinancialAccount:
     """Represents a financial account in the graph."""
@@ -15,6 +18,7 @@ class FinancialAccount:
     institution: str
     balance: float
     currency: str = "USD"
+    schema_version: str = SCHEMA_VERSION
 
 
 def create_financial_account(
@@ -33,4 +37,5 @@ def create_financial_account(
         institution=institution,
         balance=balance,
         currency=currency,
+        schema_version=SCHEMA_VERSION,
     )

--- a/tests/test_financial_account_model.py
+++ b/tests/test_financial_account_model.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from ume.models import FinancialAccount, create_financial_account
+from ume.models.financial_account import SCHEMA_VERSION
 from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
@@ -15,6 +16,7 @@ def test_create_financial_account() -> None:
     assert account.balance == 100.0
     assert account.currency == "USD"
     assert account.account_id
+    assert account.schema_version == SCHEMA_VERSION
 
 
 def _token(client: TestClient) -> str:


### PR DESCRIPTION
## Summary
- track schema version for FinancialAccount nodes
- verify schema version in financial account model tests

## Testing
- `pre-commit run --files src/ume/models/financial_account.py tests/test_financial_account_model.py`
- `pytest tests/test_financial_account_model.py::test_create_financial_account tests/test_financial_account_model.py::test_create_financial_account_edges tests/test_financial_account_model.py::test_create_financial_account_creates_user_node tests/test_mixed_access_api.py::test_financial_account_mixed_access`


------
https://chatgpt.com/codex/tasks/task_e_689f494286d88326a822533a672f209e