### PR TITLE
Add permission enforcement tests for graph routes

### DIFF
--- a/src/ume/api_deps.py
+++ b/src/ume/api_deps.py
@@ -124,8 +124,14 @@ def get_graph(role: str = Depends(get_current_role)) -> IGraphAdapter:
 
 def get_permissions_graph(
     graph: IGraphAdapter = Depends(get_graph),
-    user_id: Annotated[str | None, Query()] = None,
-    group_id: Annotated[str | None, Query()] = None,
+    user_id: Annotated[
+        str | None,
+        Query(description="User performing the request"),
+    ] = None,
+    group_id: Annotated[
+        str | None,
+        Query(description="Optional group context"),
+    ] = None,
 ) -> PermissionsGraphAdapter:
     """Return a :class:`PermissionsGraphAdapter` scoped to the request subject."""
 
@@ -134,13 +140,7 @@ def get_permissions_graph(
             status_code=400,
             detail="A user_id or group_id is required to evaluate permissions",
         )
-    user_id: str = Query(..., description="User performing the request"),
-    group_id: str | None = Query(None, description="Optional group context"),
-    graph: IGraphAdapter = Depends(get_graph),
-) -> PermissionsGraphAdapter:
-    """Return a :class:`PermissionsGraphAdapter` for the current request."""
-
-    if not user_id:
+    if user_id is None:
         raise HTTPException(status_code=400, detail="user_id is required")
     return PermissionsGraphAdapter(graph, user_id=user_id, group_id=group_id)
 

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -14,7 +14,8 @@ except Exception:  # pragma: no cover - provide stub for tests without limiter
             return None
 
         return _noop
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
+from pydantic_core import PydanticCustomError
 from sse_starlette.sse import EventSourceResponse
 
 from .analytics import shortest_path
@@ -100,6 +101,18 @@ class EdgeCreateRequest(BaseModel):
     target: str
     label: str
     attrs: Dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def _require_permission_level(self) -> "EdgeCreateRequest":
+        if self.label in {"OWNED_BY", "SHARED_WITH"}:
+            attrs = self.attrs or {}
+            perm = attrs.get("permission_level")
+            if not isinstance(perm, str) or not perm:
+                raise PydanticCustomError(
+                    "permission_level_missing",
+                    "permission_level is required for OWNED_BY/SHARED_WITH edges",
+                )
+        return self
 
 
 class RedactEdgeRequest(BaseModel):

