### PR TITLE
Ensure Neo4j edges expose permission metadata

### DIFF
--- a/src/ume/neo4j_graph.py
+++ b/src/ume/neo4j_graph.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional, cast
 import time
 
@@ -14,6 +15,34 @@ from .graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .graph_algorithms import GraphAlgorithmsMixin
 from .replay_mixin import ReplayMixin
+
+
+def _apply_edge_metadata_defaults(
+    label: str,
+    attrs: Dict[str, Any],
+    *,
+    edge_def: Any | None,
+    schema_version: str | None = None,
+) -> None:
+    """Populate permission and schema metadata defaults for an edge."""
+
+    perm_level = None
+    if edge_def is not None:
+        perm_level = getattr(edge_def, "permission_level", None)
+    if perm_level is None:
+        if label == "OWNED_BY":
+            perm_level = "editor"
+        elif label == "SHARED_WITH":
+            perm_level = "viewer"
+    if perm_level is not None:
+        attrs.setdefault("permission_level", perm_level)
+
+    if schema_version is not None:
+        attrs.setdefault("schema_version", schema_version)
+    elif edge_def is not None:
+        version = getattr(edge_def, "version", None)
+        if version is not None:
+            attrs.setdefault("schema_version", version)
 
 
 class Neo4jGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
@@ -142,6 +171,7 @@ class Neo4jGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
     ) -> None:
         schema = DEFAULT_SCHEMA_MANAGER.get_schema(DEFAULT_VERSION)
         schema.validate_edge_label(label)
+        edge_def = schema.edge_labels.get(label)
         escaped_label = label.replace("`", "``")
         with self._driver.session() as session:
             result = session.run(
@@ -166,8 +196,12 @@ class Neo4jGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
                 )
             props = {"redacted": False, "created_at": int(time.time())}
             attr_dict: Dict[str, Any] = dict(attrs or {})
-            if schema_version is not None and "schema_version" not in attr_dict:
-                attr_dict["schema_version"] = schema_version
+            _apply_edge_metadata_defaults(
+                label,
+                attr_dict,
+                edge_def=edge_def,
+                schema_version=schema_version,
+            )
             if attr_dict:
                 props.update(attr_dict)
             session.run(
@@ -176,6 +210,7 @@ class Neo4jGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
             )
 
     def get_all_edges(self) -> List[tuple[str, str, str, Dict[str, Any]]]:
+        schema = DEFAULT_SCHEMA_MANAGER.get_schema(DEFAULT_VERSION)
         with self._driver.session() as session:
             result = session.run(
                 "MATCH (s)-[r]->(t) "
@@ -184,7 +219,23 @@ class Neo4jGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
                 "AND coalesce(t.redacted, false) = false "
                 "RETURN s.id AS src, t.id AS tgt, type(r) AS label, properties(r) AS attrs"
             )
