### PR TITLE
Restrict calendar group events to public visibility

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -107,6 +107,11 @@ def create_event(
     _ensure_user_node(graph, req.user_id)
     if req.group_id:
         ensure_group_member(graph, req.user_id, req.group_id)
+        if event.visibility != CalendarEventVisibility.PUBLIC_TO_GROUP:
+            raise HTTPException(
+                status_code=400,
+                detail="Group events must have visibility public_to_group",
+            )
     graph.add_node(event.event_id, attrs)
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     try:
@@ -198,6 +203,12 @@ def list_events(
     for eid in event_ids:
         attrs = graph.get_node(eid)
         if not attrs or attrs.get("type") != "CalendarEvent":
+            continue
+        if (
+            group_id is not None
+            and attrs.get("visibility")
+            != CalendarEventVisibility.PUBLIC_TO_GROUP.value
+        ):
             continue
         start_ts = attrs.get("start_time")
         if since is not None and (start_ts is None or start_ts <= since):

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -152,6 +152,7 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
             "start_time": start,
             "user_id": "user1",
             "group_id": "group1",
+            "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
         },
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -168,14 +169,19 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     assert res.status_code == 200
     assert res.json() == []
 
-    # User creates their own event
+    # User creates their own private event
     res = client.post(
         "/v1/calendar/events",
-        json={"title": "Solo", "start_time": start, "user_id": "user2"},
+        json={
+            "title": "Solo",
+            "start_time": start,
+            "user_id": "user2",
+            "visibility": CalendarEventVisibility.PRIVATE.value,
+        },
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    own_event = res.json()
+    _own_event = res.json()
 
     # Group-scoped retrieval returns the event
     res = client.get(
@@ -184,9 +190,7 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    assert sorted(res.json(), key=lambda e: e["event_id"]) == sorted(
-        [event_data, own_event], key=lambda e: e["event_id"]
-    )
+    assert res.json() == [event_data]
 
     edges = graph.get_all_edges()
     assert any(
@@ -209,7 +213,13 @@ def test_calendar_event_group_membership_required(client_and_graph) -> None:
     # Non-member cannot create an event for the group
     res = client.post(
         "/v1/calendar/events",
-        json={"title": "Meet", "start_time": start, "user_id": "user2", "group_id": "group1"},
+        json={
+            "title": "Meet",
+            "start_time": start,
+            "user_id": "user2",
+            "group_id": "group1",
+            "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
+        },
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 403
@@ -217,7 +227,13 @@ def test_calendar_event_group_membership_required(client_and_graph) -> None:
     # Member creates an event
     res = client.post(
         "/v1/calendar/events",
-        json={"title": "Meet", "start_time": start, "user_id": "user1", "group_id": "group1"},
+        json={
+            "title": "Meet",
+            "start_time": start,
+            "user_id": "user1",
+            "group_id": "group1",
+            "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
+        },
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
@@ -277,6 +293,7 @@ def test_calendar_event_group_and_layer_filter(client_and_graph) -> None:
             "user_id": "user1",
             "group_id": "group1",
             "layer_ids": [layer_id],
+            "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
         },
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -292,6 +309,7 @@ def test_calendar_event_group_and_layer_filter(client_and_graph) -> None:
             "user_id": "user1",
             "group_id": "group1",
             "layer_ids": [layer2_id],
+            "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
         },
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -381,10 +399,34 @@ def test_calendar_event_group_share_requires_editor(client_and_graph) -> None:
             "start_time": start,
             "user_id": "user1",
             "group_id": "group1",
+            "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
         },
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
+
+
+def test_calendar_event_private_group_rejected(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+    graph.add_node("group1", {"members": ["user1"]})
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Hidden",
+            "start_time": start,
+            "user_id": "user1",
+            "group_id": "group1",
+            "visibility": CalendarEventVisibility.PRIVATE.value,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400
 
 
 def test_calendar_event_unauthorized_access(client_and_graph) -> None:

--- a/tests/test_calendar_event_validation.py
+++ b/tests/test_calendar_event_validation.py
@@ -6,6 +6,7 @@ from fastapi.testclient import TestClient
 from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
+from ume.models import CalendarEventVisibility
 
 
 def _token(client: TestClient) -> str:
@@ -56,3 +57,26 @@ def test_valid_event_creation(client_and_graph) -> None:
     attrs = graph.get_node(event_id)
     assert attrs["start_time"] == int(start_dt.timestamp())
     assert attrs["end_time"] == int(end_dt.timestamp())
+
+
+def test_group_event_private_visibility_rejected(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+    graph.add_node("group1", {"members": ["user1"]})
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Hidden",
+            "start_time": start,
+            "user_id": "user1",
+            "group_id": "group1",
+            "visibility": CalendarEventVisibility.PRIVATE.value,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 400


### PR DESCRIPTION
## Summary
- Require `public_to_group` visibility for calendar events shared with groups
- Exclude private events from group-scoped event queries
- Add tests for public and private calendar event visibility

## Testing
- `ruff check src/ume/calendar_routes.py tests/test_calendar_decision_api.py tests/test_calendar_event_validation.py`
- `pytest tests/test_calendar_decision_api.py tests/test_calendar_event_validation.py tests/test_calendar_invites.py tests/test_calendar_layer_model.py tests/test_calendar_layer_routes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c03228b3148326bcbf3dbc7e52c366