### PR TITLE
Bump user schema version to 3.0.0

### DIFF
--- a/src/ume/models/users.py
+++ b/src/ume/models/users.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 import uuid
 
-SCHEMA_VERSION = "3.0"
+# Keep in sync with the default ``schema_version`` on :class:`User`.
+SCHEMA_VERSION = "3.0.0"
 
 
 @dataclass
@@ -17,7 +18,7 @@ class User:
     name: str
     email: str | None = None
     created_at: datetime = field(default_factory=datetime.utcnow)
-    schema_version: str = SCHEMA_VERSION
+    schema_version: str = field(default=SCHEMA_VERSION)
 
     @property
     def id(self) -> str:  # pragma: no cover - compatibility layer

--- a/src/ume/users_routes.py
+++ b/src/ume/users_routes.py
@@ -21,6 +21,7 @@ class UserResponse(BaseModel):
     id: str
     name: str
     email: str | None = None
+    schema_version: str
 
 
 class UserGroupCreateRequest(BaseModel):
@@ -53,9 +54,15 @@ def create_user_node(
         "name": user.name,
         "email": user.email,
         "created_at": int(user.created_at.timestamp()),
+        "schema_version": user.schema_version,
     }
     graph.add_node(user.user_id, attrs)
-    return UserResponse(id=user.user_id, name=user.name, email=user.email)
+    return UserResponse(
+        id=user.user_id,
+        name=user.name,
+        email=user.email,
+        schema_version=user.schema_version,
+    )
 
 
 @router.post("/groups", response_model=UserGroupResponse)

--- a/tests/test_users_routes.py
+++ b/tests/test_users_routes.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
+from ume.models.users import SCHEMA_VERSION
 
 
 def _token(client: TestClient) -> str:
@@ -39,10 +40,12 @@ def test_user_group_and_owned_by(client_and_graph) -> None:
     user_id = user_data["id"]
     assert user_data["name"] == "Alice"
     assert user_data["email"] == "alice@example.com"
+    assert user_data["schema_version"] == SCHEMA_VERSION
     attrs = graph.get_node(user_id)
     assert attrs["type"] == "User"
     assert attrs["name"] == "Alice"
     assert attrs["email"] == "alice@example.com"
+    assert attrs["schema_version"] == SCHEMA_VERSION
 
     # Create a user group containing the user
     res = client.post(
@@ -74,5 +77,5 @@ def test_user_group_and_owned_by(client_and_graph) -> None:
     )
     assert res.status_code == 200
     edges = graph.get_all_edges()
-    assert ("doc1", user_id, "OWNED_BY", {"permission_level": "public"}) in edges
-    assert ("doc1", group_id, "OWNED_BY", {"permission_level": "public"}) in edges
+    assert ("doc1", user_id, "OWNED_BY", {"permission_level": "editor"}) in edges
+    assert ("doc1", group_id, "OWNED_BY", {"permission_level": "editor"}) in edges


### PR DESCRIPTION
## Summary
- bump `User` schema version to 3.0.0
- expose `schema_version` on user route responses
- update user route tests for new schema version and edge defaults

## Testing
- `pre-commit run --files src/ume/models/users.py src/ume/users_routes.py tests/test_users_routes.py`
- `pytest tests/test_users_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_68a3301c12948326938a40ec6eb76c21