### PR TITLE
Validate permission level in add_edge

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -154,6 +154,12 @@ class PermissionsGraphAdapter(IGraphAdapter):
             version = "3.0.0"
         else:
             version = None
+        if attrs and "permission_level" in attrs:
+            perm_level = attrs["permission_level"]
+            if perm_level not in {"viewer", "editor"}:
+                raise AccessDeniedError(
+                    f"Invalid permission_level '{perm_level}'"
+                )
         self._adapter.add_edge(
             source_node_id,
             target_node_id,

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -175,3 +175,21 @@ def test_shared_with_edge_sets_schema_version_and_allows_view_only() -> None:
     assert adapter_u2.get_node("Document.d1") == {"title": "doc1"}
     with pytest.raises(AccessDeniedError):
         adapter_u2.update_node("Document.d1", {"title": "nope"})
+
+
+def test_add_edge_rejects_invalid_permission_level() -> None:
+    g = MockGraph()
+    g.add_node("User.u1", {})
+    g.add_node("User.u2", {})
+    g.add_node("Document.d1", {"title": "doc1"})
+    g._edges["Document.d1"].append(
+        ("User.u1", "OWNED_BY", {"permission_level": "editor"})
+    )
+    adapter = PermissionsGraphAdapter(g, user_id="User.u1")
+    with pytest.raises(AccessDeniedError):
+        adapter.add_edge(
+            "Document.d1",
+            "User.u2",
+            "SHARED_WITH",
+            {"permission_level": "admin"},
+        )


### PR DESCRIPTION
## Summary
- validate `permission_level` in `add_edge` to only allow viewer or editor
- add regression test rejecting invalid permission levels

## Testing
- `pre-commit run --files src/ume/permissions_adapter.py tests/test_permissions_adapter.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6f04bd7c88326925abfcbacf17f73