### PR TITLE
Update schema upgrade tests for schema_version metadata

### DIFF
--- a/src/ume/schema_manager.py
+++ b/src/ume/schema_manager.py
@@ -88,7 +88,13 @@ class GraphSchemaManager:
                 for src, tgt, label, *_ in list(graph.get_all_edges()):
                     if label == "L":
                         graph.delete_edge(src, tgt, label)
-                        graph.add_edge(src, tgt, "LINKS_TO")
+                        edge_def = new_schema.edge_labels.get("LINKS_TO")
+                        graph.add_edge(
+                            src,
+                            tgt,
+                            "LINKS_TO",
+                            schema_version=edge_def.version if edge_def else None,
+                        )
                     elif label == "TO_DELETE":
                         graph.delete_edge(src, tgt, label)
 
@@ -97,7 +103,15 @@ class GraphSchemaManager:
                     if label == "NEW_LABEL":
                         graph.delete_edge(src, tgt, label)
                         new_attrs = dict(attrs) if isinstance(attrs, dict) else {}
-                        graph.add_edge(src, tgt, "TAGGED_AS", new_attrs)
+                        new_attrs.pop("version", None)
+                        edge_def = new_schema.edge_labels.get("TAGGED_AS")
+                        graph.add_edge(
+                            src,
+                            tgt,
+                            "TAGGED_AS",
+                            new_attrs,
+                            schema_version=edge_def.version if edge_def else None,
+                        )
                     elif label == "HAS_PERMISSION":
                         graph.delete_edge(src, tgt, label)
                         attr_dict = dict(attrs) if isinstance(attrs, dict) else {}
@@ -107,7 +121,17 @@ class GraphSchemaManager:
                             else attrs
                         )
                         new_label = "OWNED_BY" if perm_level == "editor" else "SHARED_WITH"
-                        graph.add_edge(src, tgt, new_label, attr_dict)
+                        if perm_level is not None and "permission_level" not in attr_dict:
+                            attr_dict["permission_level"] = perm_level
+                        attr_dict.pop("version", None)
+                        edge_def = new_schema.edge_labels.get(new_label)
+                        graph.add_edge(
+                            src,
+                            tgt,
+                            new_label,
+                            attr_dict,
+                            schema_version=edge_def.version if edge_def else None,
+                        )
                         if graph.node_exists(tgt):
                             node_attrs = graph.get_node(tgt) or {}
                             node_attrs.setdefault("type", "User")
@@ -122,7 +146,7 @@ class GraphSchemaManager:
                     }:
                         graph.delete_edge(src, tgt, label)
 
-            # Ensure all edges carry explicit version and permission metadata
+            # Ensure all edges carry explicit schema version and permission metadata
             for src, tgt, label, attrs in list(graph.get_all_edges()):
                 edge_def = new_schema.edge_labels.get(label)
                 if edge_def is None:
@@ -135,12 +159,29 @@ class GraphSchemaManager:
                 ):
                     attr_dict["permission_level"] = edge_def.permission_level
                     needs_update = True
-                if attr_dict.get("version") != edge_def.version:
-                    attr_dict["version"] = edge_def.version
+                current_version = attr_dict.pop("version", None)
+                schema_version = attr_dict.get("schema_version")
+                if schema_version != edge_def.version:
+                    attr_dict["schema_version"] = edge_def.version
+                    needs_update = True
+                elif current_version is not None and schema_version is None:
+                    attr_dict["schema_version"] = current_version
                     needs_update = True
                 if needs_update:
                     graph.delete_edge(src, tgt, label)
-                    graph.add_edge(src, tgt, label, attr_dict)
+                    graph.add_edge(
+                        src,
+                        tgt,
+                        label,
+                        attr_dict,
+                        schema_version=edge_def.version,
+                    )
+
+            # Ensure nodes carry an explicit schema version metadata
+            for node_id in graph.get_all_node_ids():
+                attrs = graph.get_node(node_id) or {}
+                if "schema_version" not in attrs:
+                    graph.update_node(node_id, {"schema_version": new_schema.version})
 
         return new_schema
 

--- a/tests/test_schema_manager.py
+++ b/tests/test_schema_manager.py
@@ -95,7 +95,7 @@ def test_upgrade_transforms_graph(graph: PersistentGraph) -> None:
     manager.upgrade_schema("1.0.0", "2.0.0", graph)
 
     edges = graph.get_all_edges()
