### PR TITLE
Ensure calendar events since filter is exclusive

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -195,7 +195,7 @@ def list_events(
         if not attrs or attrs.get("type") != "CalendarEvent":
             continue
         start_ts = attrs.get("start_time")
-        if since is not None and (start_ts is None or start_ts < since):
+        if since is not None and (start_ts is None or start_ts <= since):
             continue
         events.append(
             CalendarEventResponse(

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -413,13 +413,21 @@ def test_calendar_events_since_returns_only_future(client_and_graph) -> None:
     graph.add_node("user1", {})
 
     past = datetime(2023, 1, 1, 12, 0, tzinfo=timezone.utc)
-    future = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
     since = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    future = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
 
     # Create a past event
     res = client.post(
         "/v1/calendar/events",
         json={"title": "Past", "start_time": past.isoformat(), "user_id": "user1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+
+    # Create an event at the since timestamp
+    res = client.post(
+        "/v1/calendar/events",
+        json={"title": "At", "start_time": since.isoformat(), "user_id": "user1"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200


### PR DESCRIPTION
## Summary
- Exclude events starting at or before a given timestamp from calendar listings
- Test calendar events retrieval using `since` to ensure only later events are returned

## Testing
- `ruff check tests/test_calendar_decision_api.py src/ume/calendar_routes.py`
- `pytest tests/test_calendar_decision_api.py::test_calendar_events_since_returns_only_future -q`

------
https://chatgpt.com/codex/tasks/task_e_68b85c273f8883269995ccd7c6e9f339