### PR TITLE
Verify group membership for financial accounts

### DIFF
--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -40,9 +40,13 @@ def create_account(
 ) -> FinancialAccountResponse:
     if not graph.node_exists(req.user_id):
         graph.add_node(req.user_id, {})
-    if req.group_id and not graph.node_exists(req.group_id):
-        graph.add_node(req.group_id, {})
-
+    if req.group_id:
+        group_attrs = graph.get_node(req.group_id)
+        if group_attrs is None or group_attrs.get("type") != "UserGroup":
+            raise HTTPException(status_code=404, detail="Group not found")
+        members = cast(list[str], group_attrs.get("members", []))
+        if req.user_id not in members:
+            raise HTTPException(status_code=403, detail="User not in group")
     account = create_financial_account(
         req.account_type,
         req.institution,
@@ -92,6 +96,13 @@ def get_account(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> FinancialAccountResponse:
+    if group_id:
+        group_attrs = graph.get_node(group_id)
+        if group_attrs is None or group_attrs.get("type") != "UserGroup":
+            raise HTTPException(status_code=404, detail="Group not found")
+        members = cast(list[str], group_attrs.get("members", []))
+        if user_id not in members:
+            raise HTTPException(status_code=403, detail="User not in group")
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=user_id, group_id=group_id
     )

--- a/tests/test_financial_account_routes.py
+++ b/tests/test_financial_account_routes.py
@@ -32,9 +32,8 @@ def test_create_and_get_financial_account(client_and_graph) -> None:
     token = _token(client)
 
     graph.add_node("user1", {})
-    graph.add_node("group1", {})
-    graph.add_edge(
-        "group1", "user1", "SHARED_WITH", {"permission_level": "editor"}
+    graph.add_node(
+        "group1", {"type": "UserGroup", "members": ["user1"]}
     )
 
     res = client.post(
@@ -78,7 +77,7 @@ def test_create_and_get_financial_account(client_and_graph) -> None:
 
     get_res = client.get(
         f"/v1/accounts/{account_id}",
-        params={"user_id": "user1"},
+        params={"user_id": "user1", "group_id": "group1"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert get_res.status_code == 200
@@ -110,3 +109,56 @@ def test_create_financial_account_creates_user_node(client_and_graph) -> None:
         "OWNED_BY",
         {"permission_level": "editor", "schema_version": EDGE_VERSION},
     ) in edges
+
+
+def test_create_financial_account_rejects_non_member_group(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+    graph.add_node("group1", {"type": "UserGroup", "members": []})
+
+    res = client.post(
+        "/v1/accounts",
+        json={
+            "account_type": "checking",
+            "institution": "ACME Bank",
+            "balance": 100.0,
+            "currency": "USD",
+            "user_id": "user1",
+            "group_id": "group1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
+
+
+def test_get_financial_account_rejects_non_member_group(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+    graph.add_node("user2", {})
+    graph.add_node("group1", {"type": "UserGroup", "members": ["user1"]})
+
+    res = client.post(
+        "/v1/accounts",
+        json={
+            "account_type": "checking",
+            "institution": "ACME Bank",
+            "balance": 100.0,
+            "currency": "USD",
+            "user_id": "user1",
+            "group_id": "group1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    account_id = res.json()["id"]
+
+    get_res = client.get(
+        f"/v1/accounts/{account_id}",
+        params={"user_id": "user2", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert get_res.status_code == 403


### PR DESCRIPTION
## Summary
- validate that users belong to supplied groups before creating or retrieving financial accounts
- test financial account creation and retrieval with valid and invalid group memberships

## Testing
- `ruff check src/ume/financial_account_routes.py`
- `pytest tests/test_financial_account_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68adad072b508326af9768542871d1ca