### PR TITLE
test: check schema version persistence

### DIFF
--- a/src/ume/schema_manager.py
+++ b/src/ume/schema_manager.py
@@ -96,21 +96,19 @@ class GraphSchemaManager:
                 for src, tgt, label, attrs in list(graph.get_all_edges()):
                     if label == "NEW_LABEL":
                         graph.delete_edge(src, tgt, label)
-                        graph.add_edge(src, tgt, "TAGGED_AS")
+                        new_attrs = dict(attrs) if isinstance(attrs, dict) else {}
+                        graph.add_edge(src, tgt, "TAGGED_AS", new_attrs)
                     elif label == "HAS_PERMISSION":
                         graph.delete_edge(src, tgt, label)
-                        perm_level = None
-                        if isinstance(attrs, dict):
-                            perm_level = attrs.get("permission_level")
-                        else:
-                            perm_level = attrs
-                        new_label = "OWNED_BY" if perm_level == "editor" else "SHARED_WITH"
-                        graph.add_edge(
-                            src,
-                            tgt,
-                            new_label,
-                            {"permission_level": "public"},
+                        attr_dict = dict(attrs) if isinstance(attrs, dict) else {}
+                        perm_level = (
+                            attr_dict.get("permission_level")
+                            if isinstance(attrs, dict)
+                            else attrs
                         )
+                        new_label = "OWNED_BY" if perm_level == "editor" else "SHARED_WITH"
+                        attr_dict["permission_level"] = "public"
+                        graph.add_edge(src, tgt, new_label, attr_dict)
                         if graph.node_exists(tgt):
                             node_attrs = graph.get_node(tgt) or {}
                             node_attrs.setdefault("type", "User")
@@ -126,15 +124,24 @@ class GraphSchemaManager:
                     }:
                         graph.delete_edge(src, tgt, label)
 
-            # Ensure all edges carry explicit version metadata
+            # Ensure all edges carry explicit version and permission metadata
             for src, tgt, label, attrs in list(graph.get_all_edges()):
                 edge_def = new_schema.edge_labels.get(label)
                 if edge_def is None:
                     continue
-                attr_dict = dict(attrs or {})
+                attr_dict = dict(attrs) if isinstance(attrs, dict) else {}
+                needs_update = False
+                if (
+                    edge_def.permission_level is not None
+                    and attr_dict.get("permission_level") != edge_def.permission_level
+                ):
+                    attr_dict["permission_level"] = edge_def.permission_level
+                    needs_update = True
                 if attr_dict.get("version") != edge_def.version:
-                    graph.delete_edge(src, tgt, label)
                     attr_dict["version"] = edge_def.version
+                    needs_update = True
+                if needs_update:
+                    graph.delete_edge(src, tgt, label)
                     graph.add_edge(src, tgt, label, attr_dict)
 
         return new_schema

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -203,3 +203,44 @@ def test_upgrade_permission_nodes_multi_user(graph: PersistentGraph) -> None:
         "type": "User",
         "permission_level": "public",
     }
+
+
+def test_upgrade_preserves_schema_version(graph: PersistentGraph) -> None:
+    graph.add_node("a", {"schema_version": "2.0.0"})
+    graph.add_node("b", {"schema_version": "2.0.0"})
+    graph.add_edge(
+        "a", "b", "NEW_LABEL", {"schema_version": "2.0.0"}
+    )
+
+    manager = GraphSchemaManager()
+    manager.upgrade_schema("2.0.0", "3.0.0", graph)
+
+    assert graph.get_node("a")["schema_version"] == "2.0.0"
+    edges = graph.get_all_edges()
+    assert (
+        "a",
+        "b",
+        "TAGGED_AS",
+        {
+            "permission_level": "public",
+            "schema_version": "2.0.0",
+            "version": "3.0.0",
+        },
+    ) in edges
+
+
+def test_upgrade_adds_version_when_missing(graph: PersistentGraph) -> None:
+    graph.add_node("a", {})
+    graph.add_node("b", {})
+    graph.add_edge("a", "b", "TAGGED_AS")
+
+    manager = GraphSchemaManager()
+    manager.upgrade_schema("2.0.0", "3.0.0", graph)
+
+    edges = graph.get_all_edges()
+    assert (
+        "a",
+        "b",
+        "TAGGED_AS",
+        {"permission_level": "public", "version": "3.0.0"},
+    ) in edges


### PR DESCRIPTION
## Summary
- add tests asserting `schema_version` is preserved on nodes and edges after schema upgrades
- test upgrade path for edges missing version metadata
- preserve existing edge attributes when upgrading to v3
- default missing edge permission levels and version metadata during upgrades

## Testing
- `ruff check src/ume/schema_manager.py tests/test_schema_manager.py`
- `pytest tests/test_schema_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68af02ac65448326a9a31efc9bee08f1