### PR TITLE
Rename calendar event id field

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -56,7 +56,7 @@ class CalendarEventCreateRequest(BaseModel):
 
 
 class CalendarEventResponse(BaseModel):
-    id: str
+    event_id: str
     title: str
     start_time: int
     end_time: int | None = None
@@ -107,15 +107,15 @@ def create_event(
     _ensure_user_node(graph, req.user_id)
     if req.group_id:
         ensure_group_member(graph, req.user_id, req.group_id)
-    graph.add_node(event.id, attrs)
+    graph.add_node(event.event_id, attrs)
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     try:
         perm_graph.add_edge(
-            event.id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
+            event.event_id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
         )
     except AccessDeniedError:
         graph.add_edge(
-            event.id,
+            event.event_id,
             req.user_id,
             "OWNED_BY",
             {"permission_level": "editor"},
@@ -125,16 +125,16 @@ def create_event(
     for uid in req.invitee_ids or []:
         _ensure_user_node(graph, uid)
         try:
-            perm_graph.add_edge(event.id, uid, "INVITES")
+            perm_graph.add_edge(event.event_id, uid, "INVITES")
             perm_graph.add_edge(
-                event.id, uid, "SHARED_WITH", {"permission_level": "viewer"}
+                event.event_id, uid, "SHARED_WITH", {"permission_level": "viewer"}
             )
         except AccessDeniedError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
     if req.group_id:
         try:
             perm_graph.add_edge(
-                event.id,
+                event.event_id,
                 req.group_id,
                 "SHARED_WITH",
                 {"permission_level": "viewer"},
@@ -152,11 +152,11 @@ def create_event(
                 status_code=403, detail=f"No access to layer: {lid}"
             )
         try:
-            perm_graph.add_edge(event.id, lid, "TAGGED_AS")
+            perm_graph.add_edge(event.event_id, lid, "TAGGED_AS")
         except AccessDeniedError as exc:
             raise HTTPException(status_code=403, detail=str(exc))
     return CalendarEventResponse(
-        id=event.id,
+        event_id=event.event_id,
         title=event.title,
         start_time=attrs["start_time"],
         end_time=attrs["end_time"],
@@ -204,7 +204,7 @@ def list_events(
             continue
         events.append(
             CalendarEventResponse(
-                id=eid,
+                event_id=eid,
                 title=attrs.get("title", ""),
                 start_time=start_ts,
                 end_time=attrs.get("end_time"),

--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -30,7 +30,7 @@ class CalendarEventVisibility(str, Enum):
 class CalendarEvent:
     """Represents a calendar event in the graph."""
 
-    id: str
+    event_id: str
     title: str
     start_time: datetime
     end_time: datetime | None = None
@@ -59,7 +59,7 @@ def create_calendar_event(
     """Factory helper to build :class:`CalendarEvent` instances."""
 
     return CalendarEvent(
-        id=event_id or str(uuid.uuid4()),
+        event_id=event_id or str(uuid.uuid4()),
         title=title,
         start_time=start_time,
         end_time=end_time,

--- a/src/ume/schemas/graph_schema_v3.yaml
+++ b/src/ume/schemas/graph_schema_v3.yaml
@@ -23,7 +23,7 @@ node_types:
     CalendarEvent:
       version: "3.0.0"
     properties:
-      id:
+      event_id:
         version: "3.0.0"
       title:
         version: "3.0.0"

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -67,9 +67,9 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     )
     assert res.status_code == 200
     event_data = res.json()
-    event_id = event_data["id"]
+    event_id = event_data["event_id"]
     assert event_data == {
-        "id": event_id,
+        "event_id": event_id,
         "title": "Meeting",
         "start_time": start_ts,
         "end_time": end_ts,
@@ -157,7 +157,7 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     )
     assert res.status_code == 200
     event_data = res.json()
-    event_id = event_data["id"]
+    event_id = event_data["event_id"]
 
     # Unrelated user without group access cannot see the event
     res = client.get(
@@ -184,8 +184,8 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    assert sorted(res.json(), key=lambda e: e["id"]) == sorted(
-        [event_data, own_event], key=lambda e: e["id"]
+    assert sorted(res.json(), key=lambda e: e["event_id"]) == sorted(
+        [event_data, own_event], key=lambda e: e["event_id"]
     )
 
     edges = graph.get_all_edges()

--- a/tests/test_calendar_event_validation.py
+++ b/tests/test_calendar_event_validation.py
@@ -52,7 +52,7 @@ def test_valid_event_creation(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    event_id = res.json()["id"]
+    event_id = res.json()["event_id"]
     attrs = graph.get_node(event_id)
     assert attrs["start_time"] == int(start_dt.timestamp())
     assert attrs["end_time"] == int(end_dt.timestamp())

--- a/tests/test_calendar_invites.py
+++ b/tests/test_calendar_invites.py
@@ -49,7 +49,7 @@ def test_calendar_event_invites_create_edges_and_access(client_and_graph) -> Non
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    event_id = res.json()["id"]
+    event_id = res.json()["event_id"]
 
     edges = graph.get_all_edges()
     for uid in ["invitee1", "invitee2"]:

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -67,6 +67,7 @@ def test_create_layer_with_group_share(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)
     graph.add_node("user1", {})
+    graph.add_node("group1", {"type": "UserGroup", "members": ["user1"]})
     res = client.post(
         "/v1/calendar/layers",
         json={
@@ -150,7 +151,7 @@ def test_event_with_existing_layer(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    event_id = res.json()["id"]
+    event_id = res.json()["event_id"]
     edges = graph.get_all_edges()
     assert any(
         s == event_id and t == layer_id and lbl == "TAGGED_AS" for s, t, lbl, _ in edges
@@ -198,6 +199,10 @@ def test_list_layers_shared_with_group(client_and_graph) -> None:
     token = _token(client)
     graph.add_node("user1", {})
     graph.add_node("user2", {})
+    graph.add_node(
+        "group1",
+        {"type": "UserGroup", "members": ["user1", "user2"]},
+    )
 
     res = client.post(
         "/v1/calendar/layers",

--- a/tests/test_mixed_access_api.py
+++ b/tests/test_mixed_access_api.py
@@ -110,7 +110,9 @@ def test_calendar_mixed_access(client_and_graph) -> None:
 
     graph.add_node("owner", {})
     graph.add_node("other", {})
-    graph.add_node("group1", {})
+    graph.add_node(
+        "group1", {"type": "UserGroup", "members": ["owner", "other"]}
+    )
 
     start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
 
@@ -126,7 +128,7 @@ def test_calendar_mixed_access(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    event_id = res.json()["id"]
+    event_id = res.json()["event_id"]
 
     res = client.get(
         "/v1/calendar/events",
@@ -142,7 +144,7 @@ def test_calendar_mixed_access(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    assert res.json()[0]["id"] == event_id
+    assert res.json()[0]["event_id"] == event_id
 
     res = client.get(
         "/v1/calendar/events",
@@ -157,7 +159,7 @@ def test_decision_mixed_access(client_and_graph) -> None:
 
     graph.add_node("u1", {})
     graph.add_node("u2", {})
-    graph.add_node("g1", {})
+    graph.add_node("g1", {"type": "UserGroup", "members": ["u1", "u2"]})
 
     res = client.post(
         "/v1/decisions",
@@ -203,7 +205,9 @@ def test_financial_account_mixed_access(client_and_graph) -> None:
 
     graph.add_node("u1", {})
     graph.add_node("u2", {})
-    graph.add_node("group1", {})
+    graph.add_node(
+        "group1", {"type": "UserGroup", "members": ["u1", "u2"]}
+    )
     graph.add_edge("group1", "u1", "SHARED_WITH", {"permission_level": "editor"})
     graph.add_edge("group1", "u2", "SHARED_WITH", {"permission_level": "viewer"})
 

--- a/tests/test_models_calendar_decision.py
+++ b/tests/test_models_calendar_decision.py
@@ -15,7 +15,7 @@ def test_create_calendar_event_defaults_and_schema_version() -> None:
     event = create_calendar_event("Meeting", start)
 
     assert isinstance(event, CalendarEvent)
-    uuid.UUID(event.id)
+    uuid.UUID(event.event_id)
     assert event.end_time is None
     assert event.description is None
     assert event.is_all_day is False


### PR DESCRIPTION
## Summary
- use `event_id` instead of `id` for calendar events
- update calendar routes and schema for `event_id`
- adjust tests to expect `event_id`
- add missing group fixtures so calendar and mixed-access tests pass

## Testing
- `ruff check src/ume/models/calendar.py src/ume/calendar_routes.py tests/test_calendar_invites.py tests/test_calendar_event_validation.py tests/test_calendar_layer_routes.py tests/test_models_calendar_decision.py tests/test_mixed_access_api.py tests/test_calendar_decision_api.py`
- `pytest tests/test_calendar_invites.py tests/test_calendar_event_validation.py tests/test_calendar_layer_routes.py tests/test_models_calendar_decision.py tests/test_mixed_access_api.py tests/test_calendar_decision_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c02d2558008326a9d4a2b3ff55ef01