### PR TITLE
docs: clarify group visibility

### DIFF
--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -35,7 +35,7 @@ wrapped automatically.
 
 ### Example Use Cases
 
-*Running the API with analytics permissions*
+#### Running the API with analytics permissions
 
 ```bash
 UME_API_ROLE=AnalyticsAgent uvicorn ume.api:app
@@ -44,7 +44,7 @@ UME_API_ROLE=AnalyticsAgent uvicorn ume.api:app
 Requests to `/analytics/*` will succeed. If the role is anything else, the API
 responds with HTTP 403.
 
-*Editing a user profile via the CLI*
+#### Editing a user profile via the CLI
 
 ```bash
 UME_ROLE=UserService ume new_node UserProfile.123 '{}'
@@ -62,6 +62,25 @@ introduced in schema version `3.0.0`.
 - Resources link to owners via `OWNED_BY` edges.
 - `SHARED_WITH` edges grant group access and may include a `permission_level`
   property such as `viewer` or `editor`.
+
+### Group Membership Checks
+
+The service now verifies that callers belong to any groups referenced by
+`SHARED_WITH` edges. Membership is taken from the group's `members` list and a
+request from a non-member returns `HTTP 403` even if a share exists. This
+prevents users from escalating privileges by guessing group identifiers.
+
+### `PUBLIC_TO_GROUP` Visibility
+
+Some resources include a `visibility` attribute. When a resource is owned by a
+`UserGroup` and the `visibility` is set to `PUBLIC_TO_GROUP`, all members of that
+group automatically gain viewer permissions. Editing still requires a
+`SHARED_WITH` edge specifying `permission_level: editor`.
+
+For example, a calendar event owned by `Group.eng` with
+`PUBLIC_TO_GROUP` visibility allows every member to read it. If `User.u1` has an
+additional `SHARED_WITH` edge granting `editor` access, they can update or delete
+the event while other members remain read-only viewers.
 
 ### Sample Requests
 
@@ -118,7 +137,8 @@ files and let UME create new, encrypted ones on startup.
 
 ## Sample Rego Rules
 
-The following snippet demonstrates how dossier permissions could be expressed in Rego.
+The following snippet demonstrates how dossier permissions could be expressed
+in Rego.
 
 ```rego
 package ume.dossier
@@ -138,7 +158,8 @@ can_read_projects {
     input.role == "Viewer"
 }
 
-# Allow reading reflections if that section is shareable or the caller has a valid role
+# Allow reading reflections if that section is shareable
+# or the caller has a valid role
 default can_read_reflections = false
 
 can_read_reflections {

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -7,62 +7,78 @@ graph representation.
 ## Node Types
 
 ### UserMemory
-Represents memory items about a specific user.  A single user may have many
+
+Represents memory items about a specific user. A single user may have many
 memory nodes capturing different experiences or facts.
 
 Properties:
+
 - `user_id` *(string, required)*: Unique identifier of the user.
-- `data` *(object)*: Free form attributes describing the memory.  Example:
+- `data` *(object)*: Free form attributes describing the memory. Example:
   `{"text": "Alice ordered coffee"}`.
 
 ### AgentIntent
+
 Captures an intention produced by an agent.
 
 Properties:
+
 - `intent_id` *(string, required)*: Unique identifier for the intent.
 - `description` *(string)*: Short human friendly description of the action.
   Example: `"schedule meeting"`.
 
 ### PerceptualContext
+
 Stores sensory observations that provide context for reasoning.
 
 Properties:
+
 - `context_id` *(string, required)*: Unique identifier for the context entry.
 - `modality` *(string)*: E.g. `vision`, `audio`.
 - `payload` *(object)*: Raw or processed perceptual data.
   Example: `{"image": "base64..."}`.
 
 ### NewType
+
 Represents an additional concept introduced in schema version `2.0.0`.
 
 Properties:
+
 - `type_id` *(string, required)*: Unique identifier for the new entity.
 - Other attributes depend on the producer.
 
 ### User
+
 Represents an individual actor within UME. These nodes participate in
 permission edges that grant or restrict access to resources.
 
 Properties:
+
 - `user_id` *(string, required)*: Stable identifier for the user.
 - `name` *(string)*: Display name.
 - `email` *(string)*: Contact address.
 
 ### UserGroup
+
 Collects users for shared permissions and collaboration. Groups can be
 linked to resources to extend access to multiple users at once.
 
 Properties:
+
 - `group_id` *(string, required)*: Stable identifier for the group.
 - `name` *(string)*: Human friendly label.
 - `members` *(array)*: List of `user_id` values belonging to the group.
 
 ### Resource
+
 Generic node representing a shareable asset such as a document or calendar
 event.
 
 Properties:
+
 - `id` *(string, required)*: Stable identifier for the resource.
+- `visibility` *(string)*: `private` or `public_to_group`. When
+  `public_to_group`, all members of the owning group can view the resource.
 - Additional attributes depend on the resource type.
 
 ## Edge Labels
@@ -86,6 +102,33 @@ controls access to resources. Supported values:
 - `viewer` – read‑only access.
 - `editor` – read and modify access.
 - `public` – accessible without explicit ownership or sharing.
+
+### Group Membership Checks
+
+When resolving `SHARED_WITH` edges the graph now verifies that the requesting
+user is listed in the target group's `members` array. A non-member receives an
+access denied error even if the edge grants permissions.
+
+### `PUBLIC_TO_GROUP` Visibility
+
+Resources may include a `visibility` property. Setting it to
+`public_to_group` makes the resource readable by every member of the owning
+`UserGroup`. Editing still requires a `SHARED_WITH` edge with
+`permission_level: editor`.
+
+```json
+{
+  "id": "cal1",
+  "visibility": "public_to_group",
+  "edges": [
+    {"label": "OWNED_BY", "target": "Group.eng"},
+    {"label": "SHARED_WITH", "target": "Group.eng", "permission_level": "editor"}
+  ]
+}
+```
+
+Members of `Group.eng` can view `cal1`. Only those granted `editor` rights may
+modify or delete it; others remain read-only viewers.
 
 ### Permission Queries
 
@@ -135,7 +178,7 @@ vector embeddings consistently.
 
 | Field | Description |
 |-------|-------------|
-| `eventType` | The type of operation, e.g. `CREATE_NODE` or `ENTITY_DISCOVERED`. |
+| `eventType` | Operation type like `CREATE_NODE` or `ENTITY_DISCOVERED`. |
 | `timestamp` | ISO&nbsp;8601 time when the event occurred. |
 | `eventId` | Unique identifier for the event. |
 | `correlationId` | ID linking related events. |
@@ -206,20 +249,27 @@ vector embeddings consistently.
 
 ### Event Flow
 
-```
+```text
 Producer (canonical JSON) --> ume-raw-events --> Privacy Agent --> ume-clean-events
     --> Projection Engine --> Graph Adapter --> Graph Storage & Vector Store
 ```
 
 1. Producers emit events following the canonical schema above.
-2. The Privacy Agent validates and redacts sensitive data before forwarding to `ume-clean-events`.
-3. The projection engine processes sanitized events and updates the graph via the chosen adapter.
-4. `VectorStoreListener` automatically indexes any `embedding` vectors during this step.
+2. The Privacy Agent validates and redacts sensitive data before forwarding
+   to `ume-clean-events`.
+3. The projection engine processes sanitized events and updates the graph
+   via the chosen adapter.
+4. `VectorStoreListener` automatically indexes any `embedding` vectors
+   during this step.
 
-As events pass from ingestion through projection they retain the canonical schema, ensuring
-consistent processing across components.
+As events pass from ingestion through projection they retain the canonical
+schema, ensuring consistent processing across components.
 
-As events pass from the ingestion API through the Privacy Agent and into the projection engine, they retain this schema. The engine applies them to the graph and notifies listeners such as `VectorStoreListener`, which adds any embedded vectors to the configured index automatically.
+As events move from the ingestion API through the Privacy Agent
+and into the projection engine, they keep this schema. The engine
+applies them to the graph and notifies listeners such as
+`VectorStoreListener`, which adds embedded vectors to the configured
+index automatically.
 
 ## Versioning
 
@@ -401,7 +451,7 @@ returned schema object can be used for validating future events.
 
 The ``ume`` tool includes two utilities for working with schema versions:
 
-* ``register_schema <version> <schema_path> <proto_module>`` – load an external
+- ``register_schema <version> <schema_path> <proto_module>`` – load an external
   YAML schema file and associated Protobuf module at runtime.
-* ``migrate_schema <old_version> <new_version>`` – apply ``upgrade_schema`` to
+- ``migrate_schema <old_version> <new_version>`` – apply ``upgrade_schema`` to
   the current graph.


### PR DESCRIPTION
## Summary
- document group membership checks and PUBLIC_TO_GROUP visibility
- add examples contrasting viewer and editor permissions
- fix markdownlint warnings in docs

## Testing
- `markdownlint docs/ACCESS_CONTROL.md docs/GRAPH_MODEL.md`


------
https://chatgpt.com/codex/tasks/task_e_68af12054a1c83268ea1f1be58c9a923