### PR TITLE
Validate group membership in decision routes

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -56,12 +56,21 @@ def _action_to_dict(action: ProposedAction) -> dict[str, Any]:
     }
 
 
+def _ensure_group_member(graph: IGraphAdapter, user_id: str, group_id: str) -> None:
+    group = graph.get_node(group_id)
+    members = group.get("members") if isinstance(group, dict) else None
+    if not members or user_id not in members:
+        raise HTTPException(status_code=403, detail="User not in group")
+
+
 @router.post("")
 def create_decision(
     req: DecisionCreateRequest,
     _: str = Depends(deps.get_current_role),
     graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> dict[str, Any]:
+    if req.group_id:
+        _ensure_group_member(graph, req.user_id, req.group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=req.user_id, group_id=req.group_id
     )
@@ -99,6 +108,8 @@ def add_action(
     _: str = Depends(deps.get_current_role),
     graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> dict[str, Any]:
+    if req.group_id:
+        _ensure_group_member(graph, req.user_id, req.group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=req.user_id, group_id=req.group_id
     )
@@ -152,6 +163,8 @@ def get_decision(
     _: str = Depends(deps.get_current_role),
     graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> dict[str, Any]:
+    if group_id:
+        _ensure_group_member(graph, user_id, group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=user_id, group_id=group_id
     )

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -79,3 +79,52 @@ def test_decision_flow(client_and_graph) -> None:
         and e.get("permission_level") == "editor"
         for s, t, lbl, e in edges
     )
+
+
+def test_decision_flow_with_group(client_and_graph) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+    g.add_node("group1", {"members": ["user1"]})
+
+    res = client.post(
+        "/v1/decisions",
+        json={"query": "Choose", "user_id": "user1", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    analysis_id = res.json()["analysis_id"]
+
+    res = client.get(
+        f"/v1/decisions/{analysis_id}",
+        params={"user_id": "user1", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+
+
+def test_group_membership_required(client_and_graph) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+    g.add_node("group2", {"members": ["user2"]})
+
+    res = client.post(
+        "/v1/decisions",
+        json={"query": "X", "user_id": "user2", "group_id": "group2"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    analysis_id = res.json()["analysis_id"]
+
+    res = client.post(
+        "/v1/decisions",
+        json={"query": "Y", "user_id": "user1", "group_id": "group2"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
+
+    res = client.get(
+        f"/v1/decisions/{analysis_id}",
+        params={"user_id": "user1", "group_id": "group2"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- ensure `user_id` is a member of `group_id` before creating decisions, adding actions, or retrieving analyses
- add tests for authorized and unauthorized group scenarios

## Testing
- `ruff check src/ume/decisions_routes.py`
- `pytest tests/test_decisions_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68adad06a8b88326a7fd087d0d429d1c