### PR TITLE
Validate calendar event time ordering

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Calendar event endpoints and helpers."""
+
+from datetime import datetime, timezone
+
+
+class CalendarEventTimeError(ValueError):
+    """Raised when calendar event times are invalid."""
+
+
+def validate_event_times(start_time: str, end_time: str) -> None:
+    """Validate start and end times for a calendar event.
+
+    Both ``start_time`` and ``end_time`` should be ISO 8601 strings. They must
+    either both include timezone information or both be naive. If they are
+    timezone-aware they will be normalised to UTC before comparison. The
+    function raises :class:`CalendarEventTimeError` if ``end_time`` does not
+    occur after ``start_time`` or if the timezone awareness of the values
+    differs.
+    """
+    try:
+        start = datetime.fromisoformat(start_time)
+        end = datetime.fromisoformat(end_time)
+    except ValueError as exc:
+        raise CalendarEventTimeError("Invalid datetime format") from exc
+
+    # Guard against mixing aware and naive datetimes
+    if (start.tzinfo is None) != (end.tzinfo is None):
+        raise CalendarEventTimeError(
+            "start_time and end_time must both be timezone-aware or both naive"
+        )
+
+    if start.tzinfo is not None and end.tzinfo is not None:
+        start = start.astimezone(timezone.utc)
+        end = end.astimezone(timezone.utc)
+
+    if end <= start:
+        raise CalendarEventTimeError("end_time must occur after start_time")

--- a/tests/test_calendar_event_validation.py
+++ b/tests/test_calendar_event_validation.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pytest
+
+from ume.calendar_routes import CalendarEventTimeError, validate_event_times
+
+
+def test_valid_event_times():
+    """Times with matching awareness and correct order are accepted."""
+    validate_event_times(
+        "2024-01-01T10:00:00+00:00",
+        "2024-01-01T11:00:00+00:00",
+    )
+
+
+def test_end_before_start():
+    """end_time earlier than start_time should raise an error."""
+    with pytest.raises(CalendarEventTimeError):
+        validate_event_times(
+            "2024-01-01T11:00:00+00:00",
+            "2024-01-01T10:00:00+00:00",
+        )
+
+
+def test_timezone_mixing_rejected():
+    """Mixing naive and aware datetimes should be rejected."""
+    with pytest.raises(CalendarEventTimeError):
+        validate_event_times(
+            "2024-01-01T10:00:00",
+            "2024-01-01T11:00:00+00:00",
+        )


### PR DESCRIPTION
## Summary
- normalise calendar event times to guard against mixing timezone-aware and naive datetimes
- add tests ensuring timezone mismatches raise validation errors

## Testing
- `pre-commit run --files src/ume/calendar_routes.py tests/test_calendar_event_validation.py` *(fails: .pre-commit-config.yaml is not a file)*
- `pytest tests/test_calendar_event_validation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9a5c13d0c8326bb3be75e4feac447