-            return [(rec["src"], rec["tgt"], rec["label"], {}) for rec in result]
+            edges: List[tuple[str, str, str, Dict[str, Any]]] = []
+            for rec in result:
+                raw_attrs = rec["attrs"]
+                if raw_attrs is None:
+                    attrs: Dict[str, Any] = {}
+                elif isinstance(raw_attrs, Mapping):
+                    attrs = dict(raw_attrs)
+                else:
+                    try:
+                        attrs = dict(raw_attrs)
+                    except TypeError:
+                        attrs = {}
+                label = cast(str, rec["label"])
+                edge_def = schema.edge_labels.get(label)
+                _apply_edge_metadata_defaults(label, attrs, edge_def=edge_def)
+                edges.append((cast(str, rec["src"]), cast(str, rec["tgt"]), label, attrs))
+            return edges
 
 
     def delete_edge(

--- a/tests/test_graph_adapters_integration.py
+++ b/tests/test_graph_adapters_integration.py
@@ -3,6 +3,7 @@ import pytest
 
 from ume.postgres_graph import PostgresGraph
 from ume.redis_graph_adapter import RedisGraphAdapter
+from ume.neo4j_graph import Neo4jGraph
 from ume.permissions_adapter import PermissionsGraphAdapter
 from ume.graph_schema import DEFAULT_SCHEMA
 import redis
@@ -125,6 +126,62 @@ def test_permissions_adapter_with_redis(redis_service):
 
         permissions_graph = PermissionsGraphAdapter(graph, user_id=user_id)
         assert resource_id in permissions_graph.get_nodes_by_user(user_id)
+    finally:
+        graph.clear()
+        graph.close()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("UME_DOCKER_TESTS"), reason="Docker tests disabled")
+def test_permissions_adapter_with_neo4j(neo4j_service):
+    graph = Neo4jGraph(
+        neo4j_service["uri"],
+        neo4j_service["user"],
+        neo4j_service["password"],
+    )
+    resource_id = "Document.neo4j_doc"
+    shared_id = "Document.neo4j_shared"
+    user_id = "User.neo4j_owner"
+    owned_perm = DEFAULT_SCHEMA.edge_labels.get("OWNED_BY")
+    shared_perm = DEFAULT_SCHEMA.edge_labels.get("SHARED_WITH")
+    expected_owned_perm = owned_perm.permission_level if owned_perm else None
+    if expected_owned_perm is None:
+        expected_owned_perm = "editor"
+    expected_shared_perm = shared_perm.permission_level if shared_perm else None
+    if expected_shared_perm is None:
+        expected_shared_perm = "viewer"
+    owned_version = DEFAULT_SCHEMA.get_edge_version("OWNED_BY")
+    shared_version = DEFAULT_SCHEMA.get_edge_version("SHARED_WITH")
+    try:
+        graph.clear()
+        graph.add_node(resource_id, {"type": "Document"})
+        graph.add_node(shared_id, {"type": "Document"})
+        graph.add_node(user_id, {"type": "User"})
+        graph.add_edge(resource_id, user_id, "OWNED_BY")
+        graph.add_edge(shared_id, user_id, "SHARED_WITH")
+
+        edges = graph.get_all_edges()
+        assert any(
+            s == resource_id
+            and t == user_id
+            and lbl == "OWNED_BY"
+            and edge_attrs.get("permission_level") == expected_owned_perm
+            and edge_attrs.get("schema_version") == owned_version
+            for s, t, lbl, edge_attrs in edges
+        )
+        assert any(
+            s == shared_id
+            and t == user_id
+            and lbl == "SHARED_WITH"
+            and edge_attrs.get("permission_level") == expected_shared_perm
+            and edge_attrs.get("schema_version") == shared_version
+            for s, t, lbl, edge_attrs in edges
+        )
+
+        permissions_graph = PermissionsGraphAdapter(graph, user_id=user_id)
+        nodes = permissions_graph.get_nodes_by_user(user_id)
+        assert resource_id in nodes
+        assert shared_id in nodes
     finally:
         graph.clear()
         graph.close()

--- a/tests/test_neo4j_graph.py
+++ b/tests/test_neo4j_graph.py
@@ -1,10 +1,12 @@
 import pytest
 
+from types import MappingProxyType
 from typing import cast
 
 from neo4j import Driver
 from ume.neo4j_graph import Neo4jGraph
-from ume.processing import ProcessingError
+from ume.processing import ProcessingError, DEFAULT_VERSION
+from ume.schema_manager import DEFAULT_SCHEMA_MANAGER
 
 
 class DummyResult:
@@ -63,14 +65,14 @@ def test_node_and_edge_crud():
 
     graph.add_node("n1", {})
     graph.add_node("n2", {})
-    graph.add_edge("n1", "n2", "RELATES_TO")
-    graph.delete_edge("n1", "n2", "RELATES_TO")
+    graph.add_edge("n1", "n2", "TAGGED_AS")
+    graph.delete_edge("n1", "n2", "TAGGED_AS")
 
     assert len(driver.session_obj.calls) == 8
 
 
 def test_add_edge_parameterized_label():
