### PR TITLE
Validate calendar event dependencies before node creation

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -112,41 +112,15 @@ def create_event(
                 status_code=400,
                 detail="Group events must have visibility public_to_group",
             )
-    graph.add_node(event.event_id, attrs)
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
-    try:
-        perm_graph.add_edge(
-            event.event_id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
-        )
-    except AccessDeniedError:
-        graph.add_edge(
-            event.event_id,
-            req.user_id,
-            "OWNED_BY",
-            {"permission_level": "editor"},
-            schema_version=EDGE_VERSION,
-        )
-        perm_graph.rebuild_index()
-    for uid in req.invitee_ids or []:
+
+    invitee_ids = list(req.invitee_ids or [])
+    layer_ids = list(req.layer_ids or [])
+
+    for uid in invitee_ids:
         _ensure_user_node(graph, uid)
-        try:
-            perm_graph.add_edge(event.event_id, uid, "INVITES")
-            perm_graph.add_edge(
-                event.event_id, uid, "SHARED_WITH", {"permission_level": "viewer"}
-            )
-        except AccessDeniedError as exc:
-            raise HTTPException(status_code=403, detail=str(exc))
-    if req.group_id:
-        try:
-            perm_graph.add_edge(
-                event.event_id,
-                req.group_id,
-                "SHARED_WITH",
-                {"permission_level": "viewer"},
-            )
-        except AccessDeniedError as exc:
-            raise HTTPException(status_code=403, detail=str(exc))
-    for lid in req.layer_ids or []:
+
+    for lid in layer_ids:
         layer_attrs = graph.get_node(lid)
         if not layer_attrs or layer_attrs.get("type") != "CalendarLayer":
             raise HTTPException(
@@ -156,10 +130,52 @@ def create_event(
             raise HTTPException(
                 status_code=403, detail=f"No access to layer: {lid}"
             )
+
+    graph.add_node(event.event_id, attrs)
+
+    try:
         try:
-            perm_graph.add_edge(event.event_id, lid, "TAGGED_AS")
-        except AccessDeniedError as exc:
-            raise HTTPException(status_code=403, detail=str(exc))
+            perm_graph.add_edge(
+                event.event_id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
+            )
+        except AccessDeniedError:
+            graph.add_edge(
+                event.event_id,
+                req.user_id,
+                "OWNED_BY",
+                {"permission_level": "editor"},
+                schema_version=EDGE_VERSION,
+            )
+            perm_graph.rebuild_index()
+
+        for uid in invitee_ids:
+            try:
+                perm_graph.add_edge(event.event_id, uid, "INVITES")
+                perm_graph.add_edge(
+                    event.event_id, uid, "SHARED_WITH", {"permission_level": "viewer"}
+                )
+            except AccessDeniedError as exc:
+                raise HTTPException(status_code=403, detail=str(exc))
+
+        if req.group_id:
+            try:
+                perm_graph.add_edge(
+                    event.event_id,
+                    req.group_id,
+                    "SHARED_WITH",
+                    {"permission_level": "viewer"},
+                )
+            except AccessDeniedError as exc:
+                raise HTTPException(status_code=403, detail=str(exc))
+
+        for lid in layer_ids:
+            try:
+                perm_graph.add_edge(event.event_id, lid, "TAGGED_AS")
+            except AccessDeniedError as exc:
+                raise HTTPException(status_code=403, detail=str(exc))
+    except Exception:
+        graph.redact_node(event.event_id)
+        raise
     return CalendarEventResponse(
         event_id=event.event_id,
         title=event.title,

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -5,6 +5,8 @@ from fastapi.testclient import TestClient
 
 from ume.api import app, configure_graph
 from ume import MockGraph
+from ume.permissions_adapter import PermissionsGraphAdapter
+from ume.rbac_adapter import AccessDeniedError
 from ume.config import settings
 from ume.models.decision_analysis import SCHEMA_VERSION
 from ume.models.proposed_action import SCHEMA_VERSION as ACTION_SCHEMA_VERSION
@@ -362,6 +364,59 @@ def test_calendar_event_invite_requires_editor(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
+
+
+def test_create_event_rollback(monkeypatch, client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    original_add_edge = PermissionsGraphAdapter.add_edge
+    created_event_ids: list[str] = []
+
+    def fail_on_invites(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs=None,
+        schema_version=None,
+    ):
+        if label == "INVITES":
+            created_event_ids.append(source_node_id)
+            raise AccessDeniedError("Invite creation failed")
+        return original_add_edge(
+            self, source_node_id, target_node_id, label, attrs, schema_version
+        )
+
+    monkeypatch.setattr(PermissionsGraphAdapter, "add_edge", fail_on_invites)
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Rollback",
+            "start_time": start,
+            "user_id": "owner",
+            "invitee_ids": ["invitee"],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert res.status_code == 403
+    assert res.json() == {"detail": "Invite creation failed"}
+
+    assert created_event_ids
+    event_id = created_event_ids[0]
+    assert event_id not in graph.get_all_node_ids()
+    assert graph.get_node(event_id) is None
+
+    visible_events = [
+        nid
+        for nid in graph.get_all_node_ids()
+        if (graph.get_node(nid) or {}).get("type") == "CalendarEvent"
+    ]
+    assert visible_events == []
 
 
 def test_calendar_event_missing_invitee_created(client_and_graph) -> None:


### PR DESCRIPTION
## Summary
- validate invitees and calendar layers before creating the event node
- defer permission edge creation until after validation and roll back the node on failure
- add a regression test that simulates a failed invite edge to ensure the event node is redacted

## Testing
- pytest tests/test_calendar_decision_api.py::test_create_event_rollback
- ruff check src tests

------
https://chatgpt.com/codex/tasks/task_e_68c990ab82c48326a8c56e61fcb7543d