### PR TITLE
fix: use group members for calendar layer

### DIFF
--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -57,16 +57,7 @@ def create_layer(
     if req.group_id:
         if not graph.node_exists(req.group_id):
             raise HTTPException(status_code=404, detail="Group not found")
-        is_member = any(
-            s == req.group_id
-            and t == req.user_id
-            and lbl == "OWNED_BY"
-            and isinstance(attrs, dict)
-            and attrs.get("permission_level") == "editor"
-            for s, t, lbl, attrs in graph.get_all_edges()
-        )
-        if not is_member:
-            raise HTTPException(status_code=403, detail="User not in group")
+        ensure_group_member(graph, req.user_id, req.group_id)
         perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
         try:
             perm_graph.add_edge(

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -67,10 +67,7 @@ def test_create_layer_with_group_share(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)
     graph.add_node("user1", {})
-    graph.add_node("group1", {})
-    graph.add_edge(
-        "group1", "user1", "OWNED_BY", {"permission_level": "editor"}
-    )
+    graph.add_node("group1", {"type": "UserGroup", "members": ["user1"]})
     res = client.post(
         "/v1/calendar/layers",
         json={
@@ -96,7 +93,7 @@ def test_create_layer_group_permission_required(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)
     graph.add_node("user1", {})
-    graph.add_node("group1", {})
+    graph.add_node("group1", {"type": "UserGroup", "members": []})
     res = client.post(
         "/v1/calendar/layers",
         json={
@@ -202,13 +199,7 @@ def test_list_layers_shared_with_group(client_and_graph) -> None:
     token = _token(client)
     graph.add_node("user1", {})
     graph.add_node("user2", {})
-    graph.add_node("group1", {"members": ["user1", "user2"]})
-    graph.add_edge(
-        "group1", "user1", "OWNED_BY", {"permission_level": "editor"}
-    )
-    graph.add_edge(
-        "group1", "user2", "OWNED_BY", {"permission_level": "editor"}
-    )
+    graph.add_node("group1", {"type": "UserGroup", "members": ["user1", "user2"]})
     res = client.post(
         "/v1/calendar/layers",
         json={
@@ -237,9 +228,26 @@ def test_list_layers_shared_with_group(client_and_graph) -> None:
         }
     ]
 
+
+def test_list_layers_shared_with_group_permission_required(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    graph.add_node("user1", {})
+    graph.add_node("user2", {})
+    graph.add_node("group1", {"type": "UserGroup", "members": ["user1"]})
+    res = client.post(
+        "/v1/calendar/layers",
+        json={
+            "layer_name": "Work",
+            "color": "blue",
+            "user_id": "user1",
+            "group_id": "group1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
     res = client.get(
         "/v1/calendar/layers",
-        params={"user_id": "user3", "group_id": "group1"},
+        params={"user_id": "user2", "group_id": "group1"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 403


### PR DESCRIPTION
## Summary
- define group membership via `members` list in calendar layer tests
- enforce group access by checking the group's `members` list when sharing layers
- add negative tests ensuring non-members can't access group-shared layers

## Testing
- `ruff check src/ume/calendar_layer_routes.py tests/test_calendar_layer_routes.py`
- `pytest tests/test_calendar_layer_routes.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85180bb108326b2ef794435ff870b