-    assert ("a", "b", "LINKS_TO", {"version": "2.0.0"}) in edges
+    assert ("a", "b", "LINKS_TO", {"schema_version": "2.0.0"}) in edges
     assert all(lbl != "L" for _, _, lbl, _ in edges)
     assert all(lbl != "TO_DELETE" for _, _, lbl, _ in edges)
 
@@ -116,7 +116,7 @@ def test_upgrade_to_v3_transforms_graph(graph: PersistentGraph) -> None:
         "a",
         "b",
         "TAGGED_AS",
-        {"version": "3.0.0"},
+        {"schema_version": "3.0.0"},
     ) in edges
     assert all(lbl == "TAGGED_AS" for _, _, lbl, _ in edges)
 
@@ -134,7 +134,7 @@ def test_upgrade_sets_edge_version(graph: PersistentGraph) -> None:
         "a",
         "b",
         "TAGGED_AS",
-        {"version": "3.0.0"},
+        {"schema_version": "3.0.0"},
     ) in edges
 
 
@@ -159,13 +159,13 @@ def test_upgrade_maps_has_permission_edges(
         "doc",
         "user1",
         "OWNED_BY",
-        {"permission_level": "editor", "version": "3.0.0"},
+        {"permission_level": "editor", "schema_version": "3.0.0"},
     ) in edges
     assert (
         "doc",
         "user2",
         "SHARED_WITH",
-        {"permission_level": "viewer", "version": "3.0.0"},
+        {"permission_level": "viewer", "schema_version": "3.0.0"},
     ) in edges
     assert all(lbl != "HAS_PERMISSION" for _, _, lbl, _ in edges)
 
@@ -185,21 +185,23 @@ def test_upgrade_permission_nodes_multi_user(graph: PersistentGraph) -> None:
         "doc",
         "u1",
         "SHARED_WITH",
-        {"permission_level": "viewer", "version": "3.0.0"},
+        {"permission_level": "viewer", "schema_version": "3.0.0"},
     ) in edges
     assert (
         "doc",
         "u2",
         "OWNED_BY",
-        {"permission_level": "editor", "version": "3.0.0"},
+        {"permission_level": "editor", "schema_version": "3.0.0"},
     ) in edges
 
     assert graph.get_node("u1") == {
         "type": "User",
+        "schema_version": "3.0.0",
     }
     assert graph.get_node("u2") == {
         "name": "Bob",
         "type": "User",
+        "schema_version": "3.0.0",
     }
 
 
@@ -219,7 +221,7 @@ def test_upgrade_preserves_schema_version(graph: PersistentGraph) -> None:
         "a",
         "b",
         "TAGGED_AS",
-        {"schema_version": "2.0.0", "version": "3.0.0"},
+        {"schema_version": "3.0.0"},
     ) in edges
 
 
@@ -236,5 +238,7 @@ def test_upgrade_adds_version_when_missing(graph: PersistentGraph) -> None:
         "a",
         "b",
         "TAGGED_AS",
-        {"version": "3.0.0"},
+        {"schema_version": "3.0.0"},
     ) in edges
+    assert graph.get_node("a")["schema_version"] == "3.0.0"
+    assert graph.get_node("b")["schema_version"] == "3.0.0"

--- a/tests/test_schema_versioning.py
+++ b/tests/test_schema_versioning.py
@@ -37,3 +37,5 @@ def test_permission_edge_schema_version() -> None:
         if s == "Document.d1" and t == "User.u2" and lbl == "SHARED_WITH"
     )
     assert edge_attrs["schema_version"] == "3.0.0"
+    assert edge_attrs["permission_level"] == "viewer"
+    assert "version" not in edge_attrs


### PR DESCRIPTION
## Summary
- switch GraphSchemaManager upgrades to write schema_version metadata on edges and nodes while preserving permission level attributes
- adjust schema manager regression tests to assert schema_version fields and ensure permission edges retain permission levels
- extend schema versioning tests to verify permission edges emit schema_version metadata without legacy version keys

## Testing
- pytest tests/test_schema_manager.py tests/test_schema_versioning.py

------
https://chatgpt.com/codex/tasks/task_e_68cd65177f388326a1640f4a1d3bc75e