### PR TITLE
Validate permission levels in PermissionsGraphAdapter

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -152,12 +152,11 @@ class PermissionsGraphAdapter(IGraphAdapter):
             version = "3.0.0"
         else:
             version = None
-        if attrs and "permission_level" in attrs:
-            perm_level = attrs["permission_level"]
-            if perm_level not in {"viewer", "editor"}:
-                raise AccessDeniedError(
-                    f"Invalid permission_level '{perm_level}'"
-                )
+        perm_level = attrs.get("permission_level") if attrs else None
+        if perm_level is not None and perm_level not in {"viewer", "editor"}:
+            raise AccessDeniedError(
+                f"Invalid permission_level '{perm_level}'"
+            )
         self._adapter.add_edge(
             source_node_id,
             target_node_id,

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -294,3 +294,20 @@ def test_add_edge_rejects_invalid_permission_level() -> None:
             "SHARED_WITH",
             {"permission_level": "admin"},
         )
+
+
+def test_add_edge_invalid_permission_level_on_non_permission_edge() -> None:
+    g = MockGraph()
+    g.add_node("User.u1", {})
+    g.add_node("Document.d1", {})
+    g.add_node("Document.d2", {})
+    g._edges["Document.d1"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
+    g._edges["Document.d2"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
+    adapter = PermissionsGraphAdapter(g, user_id="User.u1")
+    with pytest.raises(AccessDeniedError):
+        adapter.add_edge(
+            "Document.d1",
+            "Document.d2",
+            "RELATED",
+            {"permission_level": "owner"},
+        )


### PR DESCRIPTION
## Summary
- validate `permission_level` in `PermissionsGraphAdapter.add_edge`
- add negative test for invalid permission levels on non-permission edges

## Testing
- `pytest tests/test_permissions_adapter.py::test_add_edge_invalid_permission_level_on_non_permission_edge tests/test_permissions_adapter.py::test_add_edge_rejects_invalid_permission_level -q`
- `pre-commit run --files src/ume/permissions_adapter.py tests/test_permissions_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68c0322959108326909d2595faf935e6