### PR TITLE
Add regression tests for permission metadata persistence

### DIFF
--- a/tests/test_graph_adapters_integration.py
+++ b/tests/test_graph_adapters_integration.py
@@ -4,7 +4,6 @@ import pytest
 from ume.arango_graph import ArangoGraph
 from ume.postgres_graph import PostgresGraph
 from ume.redis_graph_adapter import RedisGraphAdapter
-from ume.neo4j_graph import Neo4jGraph
 from ume.permissions_adapter import PermissionsGraphAdapter
 from ume.graph_schema import DEFAULT_SCHEMA
 import redis
@@ -54,7 +53,24 @@ def test_redis_graph_crud(redis_service):
     graph.add_node("n2", {})
     graph.add_edge("n1", "n2", "R")
     assert ("n1", "n2", "R", {}) in graph.get_all_edges()
+    graph.add_node("n3", {})
+    schema_version = DEFAULT_SCHEMA.get_edge_version("SHARED_WITH")
+    graph.add_edge(
+        "n1",
+        "n3",
+        "SHARED_WITH",
+        {"permission_level": "viewer"},
+        schema_version=schema_version,
+    )
+    edges = graph.get_all_edges()
+    assert (
+        "n1",
+        "n3",
+        "SHARED_WITH",
+        {"permission_level": "viewer", "schema_version": schema_version},
+    ) in edges
     graph.delete_edge("n1", "n2", "R")
+    graph.delete_edge("n1", "n3", "SHARED_WITH")
     assert graph.get_all_edges() == []
     graph.clear()
     graph.close()

--- a/tests/test_postgres_permissions.py
+++ b/tests/test_postgres_permissions.py
@@ -1,0 +1,71 @@
+import os
+
+import pytest
+
+from ume.graph_schema import DEFAULT_SCHEMA
+from ume.permissions_adapter import PermissionsGraphAdapter
+from ume.postgres_graph import PostgresGraph
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("UME_DOCKER_TESTS"),
+    reason="Docker tests disabled",
+)
+def test_get_nodes_by_user_returns_owned_resources(postgres_service):
+    graph = PostgresGraph(postgres_service["dsn"])
+    resource_id = "Document.pg_owned"
+    shared_id = "Document.pg_shared"
+    user_id = "User.pg_user"
+    other_user = "User.pg_other"
+    try:
+        graph.add_node(resource_id, {"type": "Document"})
+        graph.add_node(shared_id, {"type": "Document"})
+        graph.add_node(user_id, {"type": "User"})
+        graph.add_node(other_user, {"type": "User"})
+        owned_schema = DEFAULT_SCHEMA.get_edge_version("OWNED_BY")
+        shared_schema = DEFAULT_SCHEMA.get_edge_version("SHARED_WITH")
+        graph.add_edge(
+            resource_id,
+            user_id,
+            "OWNED_BY",
+            {"permission_level": "editor"},
+            schema_version=owned_schema,
+        )
+        graph.add_edge(
+            shared_id,
+            other_user,
+            "OWNED_BY",
+            {"permission_level": "editor"},
+            schema_version=owned_schema,
+        )
+        graph.add_edge(
+            shared_id,
+            user_id,
+            "SHARED_WITH",
+            {"permission_level": "viewer"},
+            schema_version=shared_schema,
+        )
+
+        permissions_graph = PermissionsGraphAdapter(graph, user_id=user_id)
+        assert set(permissions_graph.get_nodes_by_user(user_id)) == {
+            resource_id,
+            shared_id,
+        }
+
+        edges = graph.get_all_edges()
+        assert (
+            resource_id,
+            user_id,
+            "OWNED_BY",
+            {"permission_level": "editor", "schema_version": owned_schema},
+        ) in edges
+        assert (
+            shared_id,
+            user_id,
+            "SHARED_WITH",
+            {"permission_level": "viewer", "schema_version": shared_schema},
+        ) in edges
+    finally:
+        graph.clear()
+        graph.close()

--- a/tests/test_redis_permissions.py
+++ b/tests/test_redis_permissions.py
@@ -1,0 +1,71 @@
+import os
+
+import pytest
+
+from ume.graph_schema import DEFAULT_SCHEMA
+from ume.permissions_adapter import PermissionsGraphAdapter
+from ume.redis_graph_adapter import RedisGraphAdapter
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("UME_DOCKER_TESTS"),
+    reason="Docker tests disabled",
+)
+def test_get_nodes_by_user_returns_owned_resources(redis_service):
+    graph = RedisGraphAdapter(redis_service["url"])
+    resource_id = "Document.redis_owned"
+    shared_id = "Document.redis_shared"
+    user_id = "User.redis_user"
+    other_user = "User.redis_other"
+    try:
+        graph.add_node(resource_id, {"type": "Document"})
+        graph.add_node(shared_id, {"type": "Document"})
+        graph.add_node(user_id, {"type": "User"})
+        graph.add_node(other_user, {"type": "User"})
+        owned_schema = DEFAULT_SCHEMA.get_edge_version("OWNED_BY")
+        shared_schema = DEFAULT_SCHEMA.get_edge_version("SHARED_WITH")
+        graph.add_edge(
+            resource_id,
+            user_id,
+            "OWNED_BY",
+            {"permission_level": "editor"},
+            schema_version=owned_schema,
+        )
+        graph.add_edge(
+            shared_id,
+            other_user,
+            "OWNED_BY",
+            {"permission_level": "editor"},
+            schema_version=owned_schema,
+        )
+        graph.add_edge(
+            shared_id,
+            user_id,
+            "SHARED_WITH",
+            {"permission_level": "viewer"},
+            schema_version=shared_schema,
+        )
+
+        permissions_graph = PermissionsGraphAdapter(graph, user_id=user_id)
+        assert set(permissions_graph.get_nodes_by_user(user_id)) == {
+            resource_id,
+            shared_id,
+        }
+
+        edges = graph.get_all_edges()
+        assert (
+            resource_id,
+            user_id,
+            "OWNED_BY",
+            {"permission_level": "editor", "schema_version": owned_schema},
+        ) in edges
+        assert (
+            shared_id,
+            user_id,
+            "SHARED_WITH",
+            {"permission_level": "viewer", "schema_version": shared_schema},
+        ) in edges
+    finally:
+        graph.clear()
+        graph.close()


### PR DESCRIPTION
## Summary
- update Redis graph integration test to assert persisted permission metadata on SHARED_WITH edges
- add Postgres-specific regression test covering PermissionsGraphAdapter.get_nodes_by_user
- add Redis-specific regression test covering PermissionsGraphAdapter.get_nodes_by_user

## Testing
- PYTHONPATH="/tmp/fastapi_stub" pytest tests/test_graph_adapters_integration.py tests/test_postgres_permissions.py tests/test_redis_permissions.py -vv
- ruff check tests/test_graph_adapters_integration.py tests/test_postgres_permissions.py tests/test_redis_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1245a9a483268bbb9e73ec13b27b