### PR TITLE
Add base-62 pipe-based RPN calculator

### DIFF
--- a/src/ume/pipe_calculator.py
+++ b/src/ume/pipe_calculator.py
@@ -1,0 +1,98 @@
+"""A simple pipe-based RPN calculator with base-62 numbers.
+
+The calculator reads tokens from standard input separated by whitespace and
+performs stack-based evaluation. Numbers are interpreted as base-62 using the
+character set ``0-9A-Za-z``. Arithmetic operators ``+``, ``-``, ``*`` and ``/``
+operate on the top two stack values. ``dup`` duplicates the top stack value.
+
+Custom functions can be defined using the ``fn`` keyword::
+
+    fn inc 1 + ; 3 inc
+
+which pushes ``4`` onto the stack.
+
+The resulting stack is printed as base-62 numbers separated by spaces.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+DIGITS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+
+def b62_to_int(value: str) -> int:
+    """Convert a base-62 encoded string to an integer."""
+    total = 0
+    for char in value:
+        total = total * 62 + DIGITS.index(char)
+    return total
+
+
+def int_to_b62(value: int) -> str:
+    """Convert an integer to a base-62 encoded string."""
+    if value == 0:
+        return "0"
+    digits: List[str] = []
+    n = value
+    while n > 0:
+        n, rem = divmod(n, 62)
+        digits.append(DIGITS[rem])
+    return "".join(reversed(digits))
+
+
+def evaluate(tokens: Iterable[str]) -> List[int]:
+    """Evaluate a sequence of tokens and return the resulting stack."""
+    stack: List[int] = []
+    functions: Dict[str, List[str]] = {}
+    tokens = list(tokens)
+    i = 0
+    while i < len(tokens):
+        token = tokens[i]
+        if token == "fn":
+            if i + 2 >= len(tokens):
+                raise ValueError("Malformed function definition")
+            name = tokens[i + 1]
+            body: List[str] = []
+            j = i + 2
+            while j < len(tokens) and tokens[j] != ";":
+                body.append(tokens[j])
+                j += 1
+            if j == len(tokens):
+                raise ValueError("Function definition missing terminator ';'")
+            functions[name] = body
+            i = j + 1
+            continue
+        if token in functions:
+            # insert function body into token stream after current position
+            tokens[i:i + 1] = functions[token]
+            continue
+        if token in {"+", "-", "*", "/"}:
+            b = stack.pop()
+            a = stack.pop()
+            if token == "+":
+                stack.append(a + b)
+            elif token == "-":
+                stack.append(a - b)
+            elif token == "*":
+                stack.append(a * b)
+            else:
+                stack.append(a // b)
+        elif token == "dup":
+            stack.append(stack[-1])
+        else:
+            stack.append(b62_to_int(token))
+        i += 1
+    return stack
+
+
+def main() -> None:
+    import sys
+
+    tokens = sys.stdin.read().split()
+    stack = evaluate(tokens)
+    print(" ".join(int_to_b62(n) for n in stack))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_pipe_calculator.py
+++ b/tests/test_pipe_calculator.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from ume.pipe_calculator import b62_to_int, int_to_b62, evaluate
+
+
+def run_calc(expr: str) -> str:
+    script = Path(__file__).resolve().parents[1] / "src" / "ume" / "pipe_calculator.py"
+    result = subprocess.run(
+        [sys.executable, str(script)],
+        input=expr.encode(),
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout.decode().strip()
+
+
+def test_base62_conversion() -> None:
+    value = "Az"
+    assert int_to_b62(b62_to_int(value)) == value
+
+
+def test_addition() -> None:
+    assert evaluate(["1", "1", "+"]) == [2]
+
+
+def test_function_definition() -> None:
+    tokens = "fn inc 1 + ; 3 inc".split()
+    assert evaluate(tokens) == [4]
+
+
+def test_cli_usage() -> None:
+    output = run_calc("fn inc 1 + ; 3 inc")
+    assert output == "4"


### PR DESCRIPTION
## Summary
- implement pipe-based RPN calculator supporting base-62 numbers and simple functions
- add unit tests for base-62 conversion, evaluation, and CLI usage

## Testing
- `ruff check src/ume/pipe_calculator.py tests/test_pipe_calculator.py`
- `pytest tests/test_pipe_calculator.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a336644e4c83269ebd1585948ad7dc