### PR TITLE
Add schema version to UserGroup model

### DIFF
--- a/src/ume/models/user_group.py
+++ b/src/ume/models/user_group.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import uuid
 
+SCHEMA_VERSION = "1.0"
+
 
 @dataclass
 class UserGroup:
@@ -13,6 +15,7 @@ class UserGroup:
     group_id: str
     name: str
     members: list[str] = field(default_factory=list)
+    schema_version: str = SCHEMA_VERSION
 
 
 def create_user_group(
@@ -27,4 +30,5 @@ def create_user_group(
         group_id=group_id or str(uuid.uuid4()),
         name=name,
         members=members or [],
+        schema_version=SCHEMA_VERSION,
     )

--- a/tests/test_user_group.py
+++ b/tests/test_user_group.py
@@ -9,6 +9,7 @@ def test_create_user_group_generates_id_and_defaults_members():
     uuid.UUID(group.group_id)
     assert group.name == "Admins"
     assert group.members == []
+    assert group.schema_version == "1.0"
 
 
 def test_create_user_group_accepts_members_and_id():
@@ -17,6 +18,7 @@ def test_create_user_group_accepts_members_and_id():
     group = create_user_group(name="Team", members=members, group_id=custom_id)
     assert group.group_id == custom_id
     assert group.members == members
+    assert group.schema_version == "1.0"
 
 
 def test_create_user_group_invalid_uuid():


### PR DESCRIPTION
## Summary
- include SCHEMA_VERSION constant and schema_version field in UserGroup model
- ensure create_user_group sets schema_version
- test UserGroup schema version handling

## Testing
- `ruff check src/ume/models/user_group.py tests/test_user_group.py tests/test_users_routes.py`
- `pytest tests/test_user_group.py`


------
https://chatgpt.com/codex/tasks/task_e_689f494196188326a359a6d549af9d41