### PR TITLE
Persist group schema version and enforce owned_by permissions

### DIFF
--- a/src/ume/users_routes.py
+++ b/src/ume/users_routes.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .models import create_user, create_user_group
+from .permissions_adapter import PermissionsGraphAdapter
 
 router = APIRouter(prefix="/v1")
 
@@ -33,6 +34,7 @@ class UserGroupResponse(BaseModel):
     id: str
     name: str
     members: List[str]
+    schema_version: str
 
 
 class OwnedByRequest(BaseModel):
@@ -77,9 +79,15 @@ def create_user_group_node(
         "group_id": group.group_id,
         "name": group.name,
         "members": group.members,
+        "schema_version": group.schema_version,
     }
     graph.add_node(group.group_id, attrs)
-    return UserGroupResponse(id=group.group_id, name=group.name, members=group.members)
+    return UserGroupResponse(
+        id=group.group_id,
+        name=group.name,
+        members=group.members,
+        schema_version=group.schema_version,
+    )
 
 
 @router.post("/owned_by")
@@ -88,7 +96,12 @@ def create_owned_by_edge(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> dict[str, str]:
-    graph.add_edge(
+    owner_attrs = graph.get_node(req.owner_id) or {}
+    if owner_attrs.get("type") == "UserGroup":
+        perm_graph = PermissionsGraphAdapter(graph, group_id=req.owner_id)
+    else:
+        perm_graph = PermissionsGraphAdapter(graph, user_id=req.owner_id)
+    perm_graph.add_edge(
         req.node_id,
         req.owner_id,
         "OWNED_BY",

--- a/tests/test_users_routes.py
+++ b/tests/test_users_routes.py
@@ -4,7 +4,8 @@ from fastapi.testclient import TestClient
 from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
-from ume.models.users import SCHEMA_VERSION
+from ume.models.users import SCHEMA_VERSION as USER_SCHEMA_VERSION
+from ume.models.user_group import SCHEMA_VERSION as GROUP_SCHEMA_VERSION
 
 
 def _token(client: TestClient) -> str:
@@ -40,12 +41,12 @@ def test_user_group_and_owned_by(client_and_graph) -> None:
     user_id = user_data["id"]
     assert user_data["name"] == "Alice"
     assert user_data["email"] == "alice@example.com"
-    assert user_data["schema_version"] == SCHEMA_VERSION
+    assert user_data["schema_version"] == USER_SCHEMA_VERSION
     attrs = graph.get_node(user_id)
     assert attrs["type"] == "User"
     assert attrs["name"] == "Alice"
     assert attrs["email"] == "alice@example.com"
-    assert attrs["schema_version"] == SCHEMA_VERSION
+    assert attrs["schema_version"] == USER_SCHEMA_VERSION
 
     # Create a user group containing the user
     res = client.post(
@@ -57,10 +58,12 @@ def test_user_group_and_owned_by(client_and_graph) -> None:
     group_data = res.json()
     group_id = group_data["id"]
     assert group_data["members"] == [user_id]
+    assert group_data["schema_version"] == GROUP_SCHEMA_VERSION
     attrs = graph.get_node(group_id)
     assert attrs["type"] == "UserGroup"
     assert attrs["name"] == "Team"
     assert attrs["members"] == [user_id]
+    assert attrs["schema_version"] == GROUP_SCHEMA_VERSION
 
     # Prepare a resource node and create OWNED_BY edges
     graph.add_node("doc1", {"type": "Document"})
@@ -69,13 +72,23 @@ def test_user_group_and_owned_by(client_and_graph) -> None:
         json={"node_id": "doc1", "owner_id": user_id},
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert res.status_code == 200
+    assert res.status_code == 403
     res = client.post(
         "/v1/owned_by",
         json={"node_id": "doc1", "owner_id": group_id},
         headers={"Authorization": f"Bearer {token}"},
     )
-    assert res.status_code == 200
+    assert res.status_code == 403
     edges = graph.get_all_edges()
-    assert ("doc1", user_id, "OWNED_BY", {"permission_level": "editor"}) in edges
-    assert ("doc1", group_id, "OWNED_BY", {"permission_level": "editor"}) in edges
+    assert (
+        "doc1",
+        user_id,
+        "OWNED_BY",
+        {"permission_level": "editor"},
+    ) not in edges
+    assert (
+        "doc1",
+        group_id,
+        "OWNED_BY",
+        {"permission_level": "editor"},
+    ) not in edges


### PR DESCRIPTION
## Summary
- store `schema_version` on user group nodes and expose it in API responses
- enforce permission checks when creating `OWNED_BY` edges by using `PermissionsGraphAdapter`
- test user and group responses now include schema version and verify permission errors on ownership

## Testing
- `ruff check src/ume/users_routes.py tests/test_users_routes.py`
- `pytest tests/test_users_routes.py::test_user_group_and_owned_by -q`

------
https://chatgpt.com/codex/tasks/task_e_68a71f1b1458832688f9a7e186b66ed4