### PR TITLE
test: cover permission edge cases

### DIFF
--- a/tests/test_permissions_routes.py
+++ b/tests/test_permissions_routes.py
@@ -1,8 +1,8 @@
 import pytest
 from fastapi.testclient import TestClient
 
+from ume import AccessDeniedError, MockGraph, PermissionsGraphAdapter
 from ume.api import app, configure_graph
-from ume import MockGraph
 from ume.config import settings
 
 
@@ -35,12 +35,20 @@ def _seed_graph(graph: MockGraph) -> None:
     graph.add_edge("u_viewer", "user1", "OWNED_BY", {"permission_level": "viewer"})
     graph.add_node("u_editor", {})
     graph.add_edge("u_editor", "user1", "OWNED_BY", {"permission_level": "editor"})
+    graph.add_node("u_no_perm", {})
+    graph.add_edge("u_no_perm", "user1", "OWNED_BY", {})
+    graph.add_node("u_invalid", {})
+    graph.add_edge("u_invalid", "user1", "OWNED_BY", {"permission_level": "invalid"})
 
     # Group-only nodes
     graph.add_node("g_viewer", {})
     graph.add_edge("g_viewer", "group1", "SHARED_WITH", {"permission_level": "viewer"})
     graph.add_node("g_editor", {})
     graph.add_edge("g_editor", "group1", "SHARED_WITH", {"permission_level": "editor"})
+    graph.add_node("g_no_perm", {})
+    graph.add_edge("g_no_perm", "group1", "SHARED_WITH", {})
+    graph.add_node("g_invalid", {})
+    graph.add_edge("g_invalid", "group1", "SHARED_WITH", {"permission_level": "invalid"})
 
     # Mixed node accessible to both
     graph.add_node("mixed", {})
@@ -78,3 +86,48 @@ def test_get_nodes_shared_with_filters_viewer_editor(client_and_graph):
     )
     assert res.status_code == 200
     assert set(res.json()["nodes"]) == {"g_viewer", "g_editor", "mixed"}
+
+
+def test_get_nodes_by_user_excludes_nodes_without_permission_level(client_and_graph):
+    client, graph = client_and_graph
+    _seed_graph(graph)
+    token = _token(client)
+
+    res = client.get(
+        "/v1/nodes",
+        params={"user_id": "user1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    nodes = set(res.json()["nodes"])
+    assert "u_no_perm" not in nodes
+    assert "u_invalid" not in nodes
+
+
+def test_get_nodes_shared_with_excludes_nodes_without_permission_level(
+    client_and_graph,
+) -> None:
+    client, graph = client_and_graph
+    _seed_graph(graph)
+    token = _token(client)
+
+    res = client.get(
+        "/v1/nodes/shared",
+        params={"group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    nodes = set(res.json()["nodes"])
+    assert "g_no_perm" not in nodes
+    assert "g_invalid" not in nodes
+
+
+def test_editor_vs_viewer_permissions(client_and_graph) -> None:
+    _, graph = client_and_graph
+    _seed_graph(graph)
+    perm_graph = PermissionsGraphAdapter(graph, user_id="user1")
+
+    with pytest.raises(AccessDeniedError):
+        perm_graph.update_node("u_viewer", {"attr": 1})
+
+    perm_graph.update_node("u_editor", {"attr": 2})


### PR DESCRIPTION
## Summary
- expand graph seed with invalid permission-level edges
- add tests ensuring nodes without valid permission levels are excluded
- verify editor permissions are required for node updates

## Testing
- `ruff check tests/test_permissions_routes.py`
- `pytest tests/test_permissions_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68af02abbf188326a970f8241784d605