### PR TITLE
Ensure decision routes materialize subject metadata

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -15,6 +15,8 @@ from .models import (
     ProposedAction,
     create_decision_analysis,
     create_proposed_action,
+    create_user,
+    create_user_group,
 )
 
 EDGE_VERSION = "3.0.0"
@@ -57,6 +59,68 @@ def _action_to_dict(action: ProposedAction) -> dict[str, Any]:
     }
 
 
+def _user_node_defaults(user_id: str) -> dict[str, Any]:
+    user = create_user(user_id, user_id=user_id)
+    return {
+        "type": "User",
+        "user_id": user.user_id,
+        "name": user.name,
+        "email": user.email,
+        "created_at": int(user.created_at.timestamp()),
+        "schema_version": user.schema_version,
+    }
+
+
+def _ensure_user_node(graph: IGraphAdapter, user_id: str) -> None:
+    defaults = _user_node_defaults(user_id)
+    attrs = graph.get_node(user_id)
+    if attrs is None:
+        graph.add_node(user_id, defaults)
+        return
+    update_attrs: dict[str, Any] = {}
+    if attrs.get("type") != "User":
+        update_attrs["type"] = "User"
+    for field in ("user_id", "name", "email", "created_at"):
+        if attrs.get(field) is None:
+            update_attrs[field] = defaults[field]
+    if not attrs.get("schema_version"):
+        update_attrs["schema_version"] = defaults["schema_version"]
+    if update_attrs:
+        graph.update_node(user_id, update_attrs)
+
+
+def _group_node_defaults(group_id: str) -> dict[str, Any]:
+    group = create_user_group(group_id, group_id=group_id)
+    return {
+        "type": "UserGroup",
+        "group_id": group.group_id,
+        "name": group.name,
+        "members": list(group.members),
+        "schema_version": group.schema_version,
+    }
+
+
+def _ensure_group_node(graph: IGraphAdapter, group_id: str) -> None:
+    defaults = _group_node_defaults(group_id)
+    attrs = graph.get_node(group_id)
+    if attrs is None:
+        graph.add_node(group_id, defaults)
+        return
+    update_attrs: dict[str, Any] = {}
+    if attrs.get("type") != "UserGroup":
+        update_attrs["type"] = "UserGroup"
+    if not attrs.get("group_id"):
+        update_attrs["group_id"] = defaults["group_id"]
+    if not attrs.get("name"):
+        update_attrs["name"] = defaults["name"]
+    if "members" not in attrs:
+        update_attrs["members"] = defaults["members"]
+    if not attrs.get("schema_version"):
+        update_attrs["schema_version"] = defaults["schema_version"]
+    if update_attrs:
+        graph.update_node(group_id, update_attrs)
+
+
 @router.post("")
 def create_decision(
     req: DecisionCreateRequest,
@@ -65,6 +129,7 @@ def create_decision(
 ) -> dict[str, Any]:
     if req.group_id:
         ensure_group_member(graph, req.user_id, req.group_id)
+        _ensure_group_node(graph, req.group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=req.user_id, group_id=req.group_id
     )
@@ -72,8 +137,7 @@ def create_decision(
     attrs = _analysis_to_dict(analysis)
     perm_graph.add_node(analysis.analysis_id, attrs)
     # Ensure subject nodes exist
-    if not graph.node_exists(req.user_id):
-        graph.add_node(req.user_id, {})
+    _ensure_user_node(graph, req.user_id)
     # Link analysis to the owning user
     graph.add_edge(
         analysis.analysis_id,
@@ -84,8 +148,6 @@ def create_decision(
     )
     perm_graph.rebuild_index()
     if req.group_id:
-        if not graph.node_exists(req.group_id):
-            graph.add_node(req.group_id, {})
         perm_graph.add_edge(
             analysis.analysis_id,
             req.group_id,
@@ -104,6 +166,7 @@ def add_action(
 ) -> dict[str, Any]:
     if req.group_id:
         ensure_group_member(graph, req.user_id, req.group_id)
+        _ensure_group_node(graph, req.group_id)
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=req.user_id, group_id=req.group_id
     )
@@ -118,8 +181,7 @@ def add_action(
     action_attrs = _action_to_dict(action)
     perm_graph.add_node(action.action_id, action_attrs)
     # Ensure subject nodes exist
-    if not graph.node_exists(req.user_id):
-        graph.add_node(req.user_id, {})
+    _ensure_user_node(graph, req.user_id)
     # Link action to the owning user
     graph.add_edge(
         action.action_id,
@@ -130,8 +192,6 @@ def add_action(
     )
     perm_graph.rebuild_index()
     if req.group_id:
-        if not graph.node_exists(req.group_id):
-            graph.add_node(req.group_id, {})
         try:
             perm_graph.add_edge(
                 action.action_id,

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -6,6 +6,8 @@ from ume import MockGraph
 from ume.config import settings
 from ume.models.decision_analysis import SCHEMA_VERSION
 from ume.models.proposed_action import SCHEMA_VERSION as ACTION_SCHEMA_VERSION
+from ume.models.user_group import SCHEMA_VERSION as GROUP_SCHEMA_VERSION
+from ume.models.users import SCHEMA_VERSION as USER_SCHEMA_VERSION
 from ume.decisions_routes import EDGE_VERSION
 
 
@@ -37,6 +39,13 @@ def test_decision_flow(client_and_graph) -> None:
     analysis = res.json()
     analysis_id = analysis["analysis_id"]
     assert analysis["schema_version"] == SCHEMA_VERSION
+    user_attrs = g.get_node("user1")
+    assert user_attrs is not None
+    assert user_attrs["type"] == "User"
+    assert user_attrs["schema_version"] == USER_SCHEMA_VERSION
+    assert user_attrs["user_id"] == "user1"
+    assert user_attrs["name"] == "user1"
+    assert isinstance(user_attrs["created_at"], int)
 
     res = client.post(
         f"/v1/decisions/{analysis_id}/actions",
@@ -94,6 +103,13 @@ def test_decision_flow_with_group(client_and_graph) -> None:
     )
     assert res.status_code == 200
     analysis_id = res.json()["analysis_id"]
+    group_attrs = g.get_node("group1")
+    assert group_attrs is not None
+    assert group_attrs["type"] == "UserGroup"
+    assert group_attrs["schema_version"] == GROUP_SCHEMA_VERSION
+    assert group_attrs["group_id"] == "group1"
+    assert group_attrs["name"] == "group1"
+    assert group_attrs["members"] == ["user1"]
 
     res = client.get(
         f"/v1/decisions/{analysis_id}",
@@ -182,6 +198,10 @@ def test_viewer_cannot_add_action(client_and_graph) -> None:
     assert res.status_code == 403
     nodes_after = set(g.get_all_node_ids())
     assert nodes_after == nodes_before
+    user2_attrs = g.get_node("user2")
+    assert user2_attrs is not None
+    assert user2_attrs["type"] == "User"
+    assert user2_attrs["schema_version"] == USER_SCHEMA_VERSION
     proposed_action_nodes = [
         node_id
         for node_id in nodes_after


### PR DESCRIPTION
## Summary
- ensure decision routes use create_user/create_user_group helpers so auto-created subject nodes carry schema metadata
- retrofit existing bare user/group nodes to fill in missing type and schema fields before linking permissions
- extend decision route tests to assert user and group nodes now expose the expected schema attributes

## Testing
- pytest tests/test_decisions_routes.py
- poetry run ruff check src/ume/decisions_routes.py tests/test_decisions_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68dd28da15488326b8d4c68177f6d874