### PR TITLE
Validate node type properties on schema load

### DIFF
--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -55,14 +55,32 @@ class GraphSchema:
                 data = json.load(f)
         node_types = {}
         for name, info in data.get("node_types", {}).items():
-            properties = {
-                prop_name: Property(
+            if not isinstance(info, dict):
+                from .processing import ProcessingError
+
+                raise ProcessingError(
+                    f"Node type '{name}' must be a mapping",
+                )
+            properties_data = info.get("properties")
+            if properties_data is None or not isinstance(properties_data, dict):
+                from .processing import ProcessingError
+
+                raise ProcessingError(
+                    f"Node type '{name}' must include a 'properties' mapping",
+                )
+            properties = {}
+            for prop_name, prop_info in properties_data.items():
+                if not isinstance(prop_info, dict):
+                    from .processing import ProcessingError
+
+                    raise ProcessingError(
+                        f"Property '{prop_name}' for node type '{name}' must be a mapping",
+                    )
+                properties[prop_name] = Property(
                     name=prop_name,
                     version=str(prop_info.get("version", "0.0.0")),
                     permission_level=prop_info.get("permission_level"),
                 )
-                for prop_name, prop_info in info.get("properties", {}).items()
-            }
             node_types[name] = NodeType(
                 name=name,
                 version=str(info.get("version", "0.0.0")),

--- a/src/ume/schemas/graph_schema.yaml
+++ b/src/ume/schemas/graph_schema.yaml
@@ -2,10 +2,13 @@ version: "1.0.0"
 node_types:
   UserMemory:
     version: "1.0.0"
+    properties: {}
   AgentIntent:
     version: "1.0.0"
+    properties: {}
   PerceptualContext:
     version: "1.0.0"
+    properties: {}
 edge_labels:
   REMEMBERS:
     version: "1.0.0"

--- a/src/ume/schemas/graph_schema_v2.yaml
+++ b/src/ume/schemas/graph_schema_v2.yaml
@@ -2,12 +2,16 @@ version: "2.0.0"
 node_types:
   UserMemory:
     version: "2.0.0"
+    properties: {}
   AgentIntent:
     version: "2.0.0"
+    properties: {}
   PerceptualContext:
     version: "2.0.0"
+    properties: {}
   NewType:
     version: "2.0.0"
+    properties: {}
 edge_labels:
   REMEMBERS:
     version: "2.0.0"

--- a/src/ume/schemas/graph_schema_v3.yaml
+++ b/src/ume/schemas/graph_schema_v3.yaml
@@ -2,91 +2,91 @@ version: "3.0.0"
 node_types:
     User:
       version: "3.0.0"
-    properties:
-      user_id:
-        version: "3.0.0"
-      name:
-        version: "3.0.0"
-      email:
-        version: "3.0.0"
-      created_at:
-        version: "3.0.0"
+      properties:
+        user_id:
+          version: "3.0.0"
+        name:
+          version: "3.0.0"
+        email:
+          version: "3.0.0"
+        created_at:
+          version: "3.0.0"
     UserGroup:
       version: "3.0.0"
-    properties:
-      group_id:
-        version: "3.0.0"
-      name:
-        version: "3.0.0"
-      members:
-        version: "3.0.0"
+      properties:
+        group_id:
+          version: "3.0.0"
+        name:
+          version: "3.0.0"
+        members:
+          version: "3.0.0"
     CalendarEvent:
       version: "3.0.0"
-    properties:
-      event_id:
-        version: "3.0.0"
-      title:
-        version: "3.0.0"
-      start_time:
-        version: "3.0.0"
-      end_time:
-        version: "3.0.0"
-      description:
-        version: "3.0.0"
-      is_all_day:
-        version: "3.0.0"
-      location:
-        version: "3.0.0"
-      status:
-        version: "3.0.0"
-      rrule:
-        version: "3.0.0"
-      visibility:
-        version: "3.0.0"
+      properties:
+        event_id:
+          version: "3.0.0"
+        title:
+          version: "3.0.0"
+        start_time:
+          version: "3.0.0"
+        end_time:
+          version: "3.0.0"
+        description:
+          version: "3.0.0"
+        is_all_day:
+          version: "3.0.0"
+        location:
+          version: "3.0.0"
+        status:
+          version: "3.0.0"
+        rrule:
+          version: "3.0.0"
+        visibility:
+          version: "3.0.0"
     CalendarLayer:
       version: "3.0.0"
-    properties:
-      layer_id:
-        version: "3.0.0"
-      layer_name:
-        version: "3.0.0"
-      color:
-        version: "3.0.0"
+      properties:
+        layer_id:
+          version: "3.0.0"
+        layer_name:
+          version: "3.0.0"
+        color:
+          version: "3.0.0"
     DecisionAnalysis:
       version: "3.0.0"
-    properties:
-      analysis_id:
-        version: "3.0.0"
-      query:
-        version: "3.0.0"
-      created_at:
-        version: "3.0.0"
+      properties:
+        analysis_id:
+          version: "3.0.0"
+        query:
+          version: "3.0.0"
+        created_at:
+          version: "3.0.0"
     ProposedAction:
       version: "3.0.0"
-    properties:
-      action_id:
-        version: "3.0.0"
-      description:
-        version: "3.0.0"
-      rank:
-        version: "3.0.0"
-      is_optimal:
-        version: "3.0.0"
-      outcome_metrics:
-        version: "3.0.0"
+      properties:
+        action_id:
+          version: "3.0.0"
+        description:
+          version: "3.0.0"
+        rank:
+          version: "3.0.0"
+        is_optimal:
+          version: "3.0.0"
+        outcome_metrics:
+          version: "3.0.0"
     FinancialAccount:
       version: "3.0.0"
-    properties:
-      account_id:
-        version: "3.0.0"
-      account_type:
-        version: "3.0.0"
-      institution:
-        version: "3.0.0"
-      balance:
-        version: "3.0.0"
-      currency:
-        version: "3.0.0"
+      properties:
+        account_id:
+          version: "3.0.0"
+        account_type:
+          version: "3.0.0"
+        institution:
+          version: "3.0.0"
+        balance:
+          version: "3.0.0"
+        currency:
+          version: "3.0.0"
 edge_labels:
   OWNED_BY:
     version: "3.0.0"

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -19,6 +19,27 @@ def test_load_bad_yaml(tmp_path):
         GraphSchema.load(str(path))
 
 
+@pytest.mark.parametrize(
+    "node_def",
+    [
+        [],
+        {"version": "1.0.0"},
+        {"version": "1.0.0", "properties": []},
+        {"version": "1.0.0", "properties": {"id": []}},
+    ],
+)
+def test_load_malformed_node_type(tmp_path, node_def):
+    schema_yaml = {
+        "version": "1.0.0",
+        "node_types": {"User": node_def},
+        "edge_labels": {},
+    }
+    path = tmp_path / "schema.yaml"
+    path.write_text(yaml.safe_dump(schema_yaml))
+    with pytest.raises(ProcessingError):
+        GraphSchema.load(str(path))
+
+
 def test_validate_unknown_node_type():
     schema = load_default_schema()
     with pytest.raises(ProcessingError):


### PR DESCRIPTION
## Summary
- validate node type entries include a `properties` mapping and ensure each property definition is a mapping
- add regression tests for malformed node type and property definitions

## Testing
- `pre-commit run --files src/ume/graph_schema.py tests/test_graph_schema.py`
- `pytest tests/test_graph_schema.py`


------
https://chatgpt.com/codex/tasks/task_e_68c423dc650c8326963b93818105e499