### PR TITLE
Handle missing groups with 404 responses

### DIFF
--- a/src/ume/utils.py
+++ b/src/ume/utils.py
@@ -42,7 +42,10 @@ def ensure_group_member(
     """
 
     group = graph.get_node(group_id)
-    members = group.get("members", []) if isinstance(group, dict) else []
+    if not isinstance(group, dict):
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    members = group.get("members", [])
     if should_exist:
         if user_id not in members:
             raise HTTPException(status_code=403, detail="User not in group")

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -254,6 +254,22 @@ def test_calendar_event_group_membership_required(client_and_graph) -> None:
     assert res.status_code == 403
 
 
+def test_calendar_event_missing_group_returns_404(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {})
+
+    res = client.get(
+        "/v1/calendar/events",
+        params={"user_id": "user1", "group_id": "missing"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert res.status_code == 404
+    assert res.json() == {"detail": "Group not found"}
+
+
 def test_calendar_event_group_and_layer_filter(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -147,6 +147,20 @@ def test_group_membership_required(client_and_graph) -> None:
     assert res.status_code == 403
 
 
+def test_group_missing_returns_404(client_and_graph) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+
+    res = client.post(
+        "/v1/decisions",
+        json={"query": "Z", "user_id": "user1", "group_id": "missing"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert res.status_code == 404
+    assert res.json() == {"detail": "Group not found"}
+
+
 def test_add_action_requires_group_membership(client_and_graph) -> None:
     client, g = client_and_graph
     token = _token(client)

--- a/tests/test_permissions_routes.py
+++ b/tests/test_permissions_routes.py
@@ -136,6 +136,22 @@ def test_get_nodes_shared_with_requires_group_membership(client_and_graph) -> No
     assert res.status_code == 403
 
 
+def test_get_nodes_shared_with_missing_group_returns_404(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("user1", {"type": "User"})
+
+    res = client.get(
+        "/v1/nodes/shared",
+        params={"user_id": "user1", "group_id": "missing"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert res.status_code == 404
+    assert res.json() == {"detail": "Group not found"}
+
+
 def test_editor_vs_viewer_permissions(client_and_graph) -> None:
     _, graph = client_and_graph
     _seed_graph(graph)

--- a/tests/test_utils_group_membership.py
+++ b/tests/test_utils_group_membership.py
@@ -1,0 +1,24 @@
+import pytest
+from fastapi import HTTPException
+
+from ume.utils import ensure_group_member
+
+
+class StubGraph:
+    def __init__(self, node):
+        self._node = node
+
+    def get_node(self, node_id: str):  # pragma: no cover - simple stub
+        return self._node
+
+
+@pytest.mark.parametrize("group_payload", [None, ["not", "a", "dict"]])
+@pytest.mark.parametrize("should_exist", [True, False])
+def test_ensure_group_member_missing_group(group_payload, should_exist):
+    graph = StubGraph(group_payload)
+
+    with pytest.raises(HTTPException) as exc:
+        ensure_group_member(graph, "user", "group", should_exist=should_exist)
+
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "Group not found"


### PR DESCRIPTION
## Summary
- update `ensure_group_member` to surface a 404 when the backing group node is missing
- cover the new behaviour with a dedicated utils unit test and focused API route tests for calendars, decisions, and permissions

## Testing
- pytest tests/test_utils_group_membership.py
- pytest tests/test_calendar_decision_api.py::test_calendar_event_missing_group_returns_404
- pytest tests/test_decisions_routes.py::test_group_missing_returns_404
- pytest tests/test_permissions_routes.py::test_get_nodes_shared_with_missing_group_returns_404

------
https://chatgpt.com/codex/tasks/task_e_68de91cb920c832682b4851bfa870998