### PR TITLE
Allow proposed action metrics to accept arbitrary types

### DIFF
--- a/src/ume/models/proposed_action.py
+++ b/src/ume/models/proposed_action.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 import uuid
 
 
@@ -26,7 +27,7 @@ class ProposedAction:
     description: str
     rank: int = 0
     is_optimal: bool = False
-    outcome_metrics: dict[str, float] = field(default_factory=dict)
+    outcome_metrics: dict[str, Any] = field(default_factory=dict)
     schema_version: str = SCHEMA_VERSION
 
 
@@ -36,7 +37,7 @@ def create_proposed_action(
     action_id: str | None = None,
     rank: int = 0,
     is_optimal: bool = False,
-    outcome_metrics: dict[str, float] | None = None,
+    outcome_metrics: dict[str, Any] | None = None,
 ) -> ProposedAction:
     """Factory helper to build :class:`ProposedAction` instances."""
 

--- a/tests/test_proposed_action_model.py
+++ b/tests/test_proposed_action_model.py
@@ -22,3 +22,15 @@ def test_create_proposed_action_custom_values() -> None:
     assert action.rank == 1
     assert action.is_optimal is True
     assert action.outcome_metrics == metrics
+
+
+def test_create_proposed_action_mixed_metrics() -> None:
+    metrics = {
+        "success": True,
+        "details": {"precision": 0.8, "notes": ["fast", "reliable"]},
+        "attempts": 3,
+    }
+
+    action = create_proposed_action("deploy update", outcome_metrics=metrics)
+
+    assert action.outcome_metrics == metrics


### PR DESCRIPTION
## Summary
- update proposed action model to accept outcome metrics of any type
- extend tests to cover storing mixed-type metrics

## Testing
- `poetry run ruff check src tests`
- `poetry run pytest tests/test_proposed_action_model.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68e9254b0eac8326b8aef23c264d12e7