### PR TITLE
Add tests for calendar layer listing

### DIFF
--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
+from typing import List, cast
 
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .models import create_calendar_layer
+from .utils import ensure_group_member
 
 EDGE_VERSION = "3.0.0"
 
@@ -81,3 +83,34 @@ def create_layer(
         color=layer.color,
         schema_version=layer.schema_version,
     )
+
+
+@router.get("/layers", response_model=List[CalendarLayerResponse])
+def list_layers(
+    user_id: str = Query(...),
+    group_id: str | None = Query(None),
+    graph: IGraphAdapter = Depends(deps.get_graph),
+    _: str = Depends(deps.get_current_role),
+) -> List[CalendarLayerResponse]:
+    if group_id is not None:
+        ensure_group_member(graph, user_id, group_id)
+    perm_graph = PermissionsGraphAdapter(
+        graph, user_id=user_id, group_id=group_id
+    )
+    layer_ids = set(perm_graph.get_nodes_by_user(user_id))
+    if group_id is not None:
+        layer_ids |= set(perm_graph.get_nodes_shared_with(group_id))
+    layers: List[CalendarLayerResponse] = []
+    for lid in layer_ids:
+        attrs = graph.get_node(lid)
+        if not attrs or attrs.get("type") != "CalendarLayer":
+            continue
+        layers.append(
+            CalendarLayerResponse(
+                layer_id=lid,
+                layer_name=cast(str, attrs.get("layer_name")),
+                color=cast(str, attrs.get("color")),
+                schema_version=cast(str, attrs.get("schema_version")),
+            )
+        )
+    return layers

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -160,3 +160,85 @@ def test_event_with_existing_layer(client_and_graph) -> None:
         s == event_id and t == layer_id and lbl == "TAGGED_AS" for s, t, lbl, _ in edges
 
     )
+
+
+def test_list_layers_for_owner(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    graph.add_node("user1", {})
+    res = client.post(
+        "/v1/calendar/layers",
+        json={"layer_name": "Work", "color": "blue", "user_id": "user1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    layer_id = res.json()["layer_id"]
+
+    res = client.get(
+        "/v1/calendar/layers",
+        params={"user_id": "user1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == [
+        {
+            "layer_id": layer_id,
+            "layer_name": "Work",
+            "color": "blue",
+            "schema_version": SCHEMA_VERSION,
+        }
+    ]
+
+    res = client.get(
+        "/v1/calendar/layers",
+        params={"user_id": "user2"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == []
+
+
+def test_list_layers_shared_with_group(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    graph.add_node("user1", {})
+    graph.add_node("user2", {})
+    graph.add_node("group1", {"members": ["user1", "user2"]})
+    graph.add_edge(
+        "group1", "user1", "OWNED_BY", {"permission_level": "editor"}
+    )
+    graph.add_edge(
+        "group1", "user2", "OWNED_BY", {"permission_level": "editor"}
+    )
+    res = client.post(
+        "/v1/calendar/layers",
+        json={
+            "layer_name": "Work",
+            "color": "blue",
+            "user_id": "user1",
+            "group_id": "group1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    layer_id = res.json()["layer_id"]
+
+    res = client.get(
+        "/v1/calendar/layers",
+        params={"user_id": "user2", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == [
+        {
+            "layer_id": layer_id,
+            "layer_name": "Work",
+            "color": "blue",
+            "schema_version": SCHEMA_VERSION,
+        }
+    ]
+
+    res = client.get(
+        "/v1/calendar/layers",
+        params={"user_id": "user3", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- Add endpoint to list calendar layers for users and groups
- Cover owner and shared group layer listings in tests, including unauthorized cases

## Testing
- `pre-commit run --files src/ume/calendar_layer_routes.py tests/test_calendar_layer_routes.py`
- `pytest tests/test_calendar_layer_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8482733988326af188eef4655c26b