### PR TITLE
feat: manage group membership

### DIFF
--- a/src/ume/users_routes.py
+++ b/src/ume/users_routes.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 from typing import List
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .models import create_user, create_user_group
 from .permissions_adapter import PermissionsGraphAdapter
+from .utils import ensure_group_member
 
 router = APIRouter(prefix="/v1")
 
@@ -41,6 +42,10 @@ class OwnedByRequest(BaseModel):
     node_id: str
     owner_id: str
     permission_level: str = "editor"
+
+
+class GroupMemberRequest(BaseModel):
+    user_id: str
 
 
 @router.post("/users", response_model=UserResponse)
@@ -108,3 +113,50 @@ def create_owned_by_edge(
         {"permission_level": req.permission_level},
     )
     return {"status": "ok"}
+
+
+@router.patch("/groups/{group_id}/add_member", response_model=UserGroupResponse)
+def add_group_member(
+    group_id: str,
+    req: GroupMemberRequest,
+    graph: IGraphAdapter = Depends(deps.get_graph),
+    _: str = Depends(deps.get_current_role),
+) -> UserGroupResponse:
+    group_attrs = graph.get_node(group_id)
+    if not group_attrs or group_attrs.get("type") != "UserGroup":
+        raise HTTPException(status_code=404, detail="Group not found")
+    ensure_group_member(graph, req.user_id, group_id, should_exist=False)
+    members = list(group_attrs.get("members", []))
+    members.append(req.user_id)
+    graph.update_node(group_id, {"members": members})
+    name: str = group_attrs["name"]
+    schema_version: str = group_attrs["schema_version"]
+    return UserGroupResponse(
+        id=group_id,
+        name=name,
+        members=members,
+        schema_version=schema_version,
+    )
+
+
+@router.patch("/groups/{group_id}/remove_member", response_model=UserGroupResponse)
+def remove_group_member(
+    group_id: str,
+    req: GroupMemberRequest,
+    graph: IGraphAdapter = Depends(deps.get_graph),
+    _: str = Depends(deps.get_current_role),
+) -> UserGroupResponse:
+    group_attrs = graph.get_node(group_id)
+    if not group_attrs or group_attrs.get("type") != "UserGroup":
+        raise HTTPException(status_code=404, detail="Group not found")
+    ensure_group_member(graph, req.user_id, group_id)
+    members = [mid for mid in group_attrs.get("members", []) if mid != req.user_id]
+    graph.update_node(group_id, {"members": members})
+    name: str = group_attrs["name"]
+    schema_version: str = group_attrs["schema_version"]
+    return UserGroupResponse(
+        id=group_id,
+        name=name,
+        members=members,
+        schema_version=schema_version,
+    )

--- a/src/ume/utils.py
+++ b/src/ume/utils.py
@@ -21,12 +21,34 @@ def ssl_config() -> Dict[str, str]:
     return {}
 
 
-def ensure_group_member(graph: IGraphAdapter, user_id: str, group_id: str) -> None:
-    """Raise ``HTTPException`` if ``user_id`` is not a member of ``group_id``."""
+def ensure_group_member(
+    graph: IGraphAdapter, user_id: str, group_id: str, *, should_exist: bool = True
+) -> None:
+    """Validate membership of ``user_id`` in ``group_id``.
+
+    Parameters
+    ----------
+    graph:
+        Graph adapter used to fetch group information.
+    user_id:
+        The user identifier whose membership is being validated.
+    group_id:
+        The group identifier to check against.
+    should_exist:
+        If ``True`` (default), ensure the user is already a member of the
+        group, raising ``HTTPException`` with status 403 if not. If ``False``,
+        ensure the user is **not** a member, raising ``HTTPException`` with
+        status 400 if they already belong to the group.
+    """
+
     group = graph.get_node(group_id)
     members = group.get("members", []) if isinstance(group, dict) else []
-    if user_id not in members:
-        raise HTTPException(status_code=403, detail="User not in group")
+    if should_exist:
+        if user_id not in members:
+            raise HTTPException(status_code=403, detail="User not in group")
+    else:
+        if user_id in members:
+            raise HTTPException(status_code=400, detail="User already in group")
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_users_routes.py
+++ b/tests/test_users_routes.py
@@ -92,3 +92,66 @@ def test_user_group_and_owned_by(client_and_graph) -> None:
         "OWNED_BY",
         {"permission_level": "editor"},
     ) not in edges
+
+
+def test_group_member_add_remove(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    # Create two users
+    res = client.post(
+        "/v1/users",
+        json={"name": "Alice"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    user1 = res.json()["id"]
+    res = client.post(
+        "/v1/users",
+        json={"name": "Bob"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    user2 = res.json()["id"]
+
+    # Create a group with the first user
+    res = client.post(
+        "/v1/groups",
+        json={"name": "Team", "members": [user1]},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    group_id = res.json()["id"]
+
+    # Add the second user to the group
+    res = client.patch(
+        f"/v1/groups/{group_id}/add_member",
+        json={"user_id": user2},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json()["members"] == [user1, user2]
+    assert graph.get_node(group_id)["members"] == [user1, user2]
+
+    # Adding the same user again should fail
+    res = client.patch(
+        f"/v1/groups/{group_id}/add_member",
+        json={"user_id": user2},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400
+
+    # Remove the first user
+    res = client.patch(
+        f"/v1/groups/{group_id}/remove_member",
+        json={"user_id": user1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json()["members"] == [user2]
+    assert graph.get_node(group_id)["members"] == [user2]
+
+    # Removing a non-member should fail
+    res = client.patch(
+        f"/v1/groups/{group_id}/remove_member",
+        json={"user_id": user1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Summary
- add PATCH endpoints to add or remove members from a user group
- extend `ensure_group_member` helper to validate membership presence or absence
- test group membership addition/removal and validation errors

## Testing
- `pre-commit run --files src/ume/utils.py src/ume/users_routes.py tests/test_users_routes.py`
- `pytest tests/test_users_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68c01c625abc8326b1e0cbe735c301bd