### PR TITLE
Add calendar event validation and invite tests

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -18,6 +18,7 @@ from .models import (
     create_calendar_event,
     create_user,
 )
+from .processing import ProcessingError
 
 EDGE_VERSION = "3.0.0"
 
@@ -92,6 +93,8 @@ def create_event(
         rrule=req.rrule,
         visibility=req.visibility,
     )
+    invitee_ids = list(req.invitee_ids or [])
+    layer_ids = list(req.layer_ids or [])
     attrs = {
         "type": "CalendarEvent",
         "title": event.title,
@@ -106,6 +109,16 @@ def create_event(
         "schema_version": event.schema_version,
     }
     _ensure_user_node(graph, req.user_id)
+    graph.add_node(event.event_id, attrs)
+    for uid in invitee_ids:
+        _ensure_user_node(graph, uid)
+    for lid in layer_ids:
+        if not graph.node_exists(lid):
+            with suppress(ProcessingError):
+                graph.redact_node(event.event_id)
+            raise HTTPException(
+                status_code=400, detail=f"Invalid layer_id: {lid}"
+            )
     if req.group_id:
         ensure_group_member(graph, req.user_id, req.group_id)
         if event.visibility != CalendarEventVisibility.PUBLIC_TO_GROUP:
@@ -131,7 +144,6 @@ def create_event(
             perm_graph.rebuild_index()
 
         for uid in invitee_ids:
-
             try:
                 perm_graph.add_edge(event.event_id, uid, "INVITES")
                 perm_graph.add_edge(
@@ -152,13 +164,13 @@ def create_event(
                 raise HTTPException(status_code=403, detail=str(exc))
 
         for lid in layer_ids:
-
             try:
                 perm_graph.add_edge(event.event_id, lid, "TAGGED_AS")
             except AccessDeniedError as exc:
                 raise HTTPException(status_code=403, detail=str(exc))
     except Exception:
-        graph.redact_node(event.event_id)
+        with suppress(ProcessingError):
+            graph.redact_node(event.event_id)
 
         raise
     return CalendarEventResponse(

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -112,6 +112,7 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     assert res.json() == []
 
     attrs = graph.get_node(event_id)
+    assert attrs["type"] == "CalendarEvent"
     assert attrs["title"] == "Meeting"
     assert attrs["start_time"] == start_ts
     assert attrs["end_time"] == end_ts
@@ -183,7 +184,7 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
-    _own_event = res.json()
+    own_event = res.json()
 
     # Group-scoped retrieval returns the event
     res = client.get(
@@ -197,6 +198,10 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     edges = graph.get_all_edges()
     assert any(
         s == event_id and t == "group1" and lbl == "SHARED_WITH"
+        for s, t, lbl, _ in edges
+    )
+    assert not any(
+        s == own_event["event_id"] and t == "group1" and lbl == "SHARED_WITH"
         for s, t, lbl, _ in edges
     )
 
@@ -316,6 +321,7 @@ def test_calendar_event_group_and_layer_filter(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
+    wrong_layer_event = res.json()
 
     # Event tagged with the layer but not shared with the group
     res = client.post(
@@ -329,6 +335,7 @@ def test_calendar_event_group_and_layer_filter(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
+    no_group_event = res.json()
 
     # Query with both group and layer filters should return only the visible event
     res = client.get(
@@ -342,6 +349,36 @@ def test_calendar_event_group_and_layer_filter(client_and_graph) -> None:
     )
     assert res.status_code == 200
     assert res.json() == [visible_event]
+
+    edges = graph.get_all_edges()
+    assert any(
+        s == visible_event["event_id"] and t == "group1" and lbl == "SHARED_WITH"
+        for s, t, lbl, _ in edges
+    )
+    assert any(
+        s == visible_event["event_id"] and t == layer_id and lbl == "TAGGED_AS"
+        for s, t, lbl, _ in edges
+    )
+    assert any(
+        s == wrong_layer_event["event_id"] and t == "group1" and lbl == "SHARED_WITH"
+        for s, t, lbl, _ in edges
+    )
+    assert any(
+        s == wrong_layer_event["event_id"] and t == layer2_id and lbl == "TAGGED_AS"
+        for s, t, lbl, _ in edges
+    )
+    assert not any(
+        s == wrong_layer_event["event_id"] and t == layer_id and lbl == "TAGGED_AS"
+        for s, t, lbl, _ in edges
+    )
+    assert any(
+        s == no_group_event["event_id"] and t == layer_id and lbl == "TAGGED_AS"
+        for s, t, lbl, _ in edges
+    )
+    assert not any(
+        s == no_group_event["event_id"] and t == "group1" and lbl == "SHARED_WITH"
+        for s, t, lbl, _ in edges
+    )
 
 
 def test_calendar_event_invite_requires_editor(client_and_graph) -> None:
@@ -417,6 +454,8 @@ def test_create_event_rollback(monkeypatch, client_and_graph) -> None:
         if (graph.get_node(nid) or {}).get("type") == "CalendarEvent"
     ]
     assert visible_events == []
+    remaining_edges = graph.get_all_edges()
+    assert all(event_id not in (s, t) for s, t, *_ in remaining_edges)
 
 
 def test_calendar_event_missing_invitee_created(client_and_graph) -> None:
@@ -436,6 +475,20 @@ def test_calendar_event_missing_invitee_created(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
+    event_id = res.json()["event_id"]
+    invitee_attrs = graph.get_node("missing")
+    assert invitee_attrs is not None
+    assert invitee_attrs["type"] == "User"
+    assert invitee_attrs["user_id"] == "missing"
+    edges = graph.get_all_edges()
+    assert any(
+        s == event_id and t == "missing" and lbl == "INVITES"
+        for s, t, lbl, _ in edges
+    )
+    assert any(
+        s == event_id and t == "missing" and lbl == "SHARED_WITH"
+        for s, t, lbl, _ in edges
+    )
 
 
 def test_calendar_event_group_share_requires_editor(client_and_graph) -> None:

--- a/tests/test_calendar_event_validation.py
+++ b/tests/test_calendar_event_validation.py
@@ -54,9 +54,37 @@ def test_valid_event_creation(client_and_graph) -> None:
     )
     assert res.status_code == 200
     event_id = res.json()["event_id"]
+    assert graph.node_exists(event_id)
     attrs = graph.get_node(event_id)
+    assert attrs["type"] == "CalendarEvent"
     assert attrs["start_time"] == int(start_dt.timestamp())
     assert attrs["end_time"] == int(end_dt.timestamp())
+
+
+def test_invalid_layer_id_returns_message(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Layered",
+            "start_time": start,
+            "user_id": "user1",
+            "layer_ids": ["missing-layer"],
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert res.status_code == 400
+    assert res.json() == {"detail": "Invalid layer_id: missing-layer"}
+    calendar_nodes = [
+        nid
+        for nid in graph.get_all_node_ids()
+        if (graph.get_node(nid) or {}).get("type") == "CalendarEvent"
+    ]
+    assert calendar_nodes == []
 
 
 def test_group_event_private_visibility_rejected(client_and_graph) -> None:

--- a/tests/test_calendar_invites.py
+++ b/tests/test_calendar_invites.py
@@ -31,10 +31,8 @@ def test_calendar_event_invites_create_edges_and_access(client_and_graph) -> Non
     client, graph = client_and_graph
     token = _token(client)
 
-    # Pre-create nodes for owner and invitees
+    # Pre-create node for the owner only; invitees should be auto-created
     graph.add_node("owner", {"type": "User"})
-    graph.add_node("invitee1", {"type": "User"})
-    graph.add_node("invitee2", {"type": "User"})
 
     start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
 
@@ -53,6 +51,10 @@ def test_calendar_event_invites_create_edges_and_access(client_and_graph) -> Non
 
     edges = graph.get_all_edges()
     for uid in ["invitee1", "invitee2"]:
+        attrs = graph.get_node(uid)
+        assert attrs is not None
+        assert attrs["type"] == "User"
+        assert attrs["user_id"] == uid
         assert any(
             s == event_id and t == uid and lbl == "INVITES" for s, t, lbl, _ in edges
         )


### PR DESCRIPTION
## Summary
- persist calendar events with placeholder invitees and validate layer ids before tagging
- suppress redundant redact failures during rollback
- expand calendar API tests to cover event persistence, placeholder invitees, detailed errors, and permission-scoped edges

## Testing
- pytest tests/test_calendar_event_validation.py tests/test_calendar_invites.py tests/test_calendar_decision_api.py

------
https://chatgpt.com/codex/tasks/task_e_68cadbbe68508326942db2dd7fca1879