### PR TITLE
feat: migrate permission nodes and edges

### DIFF
--- a/src/ume/schema_manager.py
+++ b/src/ume/schema_manager.py
@@ -100,7 +100,17 @@ class GraphSchemaManager:
                         else:
                             perm_level = attrs
                         new_label = "OWNED_BY" if perm_level == "editor" else "SHARED_WITH"
-                        graph.add_edge(src, tgt, new_label, attrs)
+                        graph.add_edge(
+                            src,
+                            tgt,
+                            new_label,
+                            {"permission_level": "public"},
+                        )
+                        if graph.node_exists(tgt):
+                            node_attrs = graph.get_node(tgt) or {}
+                            node_attrs.setdefault("type", "User")
+                            node_attrs.setdefault("permission_level", "public")
+                            graph.update_node(tgt, node_attrs)
                     elif label in {
                         "REMEMBERS",
                         "ASSOCIATED_WITH",

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -5,15 +5,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from ume import (
-    GraphSchemaManager,
-    GraphSchema,
-    PersistentGraph,
-    Event,
-    EventType,
-    apply_event_to_graph,
-    ProcessingError,
-)
+from ume.schema_manager import GraphSchemaManager
+from ume.graph_schema import GraphSchema
+from ume.persistent_graph import PersistentGraph
+from ume.event import Event, EventType
+from ume.processing import apply_event_to_graph, ProcessingError
 
 
 @pytest.fixture
@@ -135,3 +131,28 @@ def test_upgrade_maps_has_permission_edges(
     assert ("doc", "user1", "OWNED_BY", {"permission_level": "public"}) in edges
     assert ("doc", "user2", "SHARED_WITH", {"permission_level": "public"}) in edges
     assert all(lbl != "HAS_PERMISSION" for _, _, lbl, _ in edges)
+
+
+def test_upgrade_permission_nodes_multi_user(graph: PersistentGraph) -> None:
+    graph.add_node("doc", {})
+    graph.add_node("u1", {})
+    graph.add_node("u2", {"name": "Bob"})
+    graph.add_edge("doc", "u1", "HAS_PERMISSION", {"permission_level": "viewer"})
+    graph.add_edge("doc", "u2", "HAS_PERMISSION", {"permission_level": "editor"})
+
+    manager = GraphSchemaManager()
+    manager.upgrade_schema("2.0.0", "3.0.0", graph)
+
+    edges = graph.get_all_edges()
+    assert ("doc", "u1", "SHARED_WITH", {"permission_level": "public"}) in edges
+    assert ("doc", "u2", "OWNED_BY", {"permission_level": "public"}) in edges
+
+    assert graph.get_node("u1") == {
+        "type": "User",
+        "permission_level": "public",
+    }
+    assert graph.get_node("u2") == {
+        "name": "Bob",
+        "type": "User",
+        "permission_level": "public",
+    }


### PR DESCRIPTION
## Summary
- upgrade permission edges from HAS_PERMISSION to OWNED_BY/SHARED_WITH
- set default user node attributes during schema upgrade
- test migration for multi-user permission scenarios

## Testing
- `ruff check src/ume/schema_manager.py tests/test_schema_manager.py`
- `pytest tests/test_schema_manager.py::test_upgrade_maps_has_permission_edges tests/test_schema_manager.py::test_upgrade_permission_nodes_multi_user -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3301e3a708326b8ada503ff62397b