### PR TITLE
Rename calendar event time fields

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -16,8 +16,8 @@ router = APIRouter(prefix="/v1/calendar")
 
 class CalendarEventCreateRequest(BaseModel):
     title: str
-    start: datetime
-    end: datetime | None = None
+    start_time: datetime
+    end_time: datetime | None = None
     description: str | None = None
     is_all_day: bool = False
     location: str | None = None
@@ -33,8 +33,8 @@ class CalendarEventCreateRequest(BaseModel):
 class CalendarEventResponse(BaseModel):
     id: str
     title: str
-    start: int
-    end: int | None = None
+    start_time: int
+    end_time: int | None = None
     description: str | None = None
     is_all_day: bool
     location: str | None = None
@@ -51,8 +51,8 @@ def create_event(
 ) -> CalendarEventResponse:
     event = create_calendar_event(
         req.title,
-        req.start,
-        req.end,
+        req.start_time,
+        req.end_time,
         description=req.description,
         is_all_day=req.is_all_day,
         location=req.location,
@@ -63,8 +63,8 @@ def create_event(
     attrs = {
         "type": "CalendarEvent",
         "title": event.title,
-        "start": int(event.start.timestamp()),
-        "end": int(event.end.timestamp()) if event.end else None,
+        "start_time": int(event.start_time.timestamp()),
+        "end_time": int(event.end_time.timestamp()) if event.end_time else None,
         "description": event.description,
         "is_all_day": event.is_all_day,
         "location": event.location,
@@ -107,8 +107,8 @@ def create_event(
     return CalendarEventResponse(
         id=event.id,
         title=event.title,
-        start=attrs["start"],
-        end=attrs["end"],
+        start_time=attrs["start_time"],
+        end_time=attrs["end_time"],
         description=event.description,
         is_all_day=event.is_all_day,
         location=event.location,
@@ -145,15 +145,15 @@ def list_events(
         attrs = graph.get_node(eid)
         if not attrs:
             continue
-        start_ts = attrs.get("start")
+        start_ts = attrs.get("start_time")
         if since is not None and (start_ts is None or start_ts < since):
             continue
         events.append(
             CalendarEventResponse(
                 id=eid,
                 title=attrs.get("title", ""),
-                start=start_ts,
-                end=attrs.get("end"),
+                start_time=start_ts,
+                end_time=attrs.get("end_time"),
                 description=attrs.get("description"),
                 is_all_day=attrs.get("is_all_day", False),
                 location=attrs.get("location"),

--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -15,8 +15,8 @@ class CalendarEvent:
 
     id: str
     title: str
-    start: datetime
-    end: datetime | None = None
+    start_time: datetime
+    end_time: datetime | None = None
     description: str | None = None
     is_all_day: bool = False
     location: str | None = None
@@ -28,8 +28,8 @@ class CalendarEvent:
 
 def create_calendar_event(
     title: str,
-    start: datetime,
-    end: datetime | None = None,
+    start_time: datetime,
+    end_time: datetime | None = None,
     *,
     description: str | None = None,
     event_id: str | None = None,
@@ -44,8 +44,8 @@ def create_calendar_event(
     return CalendarEvent(
         id=event_id or str(uuid.uuid4()),
         title=title,
-        start=start,
-        end=end,
+        start_time=start_time,
+        end_time=end_time,
         description=description,
         is_all_day=is_all_day,
         location=location,

--- a/src/ume/schemas/graph_schema_v3.yaml
+++ b/src/ume/schemas/graph_schema_v3.yaml
@@ -30,9 +30,9 @@ node_types:
         version: "3.0.0"
       title:
         version: "3.0.0"
-      start:
+      start_time:
         version: "3.0.0"
-      end:
+      end_time:
         version: "3.0.0"
       description:
         version: "3.0.0"

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -50,8 +50,8 @@ def test_calendar_event_permissions(client_and_graph) -> None:
         "/v1/calendar/events",
         json={
             "title": "Meeting",
-            "start": start,
-            "end": end,
+            "start_time": start,
+            "end_time": end,
             "description": "Discuss project",
             "is_all_day": True,
             "location": "Conference Room",
@@ -69,8 +69,8 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert event_data == {
         "id": event_id,
         "title": "Meeting",
-        "start": start_ts,
-        "end": end_ts,
+        "start_time": start_ts,
+        "end_time": end_ts,
         "description": "Discuss project",
         "is_all_day": True,
         "location": "Conference Room",
@@ -108,8 +108,8 @@ def test_calendar_event_permissions(client_and_graph) -> None:
 
     attrs = graph.get_node(event_id)
     assert attrs["title"] == "Meeting"
-    assert attrs["start"] == start_ts
-    assert attrs["end"] == end_ts
+    assert attrs["start_time"] == start_ts
+    assert attrs["end_time"] == end_ts
     assert attrs["description"] == "Discuss project"
     assert attrs["is_all_day"] is True
     assert attrs["location"] == "Conference Room"
@@ -145,7 +145,7 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
         "/v1/calendar/events",
         json={
             "title": "Standup",
-            "start": start,
+            "start_time": start,
             "user_id": "user1",
             "group_id": "group1",
         },
@@ -167,7 +167,7 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     # User creates their own event
     res = client.post(
         "/v1/calendar/events",
-        json={"title": "Solo", "start": start, "user_id": "user2"},
+        json={"title": "Solo", "start_time": start, "user_id": "user2"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
@@ -204,7 +204,7 @@ def test_calendar_event_invite_requires_editor(client_and_graph) -> None:
         "/v1/calendar/events",
         json={
             "title": "Meeting",
-            "start": start,
+            "start_time": start,
             "user_id": "user1",
             "invitee_ids": ["user2"],
         },
@@ -226,7 +226,7 @@ def test_calendar_event_group_share_requires_editor(client_and_graph) -> None:
         "/v1/calendar/events",
         json={
             "title": "Standup",
-            "start": start,
+            "start_time": start,
             "user_id": "user1",
             "group_id": "group1",
         },
@@ -242,7 +242,7 @@ def test_calendar_event_unauthorized_access(client_and_graph) -> None:
 
     res = client.post(
         "/v1/calendar/events",
-        json={"title": "Meeting", "start": start, "user_id": "user1"},
+        json={"title": "Meeting", "start_time": start, "user_id": "user1"},
     )
     assert res.status_code == 401
 

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -117,7 +117,7 @@ def test_event_layer_validation(client_and_graph) -> None:
         "/v1/calendar/events",
         json={
             "title": "Meeting",
-            "start": start,
+            "start_time": start,
             "user_id": "user1",
             "layer_ids": ["missing"],
         },
@@ -145,7 +145,7 @@ def test_event_with_existing_layer(client_and_graph) -> None:
         "/v1/calendar/events",
         json={
             "title": "Meeting",
-            "start": start,
+            "start_time": start,
             "user_id": "user1",
             "layer_ids": [layer_id],
         },

--- a/tests/test_mixed_access_api.py
+++ b/tests/test_mixed_access_api.py
@@ -116,13 +116,13 @@ def test_calendar_mixed_access(client_and_graph) -> None:
 
     res = client.post(
         "/v1/calendar/events",
-        json={"title": "Meeting", "start": start, "user_id": "owner", "group_id": "group1"},
+        json={"title": "Meeting", "start_time": start, "user_id": "owner", "group_id": "group1"},
     )
     assert res.status_code == 401
 
     res = client.post(
         "/v1/calendar/events",
-        json={"title": "Meeting", "start": start, "user_id": "owner", "group_id": "group1"},
+        json={"title": "Meeting", "start_time": start, "user_id": "owner", "group_id": "group1"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200

--- a/tests/test_models_calendar_decision.py
+++ b/tests/test_models_calendar_decision.py
@@ -16,7 +16,7 @@ def test_create_calendar_event_defaults_and_schema_version() -> None:
 
     assert isinstance(event, CalendarEvent)
     uuid.UUID(event.id)
-    assert event.end is None
+    assert event.end_time is None
     assert event.description is None
     assert event.is_all_day is False
     assert event.location is None
@@ -24,7 +24,7 @@ def test_create_calendar_event_defaults_and_schema_version() -> None:
     assert event.rrule is None
     assert event.visibility is None
     assert event.schema_version == "3.0.0"
-    assert event.start == start
+    assert event.start_time == start
 
 
 def test_create_decision_defaults_and_schema_version() -> None:


### PR DESCRIPTION
## Summary
- rename `start`/`end` to `start_time`/`end_time` in calendar models and API routes
- update Graph schema and tests for new field names

## Testing
- `pre-commit run --files src/ume/models/calendar.py src/ume/calendar_routes.py src/ume/schemas/graph_schema_v3.yaml tests/test_calendar_decision_api.py tests/test_mixed_access_api.py tests/test_models_calendar_decision.py tests/test_calendar_layer_routes.py`
- `pytest tests/test_calendar_decision_api.py tests/test_mixed_access_api.py tests/test_models_calendar_decision.py tests/test_calendar_layer_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd1ed7c083268b3f30c5fa00f9f0