### PR TITLE
Add rollback test for calendar events

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from datetime import datetime
 from typing import List
 
@@ -115,51 +116,56 @@ def create_event(
     graph.add_node(event.event_id, attrs)
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     try:
-        perm_graph.add_edge(
-            event.event_id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
-        )
-    except AccessDeniedError:
-        graph.add_edge(
-            event.event_id,
-            req.user_id,
-            "OWNED_BY",
-            {"permission_level": "editor"},
-            schema_version=EDGE_VERSION,
-        )
-        perm_graph.rebuild_index()
-    for uid in req.invitee_ids or []:
-        _ensure_user_node(graph, uid)
         try:
-            perm_graph.add_edge(event.event_id, uid, "INVITES")
             perm_graph.add_edge(
-                event.event_id, uid, "SHARED_WITH", {"permission_level": "viewer"}
+                event.event_id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
             )
-        except AccessDeniedError as exc:
-            raise HTTPException(status_code=403, detail=str(exc))
-    if req.group_id:
-        try:
-            perm_graph.add_edge(
+        except AccessDeniedError:
+            graph.add_edge(
                 event.event_id,
-                req.group_id,
-                "SHARED_WITH",
-                {"permission_level": "viewer"},
+                req.user_id,
+                "OWNED_BY",
+                {"permission_level": "editor"},
+                schema_version=EDGE_VERSION,
             )
-        except AccessDeniedError as exc:
-            raise HTTPException(status_code=403, detail=str(exc))
-    for lid in req.layer_ids or []:
-        layer_attrs = graph.get_node(lid)
-        if not layer_attrs or layer_attrs.get("type") != "CalendarLayer":
-            raise HTTPException(
-                status_code=400, detail=f"Invalid layer_id: {lid}"
-            )
-        if not perm_graph.node_exists(lid):
-            raise HTTPException(
-                status_code=403, detail=f"No access to layer: {lid}"
-            )
-        try:
-            perm_graph.add_edge(event.event_id, lid, "TAGGED_AS")
-        except AccessDeniedError as exc:
-            raise HTTPException(status_code=403, detail=str(exc))
+            perm_graph.rebuild_index()
+        for uid in req.invitee_ids or []:
+            _ensure_user_node(graph, uid)
+            try:
+                perm_graph.add_edge(event.event_id, uid, "INVITES")
+                perm_graph.add_edge(
+                    event.event_id, uid, "SHARED_WITH", {"permission_level": "viewer"}
+                )
+            except AccessDeniedError as exc:
+                raise HTTPException(status_code=403, detail=str(exc))
+        if req.group_id:
+            try:
+                perm_graph.add_edge(
+                    event.event_id,
+                    req.group_id,
+                    "SHARED_WITH",
+                    {"permission_level": "viewer"},
+                )
+            except AccessDeniedError as exc:
+                raise HTTPException(status_code=403, detail=str(exc))
+        for lid in req.layer_ids or []:
+            layer_attrs = graph.get_node(lid)
+            if not layer_attrs or layer_attrs.get("type") != "CalendarLayer":
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid layer_id: {lid}"
+                )
+            if not perm_graph.node_exists(lid):
+                raise HTTPException(
+                    status_code=403, detail=f"No access to layer: {lid}"
+                )
+            try:
+                perm_graph.add_edge(event.event_id, lid, "TAGGED_AS")
+            except AccessDeniedError as exc:
+                raise HTTPException(status_code=403, detail=str(exc))
+    except Exception:
+        with suppress(Exception):
+            graph.redact_node(event.event_id)
+        raise
     return CalendarEventResponse(
         event_id=event.event_id,
         title=event.title,

--- a/tests/test_calendar_event_rollback.py
+++ b/tests/test_calendar_event_rollback.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume import MockGraph
+from ume.config import settings
+
+
+def _token(client: TestClient) -> str:
+    response = client.post(
+        "/auth/token",
+        data={
+            "username": settings.UME_OAUTH_USERNAME,
+            "password": settings.UME_OAUTH_PASSWORD,
+        },
+    )
+    return response.json()["access_token"]
+
+
+@pytest.fixture
+def client_and_graph() -> tuple[TestClient, MockGraph]:
+    graph = MockGraph()
+    configure_graph(graph)
+    return TestClient(app), graph
+
+
+def test_event_creation_rolls_back_on_validation_failure(
+    client_and_graph: tuple[TestClient, MockGraph], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    event_uuid = uuid.UUID("00000000-0000-0000-0000-000000000123")
+    monkeypatch.setattr("ume.models.calendar.uuid.uuid4", lambda: event_uuid)
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    end = datetime(2024, 1, 1, 13, 0, tzinfo=timezone.utc)
+
+    response = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Team Sync",
+            "start_time": start.isoformat(),
+            "end_time": end.isoformat(),
+            "user_id": "user1",
+            "layer_ids": ["missing-layer"],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid layer_id: missing-layer"
+
+    event_id = str(event_uuid)
+    assert not graph.node_exists(event_id)
+    assert graph.get_node(event_id) is None


### PR DESCRIPTION
## Summary
- add a regression test that forces calendar event creation to fail after the node is written and asserts the graph rolls back
- update the calendar event creation route to redact the event node when subsequent validation fails

## Testing
- pytest tests/test_calendar_event_rollback.py

------
https://chatgpt.com/codex/tasks/task_e_68c990ad33688326a7f1664a9d801c60