### PR TITLE
Expose action schema version in decision API

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -50,6 +50,7 @@ def _action_to_dict(action: ProposedAction) -> dict[str, Any]:
         "rank": action.rank,
         "is_optimal": action.is_optimal,
         "outcome_metrics": action.outcome_metrics,
+        "schema_version": action.schema_version,
     }
 
 
@@ -75,10 +76,11 @@ def create_decision(
         "OWNED_BY",
         {"permission_level": "editor"},
     )
+    perm_graph.rebuild_index()
     if req.group_id:
         if not graph.node_exists(req.group_id):
             graph.add_node(req.group_id, {})
-        graph.add_edge(
+        perm_graph.add_edge(
             analysis.analysis_id,
             req.group_id,
             "SHARED_WITH",
@@ -117,6 +119,7 @@ def add_action(
         "OWNED_BY",
         {"permission_level": "editor"},
     )
+    perm_graph.rebuild_index()
     if req.group_id:
         if not graph.node_exists(req.group_id):
             graph.add_node(req.group_id, {})

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -7,6 +7,7 @@ from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
 from ume.models.decision_analysis import SCHEMA_VERSION
+from ume.models.proposed_action import SCHEMA_VERSION as ACTION_SCHEMA_VERSION
 from ume.models import CalendarEventStatus, CalendarEventVisibility
 
 
@@ -402,7 +403,9 @@ def test_decision_flow(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    action_id = res.json()["action_id"]
+    action = res.json()
+    action_id = action["action_id"]
+    assert action["schema_version"] == ACTION_SCHEMA_VERSION
 
     res = client.get(
         f"/v1/decisions/{analysis_id}",
@@ -414,6 +417,7 @@ def test_decision_flow(client_and_graph) -> None:
     assert data["analysis"]["analysis_id"] == analysis_id
     assert data["analysis"]["schema_version"] == SCHEMA_VERSION
     assert [a["action_id"] for a in data["actions"]] == [action_id]
+    assert data["actions"][0]["schema_version"] == ACTION_SCHEMA_VERSION
 
     assert graph.get_node(analysis_id)["query"] == "Choose option"
     assert graph.get_node(action_id)["description"] == "Option A"

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -5,6 +5,7 @@ from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
 from ume.models.decision_analysis import SCHEMA_VERSION
+from ume.models.proposed_action import SCHEMA_VERSION as ACTION_SCHEMA_VERSION
 
 
 def _token(client: TestClient) -> str:
@@ -44,6 +45,7 @@ def test_decision_flow(client_and_graph) -> None:
     assert res.status_code == 200
     action = res.json()
     action_id = action["action_id"]
+    assert action["schema_version"] == ACTION_SCHEMA_VERSION
 
     res = client.get(
         f"/v1/decisions/{analysis_id}",
@@ -56,6 +58,7 @@ def test_decision_flow(client_and_graph) -> None:
     assert data["analysis"]["schema_version"] == SCHEMA_VERSION
     assert len(data["actions"]) == 1
     assert data["actions"][0]["action_id"] == action_id
+    assert data["actions"][0]["schema_version"] == ACTION_SCHEMA_VERSION
 
     assert g.get_node(analysis_id)["query"] == "Choose option"
     assert g.get_node(action_id)["description"] == "Option A"

--- a/yaml.py
+++ b/yaml.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 import json
 from json import JSONDecodeError
-from typing import Any, IO, Union
+import io
+from typing import Any, Union
 
-Data = Union[str, bytes, IO[str], IO[bytes], None]
+Data = Union[str, bytes, io.TextIOBase, io.BufferedIOBase, None]
 
 
 def safe_load(data: Data) -> Any:
@@ -21,8 +22,8 @@ def safe_load(data: Data) -> Any:
     input to mirror :func:`yaml.safe_load`.
     If parsing fails, an empty dict is returned as a permissive fallback.
     """
-    if hasattr(data, "read"):
-        data = data.read()  # type: ignore[assignment]
+    if isinstance(data, (io.TextIOBase, io.BufferedIOBase)):
+        data = data.read()
     if not data:
         return None
     if isinstance(data, bytes):


### PR DESCRIPTION
## Summary
- include `schema_version` in proposed action responses
- route edges via `PermissionsGraphAdapter` and rebuild index after permission edges
- test coverage for action schema version
- fix yaml helper typing for mypy

## Testing
- `pre-commit run --files src/ume/decisions_routes.py tests/test_decisions_routes.py tests/test_calendar_decision_api.py yaml.py`
- `pytest tests/test_decisions_routes.py tests/test_calendar_decision_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68a71f1a1f70832680b286e42e5a7f70