### PR TITLE
Remove public permission level

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -46,9 +46,7 @@ class PermissionsGraphAdapter(IGraphAdapter):
             perm_level = attrs.get("permission_level") if isinstance(attrs, dict) else attrs
             if perm_level == perm:
                 return True
-            if perm == "viewer" and perm_level in {"editor", "public"}:
-                return True
-            if perm == "editor" and perm_level == "public":
+            if perm == "viewer" and perm_level == "editor":
                 return True
         return False
 

--- a/src/ume/schema_manager.py
+++ b/src/ume/schema_manager.py
@@ -107,12 +107,10 @@ class GraphSchemaManager:
                             else attrs
                         )
                         new_label = "OWNED_BY" if perm_level == "editor" else "SHARED_WITH"
-                        attr_dict["permission_level"] = "public"
                         graph.add_edge(src, tgt, new_label, attr_dict)
                         if graph.node_exists(tgt):
                             node_attrs = graph.get_node(tgt) or {}
                             node_attrs.setdefault("type", "User")
-                            node_attrs.setdefault("permission_level", "public")
                             graph.update_node(tgt, node_attrs)
                     elif label in {
                         "REMEMBERS",

--- a/src/ume/schemas/graph_schema_v3.yaml
+++ b/src/ume/schemas/graph_schema_v3.yaml
@@ -1,8 +1,7 @@
 version: "3.0.0"
 node_types:
-  User:
-    version: "3.0.0"
-    permission_level: "public"
+    User:
+      version: "3.0.0"
     properties:
       user_id:
         version: "3.0.0"
@@ -12,9 +11,8 @@ node_types:
         version: "3.0.0"
       created_at:
         version: "3.0.0"
-  UserGroup:
-    version: "3.0.0"
-    permission_level: "public"
+    UserGroup:
+      version: "3.0.0"
     properties:
       group_id:
         version: "3.0.0"
@@ -22,9 +20,8 @@ node_types:
         version: "3.0.0"
       members:
         version: "3.0.0"
-  CalendarEvent:
-    version: "3.0.0"
-    permission_level: "public"
+    CalendarEvent:
+      version: "3.0.0"
     properties:
       id:
         version: "3.0.0"
@@ -46,9 +43,8 @@ node_types:
         version: "3.0.0"
       visibility:
         version: "3.0.0"
-  CalendarLayer:
-    version: "3.0.0"
-    permission_level: "public"
+    CalendarLayer:
+      version: "3.0.0"
     properties:
       layer_id:
         version: "3.0.0"
@@ -56,9 +52,8 @@ node_types:
         version: "3.0.0"
       color:
         version: "3.0.0"
-  DecisionAnalysis:
-    version: "3.0.0"
-    permission_level: "public"
+    DecisionAnalysis:
+      version: "3.0.0"
     properties:
       analysis_id:
         version: "3.0.0"
@@ -66,9 +61,8 @@ node_types:
         version: "3.0.0"
       created_at:
         version: "3.0.0"
-  ProposedAction:
-    version: "3.0.0"
-    permission_level: "public"
+    ProposedAction:
+      version: "3.0.0"
     properties:
       action_id:
         version: "3.0.0"
@@ -80,9 +74,8 @@ node_types:
         version: "3.0.0"
       outcome_metrics:
         version: "3.0.0"
-  FinancialAccount:
-    version: "3.0.0"
-    permission_level: "public"
+    FinancialAccount:
+      version: "3.0.0"
     properties:
       account_id:
         version: "3.0.0"
@@ -97,16 +90,11 @@ node_types:
 edge_labels:
   OWNED_BY:
     version: "3.0.0"
-    permission_level: "public"
   SHARED_WITH:
     version: "3.0.0"
-    permission_level: "public"
   INVITES:
     version: "3.0.0"
-    permission_level: "public"
   TAGGED_AS:
     version: "3.0.0"
-    permission_level: "public"
   CONSIDERS:
     version: "3.0.0"
-    permission_level: "public"

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -190,7 +190,7 @@ def test_add_edge_success(graph: PersistentGraph):
     graph.add_node("nodeS", {})
     graph.add_node("nodeT", {})
     graph.add_edge("nodeS", "nodeT", "RELATES_TO")
-    # Ensure the edge is present via the public API
+    # Ensure the edge is present via the API
     all_edges = graph.get_all_edges()
     assert len(all_edges) == 1
     assert ("nodeS", "nodeT", "RELATES_TO", {}) in all_edges

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -116,7 +116,7 @@ def test_upgrade_to_v3_transforms_graph(graph: PersistentGraph) -> None:
         "a",
         "b",
         "TAGGED_AS",
-        {"permission_level": "public", "version": "3.0.0"},
+        {"version": "3.0.0"},
     ) in edges
     assert all(lbl == "TAGGED_AS" for _, _, lbl, _ in edges)
 
