### PR TITLE
Require requester membership when listing shared nodes

### DIFF
--- a/src/ume/permissions_routes.py
+++ b/src/ume/permissions_routes.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends, Query
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
+from .utils import ensure_group_member
 
 router = APIRouter(prefix="/v1/nodes")
 
@@ -25,11 +26,15 @@ def get_nodes_by_user(
 
 @router.get("/shared")
 def get_nodes_shared_with(
+    user_id: str = Query(...),
     group_id: str = Query(...),
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> Dict[str, List[str]]:
     """Return nodes shared with the specified group."""
-    perm_graph = PermissionsGraphAdapter(graph, group_id=group_id)
+    ensure_group_member(graph, user_id, group_id)
+    perm_graph = PermissionsGraphAdapter(
+        graph, user_id=user_id, group_id=group_id
+    )
     node_ids = perm_graph.get_nodes_shared_with(group_id)
     return {"nodes": node_ids}

--- a/tests/test_permissions_routes.py
+++ b/tests/test_permissions_routes.py
@@ -27,7 +27,7 @@ def client_and_graph():
 def _seed_graph(graph: MockGraph) -> None:
     # Subjects
     graph.add_node("user1", {"type": "User"})
-    graph.add_node("group1", {"type": "UserGroup"})
+    graph.add_node("group1", {"type": "UserGroup", "members": ["user1"]})
     graph.add_node("other", {"type": "User"})
 
     # User-only nodes
@@ -81,7 +81,7 @@ def test_get_nodes_shared_with_filters_viewer_editor(client_and_graph):
 
     res = client.get(
         "/v1/nodes/shared",
-        params={"group_id": "group1"},
+        params={"user_id": "user1", "group_id": "group1"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
@@ -113,13 +113,27 @@ def test_get_nodes_shared_with_excludes_nodes_without_permission_level(
 
     res = client.get(
         "/v1/nodes/shared",
-        params={"group_id": "group1"},
+        params={"user_id": "user1", "group_id": "group1"},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
     nodes = set(res.json()["nodes"])
     assert "g_no_perm" not in nodes
     assert "g_invalid" not in nodes
+
+
+def test_get_nodes_shared_with_requires_group_membership(client_and_graph) -> None:
+    client, graph = client_and_graph
+    _seed_graph(graph)
+    token = _token(client)
+
+    res = client.get(
+        "/v1/nodes/shared",
+        params={"user_id": "other", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert res.status_code == 403
 
 
 def test_editor_vs_viewer_permissions(client_and_graph) -> None:


### PR DESCRIPTION
## Summary
- require the requester id when fetching nodes shared with a group
- enforce group membership before listing shared nodes and initialize the permissions adapter with both identifiers
- ensure tests provide requester ids and cover non-member access returning 403

## Testing
- `poetry run ruff check src/ume/permissions_routes.py tests/test_permissions_routes.py`
- `poetry run pytest tests/test_permissions_routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68de80fc9df88326825ffde892264733