### PR TITLE
Add calendar layer listing endpoint

### DIFF
--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from . import api_deps as deps
@@ -8,6 +10,7 @@ from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .models import create_calendar_layer
+from .utils import ensure_group_member
 
 EDGE_VERSION = "3.0.0"
 
@@ -78,6 +81,37 @@ def create_layer(
     return CalendarLayerResponse(
         layer_id=layer.layer_id,
         layer_name=layer.layer_name,
-        color=layer.color,
-        schema_version=layer.schema_version,
+       color=layer.color,
+       schema_version=layer.schema_version,
     )
+
+
+@router.get("/layers", response_model=List[CalendarLayerResponse])
+def list_layers(
+    user_id: str = Query(...),
+    group_id: str | None = Query(None),
+    graph: IGraphAdapter = Depends(deps.get_graph),
+    _: str = Depends(deps.get_current_role),
+) -> List[CalendarLayerResponse]:
+    if group_id is not None:
+        ensure_group_member(graph, user_id, group_id)
+    perm_graph = PermissionsGraphAdapter(
+        graph, user_id=user_id, group_id=group_id
+    )
+    layer_ids = set(perm_graph.get_nodes_by_user(user_id))
+    if group_id is not None:
+        layer_ids |= set(perm_graph.get_nodes_shared_with(group_id))
+    layers: List[CalendarLayerResponse] = []
+    for lid in layer_ids:
+        attrs = graph.get_node(lid)
+        if not attrs or attrs.get("type") != "CalendarLayer":
+            continue
+        layers.append(
+            CalendarLayerResponse(
+                layer_id=lid,
+                layer_name=attrs.get("layer_name", ""),
+                color=attrs.get("color", ""),
+                schema_version=attrs.get("schema_version", ""),
+            )
+        )
+    return layers

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -160,3 +160,52 @@ def test_event_with_existing_layer(client_and_graph) -> None:
         s == event_id and t == layer_id and lbl == "TAGGED_AS" for s, t, lbl, _ in edges
 
     )
+
+
+def test_list_layers(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    graph.add_node("user1", {})
+    graph.add_node(
+        "group1", {"members": ["user1"]}
+    )
+    graph.add_edge(
+        "group1", "user1", "OWNED_BY", {"permission_level": "editor"}
+    )
+    res1 = client.post(
+        "/v1/calendar/layers",
+        json={"layer_name": "Work", "color": "blue", "user_id": "user1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    layer1 = res1.json()["layer_id"]
+    res2 = client.post(
+        "/v1/calendar/layers",
+        json={
+            "layer_name": "Team",
+            "color": "red",
+            "user_id": "user1",
+            "group_id": "group1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    layer2 = res2.json()["layer_id"]
+    graph.add_node(
+        "layer3",
+        {
+            "type": "CalendarLayer",
+            "layer_name": "Hidden",
+            "color": "green",
+            "schema_version": SCHEMA_VERSION,
+        },
+    )
+    res = client.get(
+        "/v1/calendar/layers",
+        params={"user_id": "user1", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    data = res.json()
+    ids = {item["layer_id"] for item in data}
+    assert ids == {layer1, layer2}
+    for item in data:
+        assert item["schema_version"] == SCHEMA_VERSION


### PR DESCRIPTION
## Summary
- add `/v1/calendar/layers` endpoint to list user and group visible layers
- enforce permissions with `PermissionsGraphAdapter`
- test retrieving layers for users and groups

## Testing
- `ruff check src/ume/calendar_layer_routes.py tests/test_calendar_layer_routes.py`
- `pytest tests/test_calendar_layer_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_68b84826aac8832690df4282ee2a6ab7