### PR TITLE
Fix Arango edge attribute handling and add tests

### DIFF
--- a/src/ume/arango_graph.py
+++ b/src/ume/arango_graph.py
@@ -132,9 +132,13 @@ class ArangoGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
             raise ProcessingError(
                 f"Both source node '{source_node_id}' and target node '{target_node_id}' must exist to add an edge."
             )
+        from .graph_schema import DEFAULT_SCHEMA  # local import to avoid circular deps
+
         key = self._edge_key(source_node_id, target_node_id, label)
         if self._edges.has(key):
             raise ProcessingError(f"Edge ({source_node_id}, {target_node_id}, {label}) already exists.")
+        edge_def = DEFAULT_SCHEMA.edge_labels.get(label)
+        permission_level = edge_def.permission_level if edge_def else None
         doc = {
             "_key": key,
             "source": source_node_id,
@@ -144,20 +148,48 @@ class ArangoGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
             "created_at": int(time.time()),
         }
         attr_dict: Dict[str, Any] = dict(attrs or {})
+        if permission_level is not None and "permission_level" not in attr_dict:
+            attr_dict["permission_level"] = permission_level
         if schema_version is not None and "schema_version" not in attr_dict:
             attr_dict["schema_version"] = schema_version
-        if attr_dict:
-            doc["attrs"] = attr_dict
+        doc["attrs"] = attr_dict
         self._edges.insert(doc)
 
     def get_all_edges(self) -> List[Tuple[str, str, str, Dict[str, Any]]]:
         result: List[Tuple[str, str, str, Dict[str, Any]]] = []
+        from .graph_schema import DEFAULT_SCHEMA  # local import to avoid circular deps
+
         for e in cast(Iterable[Dict[str, Any]], self._edges.all()):
             if e.get("redacted"):
                 continue
             if not self.node_exists(e["source"]) or not self.node_exists(e["target"]):
                 continue
-            result.append((e["source"], e["target"], e["label"], {}))
+            raw_attrs = e.get("attrs")
+            needs_update = False
+            if isinstance(raw_attrs, dict):
+                attr_dict = dict(raw_attrs)
+            else:
+                attr_dict = {}
+                if raw_attrs not in (None, ""):
+                    needs_update = True
+            if raw_attrs is None:
+                needs_update = True
+            edge_def = DEFAULT_SCHEMA.edge_labels.get(e["label"])
+            if edge_def is not None:
+                if (
+                    edge_def.permission_level is not None
+                    and "permission_level" not in attr_dict
+                ):
+                    attr_dict["permission_level"] = edge_def.permission_level
+                    needs_update = True
+                if "schema_version" not in attr_dict:
+                    attr_dict["schema_version"] = edge_def.version
+                    needs_update = True
+            if needs_update:
+                updated = e.copy()
+                updated["attrs"] = attr_dict
+                self._edges.update(updated)
+            result.append((e["source"], e["target"], e["label"], dict(attr_dict)))
 
         return result
 
@@ -204,8 +236,10 @@ class ArangoGraph(ReplayMixin, GraphAlgorithmsMixin, IGraphAdapter):
             raise ProcessingError(
                 f"Edge {(source_node_id, target_node_id, label)} does not exist and cannot be redacted."
             )
-        doc["redacted"] = True
-        self._edges.update(doc)
+        sanitized = doc.copy()
+        sanitized["redacted"] = True
+        sanitized["attrs"] = {}
+        self._edges.update(sanitized)
         log_audit_entry(settings.UME_AGENT_ID, f"redact_edge {source_node_id} {target_node_id} {label}")
 
     # ---- Misc utilities -----------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import importlib
 from typing import Generator
 from pathlib import Path
 import os
+import time
 
 # Force pure-Python protobuf implementation for compatibility with Python 3.12
 os.environ.setdefault("PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION", "python")
@@ -344,6 +345,41 @@ def redis_service():
     port = container.get_exposed_port(6379)  # type: ignore[no-untyped-call]
     host = container.get_container_host_ip()
     yield {"url": f"redis://{host}:{port}/0"}
+    container.stop()  # type: ignore[no-untyped-call]
+
+
+@pytest.fixture(scope="session")
+def arango_service():
+    """Launch an ArangoDB container for integration tests."""
+    if not _docker_enabled():
+        pytest.skip("Docker-based tests disabled")
+    if DockerContainer is None:
+        pytest.skip("Docker test container support not available")
+    try:
+        from arango import ArangoClient  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency missing
+        pytest.skip("python-arango not installed")
+    container = DockerContainer("arangodb:3.11")
+    container.with_env("ARANGO_ROOT_PASSWORD", "test")  # type: ignore[no-untyped-call]
+    container.with_exposed_ports(8529)  # type: ignore[no-untyped-call]
+    try:
+        container.start()  # type: ignore[no-untyped-call]
+    except Exception as exc:  # pragma: no cover - environment issues
+        pytest.skip(f"ArangoDB not available: {exc}")
+    host = container.get_container_host_ip()
+    port = container.get_exposed_port(8529)  # type: ignore[no-untyped-call]
+    url = f"http://{host}:{port}"
+    client = ArangoClient(hosts=url)
+    for _ in range(30):
+        try:
+            client.db("_system", username="root", password="test")
+            break
+        except Exception:
+            time.sleep(1)
+    else:  # pragma: no cover - container failed to start
+        container.stop()  # type: ignore[no-untyped-call]
+        pytest.skip("ArangoDB did not become ready in time")
+    yield {"url": url, "user": "root", "password": "test"}
     container.stop()  # type: ignore[no-untyped-call]
 
 