-    label = "RELATES_TO"
+    label = "TAGGED_AS"
     results = [
         DummyResult({"scnt": 1, "tcnt": 1}),  # check nodes exist
         DummyResult({"cnt": 0}),  # check existing edge
@@ -94,7 +96,7 @@ def test_add_edge_parameterized_label():
     assert check_params == {"src": "s1", "tgt": "t1"}
     assert create_params["src"] == "s1"
     assert create_params["tgt"] == "t1"
-    assert isinstance(create_params.get("ts"), int)
+    assert isinstance(create_params["props"]["created_at"], int)
 
 
 def test_add_node_duplicate_raises():
@@ -202,3 +204,63 @@ def test_purge_old_records_issues_queries() -> None:
     assert "n.created_at < $cutoff" in delete_nodes_query
     assert delete_edges_params == delete_nodes_params
     assert isinstance(delete_edges_params["cutoff"], int)
+
+
+def test_add_edge_populates_permission_metadata() -> None:
+    results = [
+        DummyResult({"scnt": 1, "tcnt": 1}),
+        DummyResult({"cnt": 0}),
+        DummyResult(None),
+    ]
+    driver = DummyDriver(results)
+    graph = Neo4jGraph(
+        "bolt://localhost:7687",
+        "neo4j",
+        "pass",
+        driver=cast(Driver, driver),
+    )
+
+    graph.add_edge("doc", "user", "SHARED_WITH")
+
+    _, params = driver.session_obj.calls[-1]
+    props = params["props"]
+    schema = DEFAULT_SCHEMA_MANAGER.get_schema(DEFAULT_VERSION)
+    edge_def = schema.edge_labels["SHARED_WITH"]
+    expected_perm = edge_def.permission_level or "viewer"
+    assert props["permission_level"] == expected_perm
+    assert props["schema_version"] == edge_def.version
+    assert props["redacted"] is False
+
+
+def test_get_all_edges_returns_plain_dict_with_defaults() -> None:
+    raw_attrs = MappingProxyType({"redacted": False})
+    records = [
+        {
+            "src": "Document.d1",
+            "tgt": "User.u1",
+            "label": "SHARED_WITH",
+            "attrs": raw_attrs,
+        }
+    ]
+    driver = DummyDriver([records])
+    graph = Neo4jGraph(
+        "bolt://localhost:7687",
+        "neo4j",
+        "pass",
+        driver=cast(Driver, driver),
+    )
+
+    edges = graph.get_all_edges()
+    assert len(edges) == 1
+    src, tgt, label, attrs = edges[0]
+    assert src == "Document.d1"
+    assert tgt == "User.u1"
+    assert label == "SHARED_WITH"
+    assert isinstance(attrs, dict)
+    assert attrs is not raw_attrs
+    schema = DEFAULT_SCHEMA_MANAGER.get_schema(DEFAULT_VERSION)
+    edge_def = schema.edge_labels["SHARED_WITH"]
+    expected_perm = edge_def.permission_level or "viewer"
+    assert attrs["permission_level"] == expected_perm
+    assert attrs["schema_version"] == edge_def.version
+    assert attrs["redacted"] is False


### PR DESCRIPTION
## Summary
- normalize Neo4j edge attributes via a shared helper so defaults for permission-level and schema metadata are always applied
- update `Neo4jGraph.get_all_edges` to return concrete dicts and surface stored properties instead of dropping them
- expand Neo4j-focused tests to cover permission metadata and adapter behavior, including a docker-guarded integration check for `PermissionsGraphAdapter`

## Testing
- `poetry run pytest tests/test_neo4j_graph.py tests/test_graph_adapters_integration.py`
- `poetry run ruff check src/ume/neo4j_graph.py tests/test_neo4j_graph.py tests/test_graph_adapters_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_68d29fec5f2c8326a465d72d6564a833