### PR TITLE
Document graph request context requirements

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -9,6 +9,69 @@ For gRPC clients, send the configured `UME_GRPC_TOKEN` as a bearer token in the
 `authorization` metadata. The helper class `AsyncUMEClient` accepts this token
 via its `token` argument and attaches it automatically.
 
+## Graph Request Context Requirements
+
+Graph endpoints now require a `user_id` query parameter that identifies the
+requesting principal. Optionally include `group_id` when the caller is acting on
+behalf of a delegated team or workspace. The API enforces permissions by
+inspecting ownership (`OWNED_BY`) and sharing (`SHARED_WITH`) edges that include
+an explicit `permission_level` property. Supported values remain `viewer`,
+`editor`, and `public`.
+
+When creating or updating these edges, include the `permission_level` field in
+the payload. Omitting it for ownership edges defaults to `editor` for backwards
+compatibility, but clients should begin providing it explicitly ahead of schema
+version `3.0.0` when the default will be removed.
+
+### Example: Querying Nodes with Context
+
+```bash
+curl -G "http://localhost:8000/nodes" \
+  -H "Authorization: Bearer <token>" \
+  --data-urlencode "user_id=User.u1" \
+  --data-urlencode "group_id=Group.eng"
+```
+
+Successful responses scope results to the caller's permissions:
+
+```json
+{
+  "nodes": [
+    {
+      "id": "resource-42",
+      "attributes": {
+        "title": "Launch Checklist"
+      },
+      "edges": [
+        {
+          "label": "OWNED_BY",
+          "target": "User.u1",
+          "permission_level": "editor"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Requests made without sufficient permission return an HTTP `403` status with
+context about the failing edge check:
+
+```json
+{
+  "detail": {
+    "error": "permission_denied",
+    "message": "User.u2 lacks viewer access to resource-42 via Group.eng",
+    "required_permission": "viewer"
+  }
+}
+```
+
+> **Migration note:** Update existing clients to supply `user_id`, propagate
+> any acting `group_id`, and include `permission_level` on ownership and sharing
+> edges before schema version `3.0.0` becomes the default. Requests missing this
+> context will be rejected once the migration window closes.
+
 The gRPC service also exposes `SaveSnapshot` and `LoadSnapshot` RPCs which
 mirror the `/snapshot/save` and `/snapshot/load` HTTP endpoints. Both accept a
 `SnapshotPath` message containing the target file path and return an empty

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -103,6 +103,56 @@ controls access to resources. Supported values:
 - `editor` – read and modify access.
 - `public` – accessible without explicit ownership or sharing.
 
+When creating these edges through `/edges` or `/events`, include the
+`permission_level` field in the payload. The API also requires `user_id` (and
+optionally `group_id`) query parameters on generic graph endpoints so the
+server can evaluate these permissions at request time.
+
+```bash
+curl -X POST http://localhost:8000/edges \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "user_id": "User.owner",
+        "group_id": "Group.ops",
+        "source": "Resource.1",
+        "target": "Group.ops",
+        "label": "SHARED_WITH",
+        "permission_level": "viewer"
+      }'
+```
+
+Successful edge creation responses echo the stored permission level:
+
+```json
+{
+  "status": "ok",
+  "edge": {
+    "source": "Resource.1",
+    "target": "Group.ops",
+    "label": "SHARED_WITH",
+    "permission_level": "viewer"
+  }
+}
+```
+
+If the acting `user_id` does not have `editor` rights on the resource, the
+request fails with `403 Forbidden`:
+
+```json
+{
+  "detail": {
+    "error": "permission_denied",
+    "message": "User.helper cannot grant viewer access on Resource.1",
+    "required_permission": "editor"
+  }
+}
+```
+
+> **Migration note:** Clients must supply the new query parameters and explicit
+> `permission_level` values before schema version `3.0.0` becomes the default.
+> Older requests that omit them will be rejected once the migration completes.
+
 ### Group Membership Checks
 
 When resolving `SHARED_WITH` edges the graph now verifies that the requesting


### PR DESCRIPTION
## Summary
- explain that generic graph endpoints must now include user_id and optional group_id context
- document how permission_level must be supplied on OWNED_BY and SHARED_WITH edges, including success and error payload examples
- add migration notes directing integrators to update clients before schema version 3.0.0 becomes the default

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3d9d6fa2c8326b0d9adfa36913a13