### PR TITLE
Persist Redis edge attributes

### DIFF
--- a/src/ume/redis_graph_adapter.py
+++ b/src/ume/redis_graph_adapter.py
@@ -11,6 +11,7 @@ from .graph_algorithms import GraphAlgorithmsMixin
 from .audit import log_audit_entry
 from .config import settings
 from .replay import replay_from_ledger
+from .graph_schema import DEFAULT_SCHEMA
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .event_ledger import EventLedger
@@ -25,6 +26,7 @@ class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
     NODE_PREFIX = "node:"
     EDGE_PREFIX = "edge:"
     EDGE_SET_KEY = f"{EDGE_PREFIX}all"
+    EDGE_ATTR_HASH_KEY = f"{EDGE_PREFIX}attrs"
     REDACTED_NODES_KEY = "redacted_nodes"
     REDACTED_EDGES_KEY = "redacted_edges"
 
@@ -123,10 +125,21 @@ class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
             raise ProcessingError(
                 f"Edge ({source_node_id}, {target_node_id}, {label}) already exists."
             )
-        self._client.sadd(self.EDGE_SET_KEY, member)
+        edge_def = DEFAULT_SCHEMA.edge_labels.get(label)
+        permission_level = edge_def.permission_level if edge_def else None
+        attr_dict: Dict[str, Any] = dict(attrs or {})
+        if permission_level is not None and "permission_level" not in attr_dict:
+            attr_dict["permission_level"] = permission_level
+        if schema_version is not None and "schema_version" not in attr_dict:
+            attr_dict["schema_version"] = schema_version
+        pipe = self._client.pipeline()
+        pipe.sadd(self.EDGE_SET_KEY, member)
+        pipe.hset(self.EDGE_ATTR_HASH_KEY, member, json.dumps(attr_dict))
+        pipe.execute()
 
     def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:
         result: List[Tuple[str, str, str, Dict[str, Any]]] = []
+        attr_map = self._client.hgetall(self.EDGE_ATTR_HASH_KEY)
         for b in self._client.smembers(self.EDGE_SET_KEY):
             member = b.decode()
             if self._client.sismember(self.REDACTED_EDGES_KEY, member):
@@ -137,7 +150,39 @@ class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
                 tgt,
             ):
                 continue
-            result.append((src, tgt, lbl, {}))
+            raw_attrs = attr_map.get(b)
+            attrs: Dict[str, Any]
+            needs_store = False
+            if raw_attrs is None:
+                attrs = {}
+                needs_store = True
+            else:
+                try:
+                    decoded = raw_attrs.decode()
+                    loaded = json.loads(decoded)
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    attrs = {}
+                    needs_store = True
+                else:
+                    if isinstance(loaded, dict):
+                        attrs = cast(Dict[str, Any], loaded)
+                    else:
+                        attrs = {}
+                        needs_store = True
+            edge_def = DEFAULT_SCHEMA.edge_labels.get(lbl)
+            if edge_def is not None:
+                if (
+                    edge_def.permission_level is not None
+                    and "permission_level" not in attrs
+                ):
+                    attrs["permission_level"] = edge_def.permission_level
+                    needs_store = True
+                if "schema_version" not in attrs:
+                    attrs["schema_version"] = edge_def.version
+                    needs_store = True
+            if needs_store:
+                self._client.hset(self.EDGE_ATTR_HASH_KEY, member, json.dumps(attrs))
+            result.append((src, tgt, lbl, dict(attrs)))
         return result
 
     def delete_edge(
@@ -152,7 +197,10 @@ class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
             raise ProcessingError(
                 f"Edge {(source_node_id, target_node_id, label)} does not exist and cannot be deleted."
             )
-        self._client.srem(self.REDACTED_EDGES_KEY, member)
+        pipe = self._client.pipeline()
+        pipe.srem(self.REDACTED_EDGES_KEY, member)
+        pipe.hdel(self.EDGE_ATTR_HASH_KEY, member)
+        pipe.execute()
 
     def find_connected_nodes(self, node_id: str, edge_label: Optional[str] = None) -> List[str]:
         if not self.node_exists(node_id):
@@ -185,7 +233,10 @@ class RedisGraphAdapter(GraphAlgorithmsMixin, IGraphAdapter):
             raise ProcessingError(
                 f"Edge {(source_node_id, target_node_id, label)} does not exist and cannot be redacted."
             )
-        self._client.sadd(self.REDACTED_EDGES_KEY, member)
+        pipe = self._client.pipeline()
+        pipe.sadd(self.REDACTED_EDGES_KEY, member)
+        pipe.hdel(self.EDGE_ATTR_HASH_KEY, member)
+        pipe.execute()
         log_audit_entry(
             settings.UME_AGENT_ID,
             f"redact_edge {source_node_id} {target_node_id} {label}",

--- a/tests/test_graph_adapters_integration.py
+++ b/tests/test_graph_adapters_integration.py
@@ -3,6 +3,8 @@ import pytest
 
 from ume.postgres_graph import PostgresGraph
 from ume.redis_graph_adapter import RedisGraphAdapter
+from ume.permissions_adapter import PermissionsGraphAdapter
+from ume.graph_schema import DEFAULT_SCHEMA
 import redis
 
 
@@ -75,4 +77,39 @@ def test_redis_clear_preserves_unrelated_keys(redis_service):
     assert not client.exists(RedisGraphAdapter.REDACTED_NODES_KEY)
     assert not client.exists(RedisGraphAdapter.REDACTED_EDGES_KEY)
     client.close()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("UME_DOCKER_TESTS"), reason="Docker tests disabled")
+def test_permissions_adapter_with_redis(redis_service):
+    graph = RedisGraphAdapter(redis_service["url"])
+    resource_id = "Document.redis_doc"
+    user_id = "User.redis_owner"
+    schema_version = DEFAULT_SCHEMA.get_edge_version("OWNED_BY")
+    try:
+        graph.add_node(resource_id, {"type": "Document"})
+        graph.add_node(user_id, {"type": "User"})
+        graph.add_edge(
+            resource_id,
+            user_id,
+            "OWNED_BY",
+            {"permission_level": "editor"},
+            schema_version=schema_version,
+        )
+
+        edges = graph.get_all_edges()
+        assert any(
+            s == resource_id
+            and t == user_id
+            and lbl == "OWNED_BY"
+            and edge_attrs.get("permission_level") == "editor"
+            and edge_attrs.get("schema_version") == schema_version
+            for s, t, lbl, edge_attrs in edges
+        )
+
+        permissions_graph = PermissionsGraphAdapter(graph, user_id=user_id)
+        assert resource_id in permissions_graph.get_nodes_by_user(user_id)
+    finally:
+        graph.clear()
+        graph.close()
 


### PR DESCRIPTION
## Summary
- persist Redis edge attributes alongside edge membership and enrich fetched edges with stored metadata
- clean up Redis edge attribute records when edges are deleted or redacted and gracefully backfill metadata for older deployments
- add an integration test ensuring PermissionsGraphAdapter can see OWNED_BY edges when backed by Redis

## Testing
- pytest tests/test_graph_adapters_integration.py::test_permissions_adapter_with_redis *(fails: ModuleNotFoundError: No module named 'fastapi')*
- ruff check src/ume/redis_graph_adapter.py tests/test_graph_adapters_integration.py


------
https://chatgpt.com/codex/tasks/task_e_68d1490aec68832689cdac068e2b4a91