### PR TITLE
Add shared group membership validator

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import List
 
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
+from .utils import ensure_group_member
 from .models import (
     CalendarEventStatus,
     CalendarEventVisibility,
@@ -100,10 +101,7 @@ def create_event(
     }
     _ensure_user_node(graph, req.user_id)
     if req.group_id:
-        group_attrs = graph.get_node(req.group_id)
-        members = group_attrs.get("members", []) if group_attrs else []
-        if req.user_id not in members:
-            raise HTTPException(status_code=403, detail="User not in group")
+        ensure_group_member(graph, req.user_id, req.group_id)
     graph.add_node(event.id, attrs)
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     try:
@@ -177,10 +175,7 @@ def list_events(
     _: str = Depends(deps.get_current_role),
 ) -> List[CalendarEventResponse]:
     if group_id is not None:
-        group_attrs = graph.get_node(group_id)
-        members = group_attrs.get("members", []) if group_attrs else []
-        if user_id not in members:
-            raise HTTPException(status_code=403, detail="User not in group")
+        ensure_group_member(graph, user_id, group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=user_id, group_id=group_id
     )

--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -9,6 +9,7 @@ from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
+from .utils import ensure_group_member
 from .models import (
     DecisionAnalysis,
     ProposedAction,
@@ -56,13 +57,6 @@ def _action_to_dict(action: ProposedAction) -> dict[str, Any]:
     }
 
 
-def _ensure_group_member(graph: IGraphAdapter, user_id: str, group_id: str) -> None:
-    group = graph.get_node(group_id)
-    members = group.get("members") if isinstance(group, dict) else None
-    if not members or user_id not in members:
-        raise HTTPException(status_code=403, detail="User not in group")
-
-
 @router.post("")
 def create_decision(
     req: DecisionCreateRequest,
@@ -70,7 +64,7 @@ def create_decision(
     graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> dict[str, Any]:
     if req.group_id:
-        _ensure_group_member(graph, req.user_id, req.group_id)
+        ensure_group_member(graph, req.user_id, req.group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=req.user_id, group_id=req.group_id
     )
@@ -109,7 +103,7 @@ def add_action(
     graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> dict[str, Any]:
     if req.group_id:
-        _ensure_group_member(graph, req.user_id, req.group_id)
+        ensure_group_member(graph, req.user_id, req.group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=req.user_id, group_id=req.group_id
     )
@@ -164,7 +158,7 @@ def get_decision(
     graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> dict[str, Any]:
     if group_id:
-        _ensure_group_member(graph, user_id, group_id)
+        ensure_group_member(graph, user_id, group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=user_id, group_id=group_id
     )

--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from typing import cast
 
@@ -8,6 +8,7 @@ from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .models import create_financial_account, create_user
+from .utils import ensure_group_member
 
 EDGE_VERSION = "3.0.0"
 
@@ -53,9 +54,7 @@ def create_account(
         group_attrs = graph.get_node(req.group_id)
         if group_attrs is None or group_attrs.get("type") != "UserGroup":
             raise HTTPException(status_code=404, detail="Group not found")
-        members = cast(list[str], group_attrs.get("members", []))
-        if req.user_id not in members:
-            raise HTTPException(status_code=403, detail="User not in group")
+        ensure_group_member(graph, req.user_id, req.group_id)
     account = create_financial_account(
         req.account_type,
         req.institution,
@@ -109,9 +108,7 @@ def get_account(
         group_attrs = graph.get_node(group_id)
         if group_attrs is None or group_attrs.get("type") != "UserGroup":
             raise HTTPException(status_code=404, detail="Group not found")
-        members = cast(list[str], group_attrs.get("members", []))
-        if user_id not in members:
-            raise HTTPException(status_code=403, detail="User not in group")
+        ensure_group_member(graph, user_id, group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=user_id, group_id=group_id
     )

--- a/src/ume/utils.py
+++ b/src/ume/utils.py
@@ -1,6 +1,10 @@
 from typing import Any, Dict
 import os
 
+from fastapi import HTTPException
+
+from .graph_adapter import IGraphAdapter
+
 
 def ssl_config() -> Dict[str, str]:
     """Return Kafka SSL configuration if cert env vars are set."""
@@ -15,6 +19,14 @@ def ssl_config() -> Dict[str, str]:
             "ssl.key.location": key,
         }
     return {}
+
+
+def ensure_group_member(graph: IGraphAdapter, user_id: str, group_id: str) -> None:
+    """Raise ``HTTPException`` if ``user_id`` is not a member of ``group_id``."""
+    group = graph.get_node(group_id)
+    members = group.get("members", []) if isinstance(group, dict) else []
+    if user_id not in members:
+        raise HTTPException(status_code=403, detail="User not in group")
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `ensure_group_member` helper to centralize group membership checks
- use `ensure_group_member` in calendar, decisions, and financial account routes

## Testing
- `pre-commit run --files src/ume/utils.py src/ume/calendar_routes.py src/ume/decisions_routes.py src/ume/financial_account_routes.py`
- `pytest -q` *(fails: missing optional test dependencies, 43 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b842db9cd48326a0f85f1e0e81cdd9