### PR TITLE
test: enforce group membership for user actions

### DIFF
--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -195,6 +195,42 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     )
 
 
+def test_calendar_event_group_membership_required(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    # Create users and a group with a single member
+    graph.add_node("user1", {})
+    graph.add_node("user2", {})
+    graph.add_node("group1", {"members": ["user1"]})
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+
+    # Non-member cannot create an event for the group
+    res = client.post(
+        "/v1/calendar/events",
+        json={"title": "Meet", "start_time": start, "user_id": "user2", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
+
+    # Member creates an event
+    res = client.post(
+        "/v1/calendar/events",
+        json={"title": "Meet", "start_time": start, "user_id": "user1", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+
+    # Non-member cannot list events scoped to the group
+    res = client.get(
+        "/v1/calendar/events",
+        params={"user_id": "user2", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
+
+
 def test_calendar_event_group_and_layer_filter(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -128,3 +128,24 @@ def test_group_membership_required(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 403
+
+
+def test_add_action_requires_group_membership(client_and_graph) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+    g.add_node("group1", {"members": ["user2"]})
+
+    res = client.post(
+        "/v1/decisions",
+        json={"query": "Q", "user_id": "user2", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    analysis_id = res.json()["analysis_id"]
+
+    res = client.post(
+        f"/v1/decisions/{analysis_id}/actions",
+        json={"description": "Act", "user_id": "user1", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403

--- a/tests/test_financial_account_routes.py
+++ b/tests/test_financial_account_routes.py
@@ -162,3 +162,27 @@ def test_get_financial_account_rejects_non_member_group(client_and_graph) -> Non
         headers={"Authorization": f"Bearer {token}"},
     )
     assert get_res.status_code == 403
+
+
+def test_create_financial_account_rejects_user_not_in_group_members(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+    graph.add_node(
+        "group1", {"type": "UserGroup", "members": ["user2"]}
+    )
+
+    res = client.post(
+        "/v1/accounts",
+        json={
+            "account_type": "checking",
+            "institution": "ACME Bank",
+            "balance": 100.0,
+            "currency": "USD",
+            "user_id": "user1",
+            "group_id": "group1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- add calendar API tests for group membership enforcement
- cover group membership when adding decision actions
- verify financial account creation fails for non-group members

## Testing
- `ruff check tests/test_calendar_decision_api.py tests/test_decisions_routes.py tests/test_financial_account_routes.py`
- `pytest tests/test_calendar_decision_api.py::test_calendar_event_group_membership_required -q`
- `pytest tests/test_decisions_routes.py::test_add_action_requires_group_membership -q`
- `pytest tests/test_financial_account_routes.py::test_create_financial_account_rejects_user_not_in_group_members -q`


------
https://chatgpt.com/codex/tasks/task_e_68af1204883c83268b2d46fd77cac590