### PR TITLE
Add group permission level selection for calendar and decision shares

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -22,6 +22,7 @@ from .models import (
 from .processing import ProcessingError
 
 EDGE_VERSION = "3.0.0"
+VALID_GROUP_PERMISSION_LEVELS = {"viewer", "editor"}
 
 router = APIRouter(prefix="/v1/calendar")
 
@@ -77,6 +78,7 @@ class CalendarEventCreateRequest(BaseModel):
     visibility: CalendarEventVisibility | None = None
     user_id: str
     group_id: str | None = None
+    group_permission_level: str | None = None
     invitee_ids: List[str] | None = None
     layer_ids: List[str] | None = None
 
@@ -149,6 +151,9 @@ def create_event(
                     status_code=400,
                     detail="Group events must have visibility public_to_group",
                 )
+            group_permission_level = req.group_permission_level or "viewer"
+            if group_permission_level not in VALID_GROUP_PERMISSION_LEVELS:
+                raise HTTPException(status_code=400, detail="Invalid group_permission_level")
         try:
             perm_graph.add_edge(
                 event.event_id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
@@ -168,7 +173,7 @@ def create_event(
                 event.event_id,
                 req.group_id,
                 "SHARED_WITH",
-                {"permission_level": "viewer"},
+                {"permission_level": group_permission_level},
             )
 
         for uid in invitee_ids:

--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -20,6 +20,7 @@ from .models import (
 )
 
 EDGE_VERSION = "3.0.0"
+VALID_GROUP_PERMISSION_LEVELS = {"viewer", "editor"}
 
 router = APIRouter(prefix="/v1/decisions")
 
@@ -28,6 +29,7 @@ class DecisionCreateRequest(BaseModel):
     query: str
     user_id: str
     group_id: str | None = None
+    group_permission_level: str | None = None
 
 
 class ActionCreateRequest(BaseModel):
@@ -37,6 +39,7 @@ class ActionCreateRequest(BaseModel):
     outcome_metrics: dict[str, float] | None = None
     user_id: str
     group_id: str | None = None
+    group_permission_level: str | None = None
 
 
 def _analysis_to_dict(analysis: DecisionAnalysis) -> dict[str, Any]:
@@ -130,6 +133,9 @@ def create_decision(
     if req.group_id:
         ensure_group_member(graph, req.user_id, req.group_id)
         _ensure_group_node(graph, req.group_id)
+        group_permission_level = req.group_permission_level or "editor"
+        if group_permission_level not in VALID_GROUP_PERMISSION_LEVELS:
+            raise HTTPException(status_code=400, detail="Invalid group_permission_level")
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=req.user_id, group_id=req.group_id
     )
@@ -152,7 +158,7 @@ def create_decision(
             analysis.analysis_id,
             req.group_id,
             "SHARED_WITH",
-            {"permission_level": "editor"},
+            {"permission_level": group_permission_level},
         )
     return attrs
 
@@ -167,6 +173,9 @@ def add_action(
     if req.group_id:
         ensure_group_member(graph, req.user_id, req.group_id)
         _ensure_group_node(graph, req.group_id)
+        group_permission_level = req.group_permission_level or "viewer"
+        if group_permission_level not in VALID_GROUP_PERMISSION_LEVELS:
+            raise HTTPException(status_code=400, detail="Invalid group_permission_level")
     perm_graph = PermissionsGraphAdapter(
         graph, user_id=req.user_id, group_id=req.group_id
     )
@@ -197,7 +206,7 @@ def add_action(
                 action.action_id,
                 req.group_id,
                 "SHARED_WITH",
-                {"permission_level": "viewer"},
+                {"permission_level": group_permission_level},
             )
         except AccessDeniedError:
             raise HTTPException(

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -195,14 +195,48 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     assert res.status_code == 200
     assert res.json() == [event_data]
 
+    # Event shared with the group granting editor rights
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Planning",
+            "start_time": start,
+            "user_id": "user1",
+            "group_id": "group1",
+            "group_permission_level": "editor",
+            "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    editor_event = res.json()
+
+    # Group-scoped retrieval now returns both events
+    res = client.get(
+        "/v1/calendar/events",
+        params={"user_id": "user2", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    returned_ids = {evt["event_id"] for evt in res.json()}
+    assert returned_ids == {event_data["event_id"], editor_event["event_id"]}
+
     edges = graph.get_all_edges()
     assert any(
         s == event_id and t == "group1" and lbl == "SHARED_WITH"
-        for s, t, lbl, _ in edges
+        and attrs.get("permission_level") == "viewer"
+        for s, t, lbl, attrs in edges
     )
     assert not any(
         s == own_event["event_id"] and t == "group1" and lbl == "SHARED_WITH"
         for s, t, lbl, _ in edges
+    )
+    assert any(
+        s == editor_event["event_id"]
+        and t == "group1"
+        and lbl == "SHARED_WITH"
+        and attrs.get("permission_level") == "editor"
+        for s, t, lbl, attrs in edges
     )
 
 

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -94,7 +94,7 @@ def test_decision_flow(client_and_graph) -> None:
 def test_decision_flow_with_group(client_and_graph) -> None:
     client, g = client_and_graph
     token = _token(client)
-    g.add_node("group1", {"members": ["user1"]})
+    g.add_node("group1", {"members": ["user1", "user2"]})
 
     res = client.post(
         "/v1/decisions",
@@ -109,7 +109,16 @@ def test_decision_flow_with_group(client_and_graph) -> None:
     assert group_attrs["schema_version"] == GROUP_SCHEMA_VERSION
     assert group_attrs["group_id"] == "group1"
     assert group_attrs["name"] == "group1"
-    assert group_attrs["members"] == ["user1"]
+    assert group_attrs["members"] == ["user1", "user2"]
+
+    edges = g.get_all_edges()
+    assert any(
+        s == analysis_id
+        and t == "group1"
+        and lbl == "SHARED_WITH"
+        and e.get("permission_level") == "editor"
+        for s, t, lbl, e in edges
+    )
 
     res = client.get(
         f"/v1/decisions/{analysis_id}",
@@ -117,6 +126,94 @@ def test_decision_flow_with_group(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
+
+    # Group editor can add an action and share it back with editor access
+    res = client.post(
+        f"/v1/decisions/{analysis_id}/actions",
+        json={
+            "description": "Team option",
+            "user_id": "user2",
+            "group_id": "group1",
+            "group_permission_level": "editor",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    action_id = res.json()["action_id"]
+
+    edges = g.get_all_edges()
+    assert any(
+        s == action_id
+        and t == "group1"
+        and lbl == "SHARED_WITH"
+        and e.get("permission_level") == "editor"
+        for s, t, lbl, e in edges
+    )
+
+
+def test_decision_group_viewer_share_limits_editing(client_and_graph) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+    g.add_node("group1", {"members": ["user1", "user2"]})
+
+    res = client.post(
+        "/v1/decisions",
+        json={
+            "query": "Choose",
+            "user_id": "user1",
+            "group_id": "group1",
+            "group_permission_level": "viewer",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    analysis_id = res.json()["analysis_id"]
+
+    edges = g.get_all_edges()
+    assert any(
+        s == analysis_id
+        and t == "group1"
+        and lbl == "SHARED_WITH"
+        and e.get("permission_level") == "viewer"
+        for s, t, lbl, e in edges
+    )
+
+    nodes_before = set(g.get_all_node_ids())
+    res = client.post(
+        f"/v1/decisions/{analysis_id}/actions",
+        json={"description": "Team option", "user_id": "user2", "group_id": "group1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 403
+    nodes_after = set(g.get_all_node_ids())
+    new_nodes = nodes_after - nodes_before
+    assert new_nodes <= {"user2"}
+    assert not any(
+        (g.get_node(node_id) or {}).get("type") == "ProposedAction"
+        for node_id in new_nodes
+    )
+
+    res = client.post(
+        f"/v1/decisions/{analysis_id}/actions",
+        json={
+            "description": "Owner action",
+            "user_id": "user1",
+            "group_id": "group1",
+            "group_permission_level": "viewer",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    action_id = res.json()["action_id"]
+
+    edges = g.get_all_edges()
+    assert any(
+        s == action_id
+        and t == "group1"
+        and lbl == "SHARED_WITH"
+        and e.get("permission_level") == "viewer"
+        for s, t, lbl, e in edges
+    )
 
 
 def test_group_membership_required(client_and_graph) -> None:


### PR DESCRIPTION
## Summary
- allow calendar event creation requests to include an optional group_permission_level and validate the requested access before sharing
- extend decision analysis and action creation to accept configurable group permission levels and enforce allowable values
- expand calendar and decision API tests to cover viewer/editor group shares and verify resulting permissions

## Testing
- pytest tests/test_calendar_decision_api.py tests/test_decisions_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68de95491dd883269ae54a12864d451b