--- a/tests/test_arango_graph.py
+++ b/tests/test_arango_graph.py
@@ -73,7 +73,10 @@ def test_node_and_edge_crud():
     graph.update_node("n1", {"v": 2})
     assert graph.get_node("n1")["v"] == 2
     graph.add_edge("n1", "n2", "R")
-    assert ("n1", "n2", "R", {}) in graph.get_all_edges()
+    edges = graph.get_all_edges()
+    assert ("n1", "n2", "R", {}) in edges
+    key = graph._edge_key("n1", "n2", "R")
+    assert db.collection("edges").docs[key]["attrs"] == {}
     graph.delete_edge("n1", "n2", "R")
     assert graph.get_all_edges() == []
 
@@ -95,3 +98,53 @@ def test_find_connected_nodes_filters_label():
     graph.add_edge("a", "b", "L1")
     graph.add_edge("a", "c", "L2")
     assert graph.find_connected_nodes("a", edge_label="L1") == ["b"]
+
+
+def test_add_edge_records_attrs():
+    db = DummyDatabase()
+    graph = ArangoGraph("http://localhost:8529", "root", "pass", db=db)
+    graph.add_node("doc", {"type": "Document"})
+    graph.add_node("user", {"type": "User"})
+    schema_version = "3.0.0"
+    graph.add_edge(
+        "doc",
+        "user",
+        "OWNED_BY",
+        {"permission_level": "editor"},
+        schema_version=schema_version,
+    )
+    edges = graph.get_all_edges()
+    assert edges == [
+        (
+            "doc",
+            "user",
+            "OWNED_BY",
+            {"permission_level": "editor", "schema_version": schema_version},
+        )
+    ]
+    key = graph._edge_key("doc", "user", "OWNED_BY")
+    stored = db.collection("edges").docs[key]
+    assert stored["attrs"] == {
+        "permission_level": "editor",
+        "schema_version": schema_version,
+    }
+
+
+def test_redact_edge_clears_attrs():
+    db = DummyDatabase()
+    graph = ArangoGraph("http://localhost:8529", "root", "pass", db=db)
+    graph.add_node("doc", {"type": "Document"})
+    graph.add_node("user", {"type": "User"})
+    schema_version = "3.0.0"
+    graph.add_edge(
+        "doc",
+        "user",
+        "OWNED_BY",
+        {"permission_level": "editor"},
+        schema_version=schema_version,
+    )
+    graph.redact_edge("doc", "user", "OWNED_BY")
+    key = graph._edge_key("doc", "user", "OWNED_BY")
+    stored = db.collection("edges").docs[key]
+    assert stored["redacted"] is True
+    assert stored["attrs"] == {}

--- a/tests/test_graph_adapters_integration.py
+++ b/tests/test_graph_adapters_integration.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 
+from ume.arango_graph import ArangoGraph
 from ume.postgres_graph import PostgresGraph
 from ume.redis_graph_adapter import RedisGraphAdapter
 from ume.permissions_adapter import PermissionsGraphAdapter
@@ -101,6 +102,49 @@ def test_permissions_adapter_with_redis(redis_service):
     graph = RedisGraphAdapter(redis_service["url"])
     resource_id = "Document.redis_doc"
     user_id = "User.redis_owner"
+    schema_version = DEFAULT_SCHEMA.get_edge_version("OWNED_BY")
+    try:
+        graph.add_node(resource_id, {"type": "Document"})
+        graph.add_node(user_id, {"type": "User"})
+        graph.add_edge(
+            resource_id,
+            user_id,
+            "OWNED_BY",
+            {"permission_level": "editor"},
+            schema_version=schema_version,
+        )
+
+        edges = graph.get_all_edges()
+        assert any(
+            s == resource_id
+            and t == user_id
+            and lbl == "OWNED_BY"
+            and edge_attrs.get("permission_level") == "editor"
+            and edge_attrs.get("schema_version") == schema_version
+            for s, t, lbl, edge_attrs in edges
+        )
+
+        permissions_graph = PermissionsGraphAdapter(graph, user_id=user_id)
+        assert resource_id in permissions_graph.get_nodes_by_user(user_id)
+    finally:
+        graph.clear()
+        graph.close()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not os.environ.get("UME_DOCKER_TESTS"), reason="Docker tests disabled")
+def test_permissions_adapter_with_arango(arango_service):
+    try:
+        graph = ArangoGraph(
+            arango_service["url"],
+            arango_service["user"],
+            arango_service["password"],
+        )
+    except ImportError:  # pragma: no cover - optional dependency missing
+        pytest.skip("python-arango not installed")
+
+    resource_id = "Document.arango_doc"
+    user_id = "User.arango_owner"
     schema_version = DEFAULT_SCHEMA.get_edge_version("OWNED_BY")
     try:
         graph.add_node(resource_id, {"type": "Document"})


### PR DESCRIPTION
## Summary
- persist edge permission and schema metadata in the Arango adapter and surface it from get_all_edges
- clear stored edge attributes when redacting Arango edges
- extend Arango tests and integration coverage, including a Docker fixture for ArangoDB

## Testing
- pytest tests/test_arango_graph.py
- pytest tests/test_graph_adapters_integration.py::test_permissions_adapter_with_arango -k ''
- ruff check src/ume/arango_graph.py tests/test_arango_graph.py tests/test_graph_adapters_integration.py tests/conftest.py

------
https://chatgpt.com/codex/tasks/task_e_68d29febcd8c8326a8ab72434cede863