### PR TITLE
Ensure calendar layer creation provisions owner user node

### DIFF
--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -6,6 +6,7 @@ from typing import List, cast
 
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
+from .calendar_routes import _ensure_user_node
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .models import create_calendar_layer
@@ -47,6 +48,7 @@ def create_layer(
         "schema_version": layer.schema_version,
     }
     graph.add_node(layer.layer_id, attrs)
+    _ensure_user_node(graph, req.user_id)
     graph.add_edge(
         layer.layer_id,
         req.user_id,

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -7,6 +7,7 @@ from ume.api import app, configure_graph
 from ume import MockGraph
 from ume.config import settings
 from ume.models.calendar_layer import SCHEMA_VERSION
+from ume.models.users import SCHEMA_VERSION as USER_SCHEMA_VERSION
 
 EDGE_VERSION = "3.0.0"
 
@@ -61,6 +62,30 @@ def test_create_calendar_layer(client_and_graph) -> None:
         "OWNED_BY",
         {"permission_level": "editor", "schema_version": EDGE_VERSION},
     ) in edges
+
+
+def test_create_calendar_layer_provisions_owner_user(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    res = client.post(
+        "/v1/calendar/layers",
+        json={"layer_name": "Work", "color": "blue", "user_id": "missing"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert res.status_code == 200
+    user_attrs = graph.get_node("missing")
+    assert user_attrs is not None
+    assert user_attrs == {
+        "type": "User",
+        "user_id": "missing",
+        "name": "missing",
+        "email": None,
+        "created_at": user_attrs["created_at"],
+        "schema_version": USER_SCHEMA_VERSION,
+    }
+    assert isinstance(user_attrs["created_at"], int)
 
 
 def test_create_layer_with_group_share(client_and_graph) -> None:


### PR DESCRIPTION
## Summary
- ensure calendar layer creation uses the existing helper to provision the owner user node before linking
- add a regression test covering calendar layer creation when the owner user is missing

## Testing
- pytest tests/test_calendar_layer_routes.py
- ruff check src/ume/calendar_layer_routes.py tests/test_calendar_layer_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68dd28d8fdd08326bed308b588c58a42