### PR TITLE
Validate group membership for calendar events and update visibility enum

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -83,8 +83,11 @@ def create_event(
     }
     if not graph.node_exists(req.user_id):
         graph.add_node(req.user_id, {"type": "User"})
-    if req.group_id and not graph.node_exists(req.group_id):
-        graph.add_node(req.group_id, {"type": "UserGroup"})
+    if req.group_id:
+        group_attrs = graph.get_node(req.group_id)
+        members = group_attrs.get("members", []) if group_attrs else []
+        if req.user_id not in members:
+            raise HTTPException(status_code=403, detail="User not in group")
     graph.add_node(event.id, attrs)
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     try:
@@ -158,6 +161,11 @@ def list_events(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> List[CalendarEventResponse]:
+    if group_id is not None:
+        group_attrs = graph.get_node(group_id)
+        members = group_attrs.get("members", []) if group_attrs else []
+        if user_id not in members:
+            raise HTTPException(status_code=403, detail="User not in group")
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=user_id, group_id=group_id
     )
@@ -174,7 +182,7 @@ def list_events(
     events: List[CalendarEventResponse] = []
     for eid in event_ids:
         attrs = graph.get_node(eid)
-        if not attrs:
+        if not attrs or attrs.get("type") != "CalendarEvent":
             continue
         start_ts = attrs.get("start_time")
         if since is not None and (start_ts is None or start_ts < since):

--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -22,7 +22,7 @@ class CalendarEventStatus(str, Enum):
 class CalendarEventVisibility(str, Enum):
     """Visibility levels for a calendar event."""
 
-    PUBLIC = "public"
+    PUBLIC_TO_GROUP = "public_to_group"
     PRIVATE = "private"
 
 

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -59,7 +59,7 @@ def test_calendar_event_permissions(client_and_graph) -> None:
             "location": "Conference Room",
             "status": CalendarEventStatus.CONFIRMED.value,
             "rrule": "FREQ=DAILY",
-            "visibility": CalendarEventVisibility.PUBLIC.value,
+            "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
             "user_id": "user1",
             "invitee_ids": ["user2"],
         },
@@ -78,7 +78,7 @@ def test_calendar_event_permissions(client_and_graph) -> None:
         "location": "Conference Room",
         "status": CalendarEventStatus.CONFIRMED.value,
         "rrule": "FREQ=DAILY",
-        "visibility": CalendarEventVisibility.PUBLIC.value,
+        "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
         "schema_version": SCHEMA_VERSION,
     }
 
@@ -118,7 +118,7 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert attrs["location"] == "Conference Room"
     assert attrs["status"] == CalendarEventStatus.CONFIRMED.value
     assert attrs["rrule"] == "FREQ=DAILY"
-    assert attrs["visibility"] == CalendarEventVisibility.PUBLIC.value
+    assert attrs["visibility"] == CalendarEventVisibility.PUBLIC_TO_GROUP.value
     assert attrs["schema_version"] == SCHEMA_VERSION
 
     edges = graph.get_all_edges()
@@ -138,7 +138,7 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     # Pre-create user and group nodes
     graph.add_node("user1", {})
     graph.add_node("user2", {})
-    graph.add_node("group1", {})
+    graph.add_node("group1", {"members": ["user1", "user2"]})
     graph.add_edge(
         "group1", "user1", "SHARED_WITH", {"permission_level": "editor"}
     )
@@ -202,7 +202,7 @@ def test_calendar_event_group_and_layer_filter(client_and_graph) -> None:
     # Prepare users, group, and ensure the user has control over the group
     graph.add_node("user1", {})
     graph.add_node("user2", {})
-    graph.add_node("group1", {})
+    graph.add_node("group1", {"members": ["user1", "user2"]})
     graph.add_edge(
         "group1", "user1", "OWNED_BY", {"permission_level": "editor"}
     )
@@ -334,7 +334,7 @@ def test_calendar_event_group_share_requires_editor(client_and_graph) -> None:
     token = _token(client)
 
     graph.add_node("user1", {})
-    graph.add_node("group1", {})
+    graph.add_node("group1", {"members": ["user1"]})
 
     start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
 


### PR DESCRIPTION
## Summary
- require users to belong to a group before sharing or querying calendar events by that group
- scope calendar event listings to nodes of type `CalendarEvent`
- rename `CalendarEventVisibility.PUBLIC` to `PUBLIC_TO_GROUP` and update tests

## Testing
- `ruff check src/ume/calendar_routes.py src/ume/models/calendar.py`
- `pytest tests/test_calendar_decision_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68adad0612cc8326b81101bd1261ad67