### PR TITLE
Create user nodes for missing invitees in calendar events

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -82,6 +82,8 @@ def create_event(
     )
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     for uid in req.invitee_ids or []:
+        if not graph.node_exists(uid):
+            graph.add_node(uid, {"type": "User"})
         graph.add_edge(event.id, uid, "INVITES")
         graph.add_edge(
             event.id, uid, "SHARED_WITH", {"permission_level": "viewer"}

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -213,6 +213,39 @@ def test_calendar_event_invite_requires_editor(client_and_graph) -> None:
     assert res.status_code == 200
 
 
+def test_calendar_event_missing_invitee_created(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Sync",
+            "start_time": start,
+            "user_id": "owner",
+            "invitee_ids": ["missing"],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    event = res.json()
+
+    # Invitee node should be created automatically
+    attrs = graph.get_node("missing")
+    assert attrs is not None and attrs.get("type") == "User"
+
+    # Invitee can retrieve the event
+    res = client.get(
+        "/v1/calendar/events",
+        params={"user_id": "missing"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == [event]
+
+
 def test_calendar_event_group_share_requires_editor(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)


### PR DESCRIPTION
## Summary
- ensure calendar invitees have graph nodes created before linking
- test calendar event creation with missing invitee node

## Testing
- `pre-commit run --files src/ume/calendar_routes.py tests/test_calendar_decision_api.py`
- `pytest -q tests/test_calendar_decision_api.py::test_calendar_event_missing_invitee_created tests/test_calendar_decision_api.py::test_calendar_event_permissions`


------
https://chatgpt.com/codex/tasks/task_e_68a0caa012f483268611bbdd023bb5df