### PR TITLE
Enforce permission level validation for permission edges

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -152,6 +152,11 @@ class PermissionsGraphAdapter(IGraphAdapter):
         version = edge_def.version
         attrs = dict(attrs or {})
         perm_level = attrs.get("permission_level")
+        if label in {"OWNED_BY", "SHARED_WITH"}:
+            if perm_level is None or (isinstance(perm_level, str) and not perm_level):
+                raise AccessDeniedError(
+                    "permission_level is required for OWNED_BY/SHARED_WITH edges"
+                )
         if perm_level is not None and perm_level not in {"viewer", "editor"}:
             raise AccessDeniedError(
                 f"Invalid permission_level '{perm_level}'"

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -191,6 +191,31 @@ def test_add_edge_requires_editor_and_preserves_attrs() -> None:
     ]
 
 
+def test_add_permission_edge_requires_permission_level() -> None:
+    g = MockGraph()
+    g.add_node("User.u1", {})
+    g.add_node("User.u2", {})
+    g.add_node("Document.d1", {})
+    g._edges["Document.d1"].append(("User.u1", "OWNED_BY", {"permission_level": "editor"}))
+    adapter = PermissionsGraphAdapter(g, user_id="User.u1")
+
+    with pytest.raises(AccessDeniedError) as excinfo:
+        adapter.add_edge("Document.d1", "User.u2", "SHARED_WITH")
+    assert "permission_level is required" in str(excinfo.value)
+    assert not any(
+        tgt == "User.u2" and lbl == "SHARED_WITH"
+        for _, tgt, lbl, _ in g.get_all_edges()
+    )
+
+    with pytest.raises(AccessDeniedError):
+        adapter.add_edge(
+            "Document.d1",
+            "User.u2",
+            "SHARED_WITH",
+            {"permission_level": ""},
+        )
+
+
 def test_find_connected_nodes_filters_by_permissions() -> None:
     g = build_graph()
     g.add_node("Document.d3", {})


### PR DESCRIPTION
## Summary
- ensure `PermissionsGraphAdapter.add_edge` requires `permission_level` on `OWNED_BY` and `SHARED_WITH` edges before delegating to the graph backend
- cover the new failure path with unit tests so the stricter validation remains enforced
- audited calendar, decision, and financial account routes to confirm they already supply `permission_level`

## Testing
- pytest tests/test_permissions_adapter.py
- poetry run ruff check src/ume/permissions_adapter.py tests/test_permissions_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68de91caa9f08326850ded01641d1e49