### PR TITLE
Use enums for calendar event status and visibility

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -9,7 +9,11 @@ from pydantic import BaseModel
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
-from .models import create_calendar_event
+from .models import (
+    CalendarEventStatus,
+    CalendarEventVisibility,
+    create_calendar_event,
+)
 
 router = APIRouter(prefix="/v1/calendar")
 
@@ -21,9 +25,9 @@ class CalendarEventCreateRequest(BaseModel):
     description: str | None = None
     is_all_day: bool = False
     location: str | None = None
-    status: str | None = None
+    status: CalendarEventStatus | None = None
     rrule: str | None = None
-    visibility: str | None = None
+    visibility: CalendarEventVisibility | None = None
     user_id: str
     group_id: str | None = None
     invitee_ids: List[str] | None = None
@@ -38,9 +42,9 @@ class CalendarEventResponse(BaseModel):
     description: str | None = None
     is_all_day: bool
     location: str | None = None
-    status: str | None = None
+    status: CalendarEventStatus | None = None
     rrule: str | None = None
-    visibility: str | None = None
+    visibility: CalendarEventVisibility | None = None
 
 
 @router.post("/events", response_model=CalendarEventResponse)
@@ -68,9 +72,9 @@ def create_event(
         "description": event.description,
         "is_all_day": event.is_all_day,
         "location": event.location,
-        "status": event.status,
+        "status": event.status.value if event.status else None,
         "rrule": event.rrule,
-        "visibility": event.visibility,
+        "visibility": event.visibility.value if event.visibility else None,
     }
     if not graph.node_exists(req.user_id):
         graph.add_node(req.user_id, {"type": "User"})

--- a/src/ume/models/__init__.py
+++ b/src/ume/models/__init__.py
@@ -1,7 +1,12 @@
 """Dataclass models representing various graph node types."""
 
 from .users import User, create_user
-from .calendar import CalendarEvent, create_calendar_event
+from .calendar import (
+    CalendarEvent,
+    CalendarEventStatus,
+    CalendarEventVisibility,
+    create_calendar_event,
+)
 from .calendar_layer import CalendarLayer, create_calendar_layer
 from .decision_analysis import DecisionAnalysis, create_decision_analysis
 from .decisions import Decision, create_decision
@@ -15,6 +20,8 @@ __all__ = [
     "User",
     "create_user",
     "CalendarEvent",
+    "CalendarEventStatus",
+    "CalendarEventVisibility",
     "create_calendar_event",
     "CalendarLayer",
     "create_calendar_layer",

--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -4,9 +4,26 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from enum import Enum
 import uuid
 
 SCHEMA_VERSION = "3.0.0"
+
+
+@dataclass
+class CalendarEventStatus(str, Enum):
+    """Possible participation statuses for a calendar event."""
+
+    TENTATIVE = "tentative"
+    CONFIRMED = "confirmed"
+    CANCELLED = "cancelled"
+
+
+class CalendarEventVisibility(str, Enum):
+    """Visibility levels for a calendar event."""
+
+    PUBLIC = "public"
+    PRIVATE = "private"
 
 
 @dataclass
@@ -20,9 +37,9 @@ class CalendarEvent:
     description: str | None = None
     is_all_day: bool = False
     location: str | None = None
-    status: str | None = None
+    status: CalendarEventStatus | None = None
     rrule: str | None = None
-    visibility: str | None = None
+    visibility: CalendarEventVisibility | None = None
     schema_version: str = SCHEMA_VERSION
 
 
@@ -35,9 +52,9 @@ def create_calendar_event(
     event_id: str | None = None,
     is_all_day: bool = False,
     location: str | None = None,
-    status: str | None = None,
+    status: CalendarEventStatus | None = None,
     rrule: str | None = None,
-    visibility: str | None = None,
+    visibility: CalendarEventVisibility | None = None,
 ) -> CalendarEvent:
     """Factory helper to build :class:`CalendarEvent` instances."""
 

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -7,6 +7,7 @@ from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
 from ume.models.decision_analysis import SCHEMA_VERSION
+from ume.models import CalendarEventStatus, CalendarEventVisibility
 
 
 def _token(client: TestClient) -> str:
@@ -55,9 +56,9 @@ def test_calendar_event_permissions(client_and_graph) -> None:
             "description": "Discuss project",
             "is_all_day": True,
             "location": "Conference Room",
-            "status": "confirmed",
+            "status": CalendarEventStatus.CONFIRMED.value,
             "rrule": "FREQ=DAILY",
-            "visibility": "public",
+            "visibility": CalendarEventVisibility.PUBLIC.value,
             "user_id": "user1",
             "invitee_ids": ["user2"],
         },
@@ -74,9 +75,9 @@ def test_calendar_event_permissions(client_and_graph) -> None:
         "description": "Discuss project",
         "is_all_day": True,
         "location": "Conference Room",
-        "status": "confirmed",
+        "status": CalendarEventStatus.CONFIRMED.value,
         "rrule": "FREQ=DAILY",
-        "visibility": "public",
+        "visibility": CalendarEventVisibility.PUBLIC.value,
     }
 
     # Owner sees the event with all properties
@@ -113,9 +114,9 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert attrs["description"] == "Discuss project"
     assert attrs["is_all_day"] is True
     assert attrs["location"] == "Conference Room"
-    assert attrs["status"] == "confirmed"
+    assert attrs["status"] == CalendarEventStatus.CONFIRMED.value
     assert attrs["rrule"] == "FREQ=DAILY"
-    assert attrs["visibility"] == "public"
+    assert attrs["visibility"] == CalendarEventVisibility.PUBLIC.value
 
     edges = graph.get_all_edges()
     assert any(


### PR DESCRIPTION
## Summary
- define CalendarEventStatus and CalendarEventVisibility enums
- enforce enums for calendar event models and routes with proper validation
- update tests to reference enumerated status and visibility values

## Testing
- `pre-commit run --files src/ume/models/calendar.py src/ume/models/__init__.py src/ume/calendar_routes.py tests/test_calendar_decision_api.py`
- `pytest tests/test_models_calendar_decision.py tests/test_calendar_decision_api.py::test_calendar_event_permissions tests/test_calendar_decision_api.py::test_calendar_event_group_permissions tests/test_calendar_decision_api.py::test_calendar_event_group_and_layer_filter tests/test_calendar_decision_api.py::test_calendar_event_invite_requires_editor tests/test_calendar_decision_api.py::test_calendar_event_missing_invitee_created tests/test_calendar_decision_api.py::test_calendar_event_group_share_requires_editor tests/test_calendar_decision_api.py::test_calendar_event_unauthorized_access -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3301cc25883269c1d5116b76e37a0