### PR TITLE
Allow adding permission edges without target editor rights

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -141,7 +141,8 @@ class PermissionsGraphAdapter(IGraphAdapter):
         attrs: Dict[str, Any] | None = None,
     ) -> None:
         self._require_editor(source_node_id)
-        self._require_editor(target_node_id)
+        if label not in {"OWNED_BY", "SHARED_WITH"}:
+            self._require_editor(target_node_id)
         self._adapter.add_edge(source_node_id, target_node_id, label, attrs)
         self.rebuild_index()
 

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -97,3 +97,20 @@ def test_find_connected_nodes_filters_by_permissions() -> None:
     assert adapter.find_connected_nodes("Document.d1") == ["Document.d3"]
     with pytest.raises(AccessDeniedError):
         adapter.find_connected_nodes("Document.d2")
+
+
+def test_add_permission_edge_without_target_editor() -> None:
+    g = MockGraph()
+    g.add_node("User.u1", {})
+    g.add_node("User.u2", {})
+    g.add_node("Document.d1", {})
+    g._edges["Document.d1"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
+    adapter = PermissionsGraphAdapter(g, user_id="User.u1")
+    adapter.add_edge(
+        "Document.d1",
+        "User.u2",
+        "SHARED_WITH",
+        {"permission_level": "viewer"},
+    )
+    adapter_u2 = PermissionsGraphAdapter(g, user_id="User.u2")
+    assert adapter_u2.get_node("Document.d1") == {}


### PR DESCRIPTION
## Summary
- permit adding permission edges without needing editor rights on the target subject
- test inviting a user without editor access on the target

## Testing
- `pre-commit run --files src/ume/permissions_adapter.py tests/test_permissions_adapter.py`
- `pytest tests/test_permissions_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3301d389483268a6714a32cea109c