### PR TITLE
Validate calendar event time ordering

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -75,6 +75,10 @@ def create_event(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> CalendarEventResponse:
+    if req.end_time is not None and req.end_time <= req.start_time:
+        raise HTTPException(
+            status_code=400, detail="end_time must be after start_time"
+        )
     event = create_calendar_event(
         req.title,
         req.start_time,

--- a/tests/test_calendar_event_validation.py
+++ b/tests/test_calendar_event_validation.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+
+
+def _token(client: TestClient) -> str:
+    res = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return res.json()["access_token"]
+
+
+@pytest.fixture
+def client_and_graph():
+    graph = MockGraph()
+    configure_graph(graph)
+    return TestClient(app), graph
+
+
+def test_end_before_start_rejected(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+    end = datetime(2024, 1, 1, 11, 0, tzinfo=timezone.utc).isoformat()
+    res = client.post(
+        "/v1/calendar/events",
+        json={"title": "Meeting", "start_time": start, "end_time": end, "user_id": "user1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400
+
+
+def test_valid_event_creation(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    start_dt = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    end_dt = datetime(2024, 1, 1, 13, 0, tzinfo=timezone.utc)
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Meeting",
+            "start_time": start_dt.isoformat(),
+            "end_time": end_dt.isoformat(),
+            "user_id": "user1",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    event_id = res.json()["id"]
+    attrs = graph.get_node(event_id)
+    assert attrs["start_time"] == int(start_dt.timestamp())
+    assert attrs["end_time"] == int(end_dt.timestamp())


### PR DESCRIPTION
## Summary
- reject calendar events where `end_time` precedes `start_time`
- add tests covering invalid and valid calendar event creation

## Testing
- `pre-commit run --files src/ume/calendar_routes.py tests/test_calendar_event_validation.py`
- `pytest tests/test_calendar_event_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b86162d3088326ad4e8977231ace2b