### PR TITLE
refactor: validate group membership via node property

### DIFF
--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -55,17 +55,11 @@ def create_layer(
         schema_version=EDGE_VERSION,
     )
     if req.group_id:
-        if not graph.node_exists(req.group_id):
+        group = graph.get_node(req.group_id)
+        if group is None:
             raise HTTPException(status_code=404, detail="Group not found")
-        is_member = any(
-            s == req.group_id
-            and t == req.user_id
-            and lbl == "OWNED_BY"
-            and isinstance(attrs, dict)
-            and attrs.get("permission_level") == "editor"
-            for s, t, lbl, attrs in graph.get_all_edges()
-        )
-        if not is_member:
+        members = group.get("members", []) if isinstance(group, dict) else []
+        if req.user_id not in members:
             raise HTTPException(status_code=403, detail="User not in group")
         perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
         try:

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -67,10 +67,7 @@ def test_create_layer_with_group_share(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)
     graph.add_node("user1", {})
-    graph.add_node("group1", {})
-    graph.add_edge(
-        "group1", "user1", "OWNED_BY", {"permission_level": "editor"}
-    )
+    graph.add_node("group1", {"members": ["user1"]})
     res = client.post(
         "/v1/calendar/layers",
         json={
@@ -203,12 +200,6 @@ def test_list_layers_shared_with_group(client_and_graph) -> None:
     graph.add_node("user1", {})
     graph.add_node("user2", {})
     graph.add_node("group1", {"members": ["user1", "user2"]})
-    graph.add_edge(
-        "group1", "user1", "OWNED_BY", {"permission_level": "editor"}
-    )
-    graph.add_edge(
-        "group1", "user2", "OWNED_BY", {"permission_level": "editor"}
-    )
     res = client.post(
         "/v1/calendar/layers",
         json={


### PR DESCRIPTION
## Summary
- validate group membership using `members` property instead of edges when creating calendar layers
- adjust calendar layer route tests for member property

## Testing
- `pre-commit run --files src/ume/calendar_layer_routes.py tests/test_calendar_layer_routes.py`
- `pytest tests/test_calendar_layer_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b8518003188326bfe2ea1dda63af25