### PR TITLE
Use schema permission defaults in Neo4j adapter

### DIFF
--- a/src/ume/graph_schema.py
+++ b/src/ume/graph_schema.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from importlib import resources
-from typing import Dict
+from typing import Dict, NoReturn
 import json
 import yaml
 
@@ -16,6 +16,7 @@ class Property:
     name: str
     version: str
     permission_level: str | None = None
+    permission_level_values: tuple[str, ...] = ()
 
 
 @dataclass
@@ -25,6 +26,7 @@ class NodeType:
     name: str
     version: str
     permission_level: str | None = None
+    permission_level_values: tuple[str, ...] = ()
     properties: Dict[str, Property] = field(default_factory=dict)
 
 
@@ -35,6 +37,7 @@ class EdgeLabel:
     label: str
     version: str
     permission_level: str | None = None
+    permission_level_values: tuple[str, ...] = ()
 
 
 @dataclass
@@ -53,6 +56,38 @@ class GraphSchema:
                 data = yaml.safe_load(f)
             else:
                 data = json.load(f)
+
+        def _parse_permission(
+            value: object, context: str
+        ) -> tuple[str | None, tuple[str, ...]]:
+            def _error(message: str) -> NoReturn:
+                from .processing import ProcessingError
+
+                raise ProcessingError(message)
+
+            if value is None:
+                return None, ()
+            if isinstance(value, str):
+                value_str = str(value)
+                return value_str, (value_str,)
+            if isinstance(value, dict):
+                default = value.get("default")
+                accepted = value.get("accepted_values")
+                default_str = str(default) if default is not None else None
+                if accepted is None:
+                    values: list[str] = []
+                elif isinstance(accepted, (list, tuple, set)):
+                    values = [str(v) for v in accepted]
+                else:
+                    _error(
+                        f"{context} permission_level accepted_values must be a sequence of strings"
+                    )
+                if default_str is not None and default_str not in values:
+                    values.append(default_str)
+                values = list(dict.fromkeys(values))
+                return default_str, tuple(values)
+            _error(f"{context} permission_level must be a string or mapping")
+
         node_types = {}
         for name, info in data.get("node_types", {}).items():
             if not isinstance(info, dict):
@@ -76,25 +111,43 @@ class GraphSchema:
                     raise ProcessingError(
                         f"Property '{prop_name}' for node type '{name}' must be a mapping",
                     )
+                prop_perm, prop_perm_values = _parse_permission(
+                    prop_info.get("permission_level"),
+                    f"Property '{prop_name}' for node type '{name}'",
+                )
                 properties[prop_name] = Property(
                     name=prop_name,
                     version=str(prop_info.get("version", "0.0.0")),
-                    permission_level=prop_info.get("permission_level"),
+                    permission_level=prop_perm,
+                    permission_level_values=prop_perm_values,
                 )
+            node_perm, node_perm_values = _parse_permission(
+                info.get("permission_level"), f"Node type '{name}'"
+            )
             node_types[name] = NodeType(
                 name=name,
                 version=str(info.get("version", "0.0.0")),
-                permission_level=info.get("permission_level"),
+                permission_level=node_perm,
+                permission_level_values=node_perm_values,
                 properties=properties,
             )