--- a/tests/test_graph_routes_permissions.py
+++ b/tests/test_graph_routes_permissions.py
@@ -1,0 +1,153 @@
+"""Graph route permission tests for editor vs viewer behavior."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume.api_deps import TOKENS, TOKENS_LOCK
+from ume.config import settings
+from ume.graph import MockGraph
+
+
+@pytest.fixture()
+def client_with_graph() -> tuple[TestClient, MockGraph, dict[str, str]]:
+    graph = MockGraph()
+    configure_graph(graph)
+    client = TestClient(app)
+    try:
+        token_res = client.post(
+            "/auth/token",
+            data={
+                "username": settings.UME_OAUTH_USERNAME,
+                "password": settings.UME_OAUTH_PASSWORD,
+            },
+        )
+        token_res.raise_for_status()
+        token = token_res.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+        yield client, graph, headers
+    finally:
+        client.close()
+        with TOKENS_LOCK:
+            TOKENS.clear()
+
+
+def test_viewer_cannot_modify_graph(client_with_graph: tuple[TestClient, MockGraph, dict[str, str]]) -> None:
+    client, graph, headers = client_with_graph
+
+    graph.add_node("doc", {"type": "Document"})
+    graph.add_node("viewer", {"type": "User"})
+    graph.add_node("team", {"type": "UserGroup"})
+    graph.add_node("target", {"type": "User"})
+    graph.add_edge("doc", "viewer", "OWNED_BY", {"permission_level": "viewer"})
+    graph.add_edge("target", "viewer", "OWNED_BY", {"permission_level": "viewer"})
+
+    params = {"user_id": "viewer"}
+
+    res = client.patch(
+        "/nodes/doc",
+        json={"attributes": {"title": "updated"}},
+        headers=headers,
+        params=params,
+    )
+    assert res.status_code == 403
+    assert "Editor permission required" in res.json()["detail"]
+
+    res = client.post(
+        "/edges",
+        json={
+            "source": "doc",
+            "target": "team",
+            "label": "SHARED_WITH",
+            "attrs": {"permission_level": "viewer"},
+        },
+        headers=headers,
+        params=params,
+    )
+    assert res.status_code == 403
+
+    res = client.delete("/nodes/doc", headers=headers, params=params)
+    assert res.status_code == 403
+
+
+def test_permission_edge_requires_permission_level(
+    client_with_graph: tuple[TestClient, MockGraph, dict[str, str]]
+) -> None:
+    client, graph, headers = client_with_graph
+
+    graph.add_node("doc", {"type": "Document"})
+    graph.add_node("owner", {"type": "User"})
+    graph.add_node("team_view", {"type": "UserGroup"})
+    graph.add_node("team_missing", {"type": "UserGroup"})
+    graph.add_edge("doc", "owner", "OWNED_BY", {"permission_level": "editor"})
+
+    params = {"user_id": "owner"}
+
+    success = client.post(
+        "/edges",
+        json={
+            "source": "doc",
+            "target": "team_view",
+            "label": "SHARED_WITH",
+            "attrs": {"permission_level": "viewer"},
+        },
+        headers=headers,
+        params=params,
+    )
+    assert success.status_code == 200
+    assert any(
+        edge[0] == "doc"
+        and edge[1] == "team_view"
+        and edge[2] == "SHARED_WITH"
+        and edge[3].get("permission_level") == "viewer"
+        for edge in graph.get_all_edges()
+    )
+
+    failure = client.post(
+        "/edges",
+        json={
+            "source": "doc",
+            "target": "team_missing",
+            "label": "SHARED_WITH",
+        },
+        headers=headers,
+        params=params,
+    )
+    assert failure.status_code == 400
+    detail = failure.json()["detail"]
+    assert isinstance(detail, list)
+    assert any(
+        isinstance(entry, dict)
+        and entry.get("msg", "").startswith(
+            "permission_level is required for OWNED_BY/SHARED_WITH edges"
+        )
+        for entry in detail
+    )
+
+
+def test_subgraph_filters_view_only_subjects(
+    client_with_graph: tuple[TestClient, MockGraph, dict[str, str]]
+) -> None:
+    client, graph, headers = client_with_graph
+
+    graph.add_node("visible", {"type": "Document"})
+    graph.add_node("hidden", {"type": "Document"})
+    graph.add_node("viewer", {"type": "User"})
+    graph.add_node("other", {"type": "User"})
+    graph.add_edge("visible", "viewer", "OWNED_BY", {"permission_level": "viewer"})
+    graph.add_edge("hidden", "other", "OWNED_BY", {"permission_level": "editor"})
+    graph.add_edge("visible", "hidden", "RELATES_TO")
+
+    params = {"user_id": "viewer"}
+    response = client.post(
+        "/analytics/subgraph",
+        json={"start": "visible", "depth": 1},
+        headers=headers,
+        params=params,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert set(payload["nodes"].keys()) == {"visible"}
+    assert payload["edges"] == []


### PR DESCRIPTION
## Summary
- add coverage for graph route permissions, including viewer edit denial and subgraph filtering
- enforce permission_level validation for OWNED_BY and SHARED_WITH edge requests
- clean up get_permissions_graph annotations to work with FastAPI's dependency injection

## Testing
- pytest tests/test_graph_routes_permissions.py
- ruff check src/ume/graph_routes.py tests/test_graph_routes_permissions.py

------
https://chatgpt.com/codex/tasks/task_e_68e3d9d52b688326917bd96f597d1936