### PR TITLE
Validate calendar event times

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -75,6 +75,11 @@ def create_event(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> CalendarEventResponse:
+    if req.end_time is not None and req.end_time <= req.start_time:
+        raise HTTPException(
+            status_code=400,
+            detail="end_time must be after start_time",
+        )
     event = create_calendar_event(
         req.title,
         req.start_time,


### PR DESCRIPTION
## Summary
- reject calendar events where end_time is before start_time

## Testing
- `pre-commit run --files src/ume/calendar_routes.py`
- `pytest` *(fails: 44 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68b86161c724832681e93c9c7ac254ca