### PR TITLE
Add tests for default graph schema handling

### DIFF
--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -19,6 +19,47 @@ def test_load_bad_yaml(tmp_path):
         GraphSchema.load(str(path))
 
 
+def test_default_schema_node_properties():
+    schema = load_default_schema()
+    expected_node_properties = {
+        "User": {"user_id", "name", "email", "created_at"},
+        "UserGroup": {"group_id", "name", "members"},
+        "CalendarEvent": {
+            "event_id",
+            "title",
+            "start_time",
+            "end_time",
+            "description",
+            "is_all_day",
+            "location",
+            "status",
+            "rrule",
+            "visibility",
+        },
+        "CalendarLayer": {"layer_id", "layer_name", "color"},
+        "DecisionAnalysis": {"analysis_id", "query", "created_at"},
+        "ProposedAction": {
+            "action_id",
+            "description",
+            "rank",
+            "is_optimal",
+            "outcome_metrics",
+        },
+        "FinancialAccount": {
+            "account_id",
+            "account_type",
+            "institution",
+            "balance",
+            "currency",
+        },
+    }
+
+    assert set(schema.node_types) == set(expected_node_properties)
+    for node_name, expected_properties in expected_node_properties.items():
+        node = schema.node_types[node_name]
+        assert set(node.properties) == expected_properties
+
+
 @pytest.mark.parametrize(
     "node_def",
     [
@@ -79,6 +120,27 @@ def test_load_node_properties(tmp_path):
     user = schema.node_types["User"]
     assert "id" in user.properties
     assert user.properties["id"].version == "1.0.0"
+
+
+def test_load_misindented_schema(tmp_path):
+    misindented_schema = """
+version: "1.0.0"
+node_types:
+  User:
+    version: "1.0.0"
+    properties:
+      id:
+        version: "1.0.0"
+      name:
+      version: "1.0.0"
+edge_labels: {}
+"""
+
+    path = tmp_path / "schema.yaml"
+    path.write_text(misindented_schema)
+
+    with pytest.raises(ProcessingError):
+        GraphSchema.load(str(path))
 
 
 def test_validate_node_property(tmp_path):


### PR DESCRIPTION
## Summary
- add a regression test that ensures every default node type exposes its expected property set
- add a mis-indented schema fixture to verify GraphSchema.load raises ProcessingError when property mappings are malformed

## Testing
- pytest tests/test_graph_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68c974aa17b083269369e2e41dc0370c