-        edge_labels = {
-            label: EdgeLabel(
+        edge_labels: Dict[str, EdgeLabel] = {}
+        for label, info in data.get("edge_labels", {}).items():
+            if not isinstance(info, dict):
+                from .processing import ProcessingError
+
+                raise ProcessingError(
+                    f"Edge label '{label}' must be a mapping",
+                )
+            edge_perm, edge_perm_values = _parse_permission(
+                info.get("permission_level"), f"Edge label '{label}'"
+            )
+            edge_labels[label] = EdgeLabel(
                 label=label,
                 version=str(info.get("version", "0.0.0")),
-                permission_level=info.get("permission_level"),
+                permission_level=edge_perm,
+                permission_level_values=edge_perm_values,
             )
-            for label, info in data.get("edge_labels", {}).items()
-        }
         version = str(data.get("version", "0.0.0"))
         return GraphSchema(
             version=version, node_types=node_types, edge_labels=edge_labels

--- a/src/ume/neo4j_graph.py
+++ b/src/ume/neo4j_graph.py
@@ -26,14 +26,7 @@ def _apply_edge_metadata_defaults(
 ) -> None:
     """Populate permission and schema metadata defaults for an edge."""
 
-    perm_level = None
-    if edge_def is not None:
-        perm_level = getattr(edge_def, "permission_level", None)
-    if perm_level is None:
-        if label == "OWNED_BY":
-            perm_level = "editor"
-        elif label == "SHARED_WITH":
-            perm_level = "viewer"
+    perm_level = getattr(edge_def, "permission_level", None) if edge_def else None
     if perm_level is not None:
         attrs.setdefault("permission_level", perm_level)
 

--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -157,10 +157,18 @@ class PermissionsGraphAdapter(IGraphAdapter):
                 raise AccessDeniedError(
                     "permission_level is required for OWNED_BY/SHARED_WITH edges"
                 )
-        if perm_level is not None and perm_level not in {"viewer", "editor"}:
-            raise AccessDeniedError(
-                f"Invalid permission_level '{perm_level}'"
-            )
+        if perm_level is not None:
+            if not isinstance(perm_level, str) or not perm_level:
+                raise AccessDeniedError(
+                    "permission_level must be a non-empty string when provided"
+                )
+            accepted = set(edge_def.permission_level_values)
+            if not accepted and edge_def.permission_level is not None:
+                accepted.add(edge_def.permission_level)
+            if not accepted or perm_level not in accepted:
+                raise AccessDeniedError(
+                    f"Invalid permission_level '{perm_level}'"
+                )
         attrs.pop("schema_version", None)
         self._adapter.add_edge(
             source_node_id,

--- a/src/ume/postgres_graph.py
+++ b/src/ume/postgres_graph.py
@@ -97,22 +97,40 @@ class PostgresGraph(GraphAlgorithmsMixin, IGraphAdapter):
         )
 
         # Backfill permission metadata for historical permission edges.
-        cur.execute(
-            """
-            UPDATE edges
-            SET attributes = jsonb_set(COALESCE(attributes, '{}'::jsonb), '{permission_level}', '"editor"'::jsonb, true)
-            WHERE label = 'OWNED_BY'
-              AND (attributes->>'permission_level') IS NULL
-            """
-        )
-        cur.execute(
-            """
-            UPDATE edges
-            SET attributes = jsonb_set(COALESCE(attributes, '{}'::jsonb), '{permission_level}', '"viewer"'::jsonb, true)
-            WHERE label = 'SHARED_WITH'
-              AND (attributes->>'permission_level') IS NULL
-            """
-        )
+        owned_def = DEFAULT_SCHEMA.edge_labels.get("OWNED_BY")
+        owned_default = owned_def.permission_level if owned_def else None
+        if owned_default is not None:
+            cur.execute(
+                """
+                UPDATE edges
+                SET attributes = jsonb_set(
+                    COALESCE(attributes, '{}'::jsonb),
+                    '{permission_level}',
+                    %s::jsonb,
+                    true
+                )
+                WHERE label = %s
+                  AND (attributes->>'permission_level') IS NULL
+                """,
+                (json.dumps(owned_default), "OWNED_BY"),
+            )
+        shared_def = DEFAULT_SCHEMA.edge_labels.get("SHARED_WITH")
+        shared_default = shared_def.permission_level if shared_def else None
+        if shared_default is not None:
+            cur.execute(
+                """
+                UPDATE edges
+                SET attributes = jsonb_set(
+                    COALESCE(attributes, '{}'::jsonb),
+                    '{permission_level}',
+                    %s::jsonb,
+                    true
+                )
+                WHERE label = %s
+                  AND (attributes->>'permission_level') IS NULL
+                """,
+                (json.dumps(shared_default), "SHARED_WITH"),
+            )
 
     # ---- Resource management -------------------------------------------------
     def close(self) -> None:

--- a/src/ume/schemas/graph_schema_v3.yaml
+++ b/src/ume/schemas/graph_schema_v3.yaml
@@ -90,8 +90,18 @@ node_types:
 edge_labels:
   OWNED_BY:
     version: "3.0.0"
+    permission_level:
+      default: "editor"
+      accepted_values:
+        - "viewer"
+        - "editor"
   SHARED_WITH:
     version: "3.0.0"
+    permission_level:
+      default: "viewer"
+      accepted_values:
+        - "viewer"
+        - "editor"
   INVITES:
     version: "3.0.0"
   TAGGED_AS:

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -100,6 +100,17 @@ def test_get_edge_version():
         schema.get_edge_version("UNKNOWN_LABEL")
 
 
+def test_permission_level_metadata():
+    schema = load_default_schema()
+    owned = schema.edge_labels["OWNED_BY"]
+    shared = schema.edge_labels["SHARED_WITH"]
+
+    assert owned.permission_level == "editor"
+    assert set(owned.permission_level_values) == {"viewer", "editor"}
+    assert shared.permission_level == "viewer"
+    assert set(shared.permission_level_values) == {"viewer", "editor"}
+
+
 def test_load_node_properties(tmp_path):
     schema_yaml = {
         "version": "1.0.0",


### PR DESCRIPTION
## Summary
- rely on the schema-provided permission defaults when materialising Neo4j edge metadata so that sharing defaults stay in sync with the schema

## Testing
- poetry run pytest tests/test_graph_schema.py
- poetry run pytest tests/test_permissions_adapter.py
- poetry run pytest tests/test_neo4j_graph.py

------
https://chatgpt.com/codex/tasks/task_e_68de9549b31c8326a5ad12b805f59113