### PR TITLE
Validate edge labels in permissions adapter

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -7,6 +7,7 @@ from typing import Any, DefaultDict, Dict, List, Optional
 from .graph_adapter import IGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .graph_schema import DEFAULT_SCHEMA
+from .processing import ProcessingError
 
 
 class PermissionsGraphAdapter(IGraphAdapter):
@@ -143,20 +144,19 @@ class PermissionsGraphAdapter(IGraphAdapter):
         self._require_editor(source_node_id)
         if label not in {"OWNED_BY", "SHARED_WITH", "INVITES"}:
             self._require_editor(target_node_id)
-        edge_def = DEFAULT_SCHEMA.edge_labels.get(label)
-        if schema_version is not None:
-            version = schema_version
-        elif edge_def is not None:
-            version = edge_def.version
-        elif label in {"OWNED_BY", "SHARED_WITH", "INVITES", "TAGGED_AS", "CONSIDERS"}:
-            version = "3.0.0"
-        else:
-            version = None
-        perm_level = attrs.get("permission_level") if attrs else None
+        try:
+            DEFAULT_SCHEMA.validate_edge_label(label)
+        except ProcessingError as exc:
+            raise AccessDeniedError(str(exc)) from exc
+        edge_def = DEFAULT_SCHEMA.edge_labels[label]
+        version = edge_def.version
+        attrs = dict(attrs or {})
+        perm_level = attrs.get("permission_level")
         if perm_level is not None and perm_level not in {"viewer", "editor"}:
             raise AccessDeniedError(
                 f"Invalid permission_level '{perm_level}'"
             )
+        attrs.pop("schema_version", None)
         self._adapter.add_edge(
             source_node_id,
             target_node_id,

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -177,12 +177,17 @@ def test_add_edge_requires_editor_and_preserves_attrs() -> None:
     g._edges["Document.d1"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
     adapter = PermissionsGraphAdapter(g, user_id="User.u1")
     with pytest.raises(AccessDeniedError):
-        adapter.add_edge("Document.d1", "Document.d2", "RELATED", {"weight": 1})
+        adapter.add_edge("Document.d1", "Document.d2", "TAGGED_AS", {"weight": 1})
     g._edges["Document.d2"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
     adapter.rebuild_index()
-    adapter.add_edge("Document.d1", "Document.d2", "RELATED", {"weight": 1})
+    adapter.add_edge("Document.d1", "Document.d2", "TAGGED_AS", {"weight": 1})
     assert adapter.get_all_edges() == [
-        ("Document.d1", "Document.d2", "RELATED", {"weight": 1})
+        (
+            "Document.d1",
+            "Document.d2",
+            "TAGGED_AS",
+            {"weight": 1, "schema_version": "3.0.0"},
+        )
     ]
 
 
@@ -308,6 +313,6 @@ def test_add_edge_invalid_permission_level_on_non_permission_edge() -> None:
         adapter.add_edge(
             "Document.d1",
             "Document.d2",
-            "RELATED",
+            "TAGGED_AS",
             {"permission_level": "owner"},
         )


### PR DESCRIPTION
## Summary
- validate edge labels with the default schema and raise `AccessDeniedError` for unknown labels
- attach the schema's version to edges and update tests accordingly

## Testing
- `ruff check src/ume/permissions_adapter.py`
- `ruff check tests/test_permissions_adapter.py`
- `pytest tests/test_permissions_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68c81d7a3dac8326bc8eaf6a9f325e9e