@@ -134,7 +134,7 @@ def test_upgrade_sets_edge_version(graph: PersistentGraph) -> None:
         "a",
         "b",
         "TAGGED_AS",
-        {"permission_level": "public", "version": "3.0.0"},
+        {"version": "3.0.0"},
     ) in edges
 
 
@@ -159,13 +159,13 @@ def test_upgrade_maps_has_permission_edges(
         "doc",
         "user1",
         "OWNED_BY",
-        {"permission_level": "public", "version": "3.0.0"},
+        {"permission_level": "editor", "version": "3.0.0"},
     ) in edges
     assert (
         "doc",
         "user2",
         "SHARED_WITH",
-        {"permission_level": "public", "version": "3.0.0"},
+        {"permission_level": "viewer", "version": "3.0.0"},
     ) in edges
     assert all(lbl != "HAS_PERMISSION" for _, _, lbl, _ in edges)
 
@@ -185,23 +185,21 @@ def test_upgrade_permission_nodes_multi_user(graph: PersistentGraph) -> None:
         "doc",
         "u1",
         "SHARED_WITH",
-        {"permission_level": "public", "version": "3.0.0"},
+        {"permission_level": "viewer", "version": "3.0.0"},
     ) in edges
     assert (
         "doc",
         "u2",
         "OWNED_BY",
-        {"permission_level": "public", "version": "3.0.0"},
+        {"permission_level": "editor", "version": "3.0.0"},
     ) in edges
 
     assert graph.get_node("u1") == {
         "type": "User",
-        "permission_level": "public",
     }
     assert graph.get_node("u2") == {
         "name": "Bob",
         "type": "User",
-        "permission_level": "public",
     }
 
 
@@ -221,11 +219,7 @@ def test_upgrade_preserves_schema_version(graph: PersistentGraph) -> None:
         "a",
         "b",
         "TAGGED_AS",
-        {
-            "permission_level": "public",
-            "schema_version": "2.0.0",
-            "version": "3.0.0",
-        },
+        {"schema_version": "2.0.0", "version": "3.0.0"},
     ) in edges
 
 
@@ -242,5 +236,5 @@ def test_upgrade_adds_version_when_missing(graph: PersistentGraph) -> None:
         "a",
         "b",
         "TAGGED_AS",
-        {"permission_level": "public", "version": "3.0.0"},
+        {"version": "3.0.0"},
     ) in edges


### PR DESCRIPTION
## Summary
- drop `public` from permission checks and schema upgrades
- remove `permission_level: public` entries from graph schema v3
- update tests to expect only viewer/editor permissions

## Testing
- `ruff check src/ume/permissions_adapter.py src/ume/schema_manager.py tests/test_graph.py tests/test_schema_manager.py`
- `pytest tests/test_schema_manager.py tests/test_graph.py`


------
https://chatgpt.com/codex/tasks/task_e_68c01c617f5883268231c9733c9d2f89