### PR TITLE
Allow non-float outcome metrics for decision actions

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -36,7 +36,7 @@ class ActionCreateRequest(BaseModel):
     description: str
     rank: int = 0
     is_optimal: bool = False
-    outcome_metrics: dict[str, float] | None = None
+    outcome_metrics: dict[str, Any] | None = None
     user_id: str
     group_id: str | None = None
     group_permission_level: str | None = None

--- a/src/ume/models/proposed_action.py
+++ b/src/ume/models/proposed_action.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import uuid
+
+from dataclasses import dataclass, field
+from typing import Any
 
 
 SCHEMA_VERSION = "3.0.0"
@@ -26,7 +28,7 @@ class ProposedAction:
     description: str
     rank: int = 0
     is_optimal: bool = False
-    outcome_metrics: dict[str, float] = field(default_factory=dict)
+    outcome_metrics: dict[str, Any] = field(default_factory=dict)
     schema_version: str = SCHEMA_VERSION
 
 
@@ -36,7 +38,7 @@ def create_proposed_action(
     action_id: str | None = None,
     rank: int = 0,
     is_optimal: bool = False,
-    outcome_metrics: dict[str, float] | None = None,
+    outcome_metrics: dict[str, Any] | None = None,
 ) -> ProposedAction:
     """Factory helper to build :class:`ProposedAction` instances."""
 

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -216,6 +216,37 @@ def test_decision_group_viewer_share_limits_editing(client_and_graph) -> None:
     )
 
 
+def test_add_action_preserves_outcome_metrics(client_and_graph) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+
+    res = client.post(
+        "/v1/decisions",
+        json={"query": "Q", "user_id": "user1"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    analysis_id = res.json()["analysis_id"]
+
+    metrics_payload = {"score": 1, "notes": "high", "metadata": {"tags": ["x"]}}
+    res = client.post(
+        f"/v1/decisions/{analysis_id}/actions",
+        json={
+            "description": "Act",
+            "user_id": "user1",
+            "outcome_metrics": metrics_payload,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    action_id = res.json()["action_id"]
+    assert res.json()["outcome_metrics"] == metrics_payload
+
+    node_attrs = g.get_node(action_id)
+    assert node_attrs is not None
+    assert node_attrs["outcome_metrics"] == metrics_payload
+
+
 def test_group_membership_required(client_and_graph) -> None:
     client, g = client_and_graph
     token = _token(client)

--- a/tests/test_proposed_action_model.py
+++ b/tests/test_proposed_action_model.py
@@ -22,3 +22,9 @@ def test_create_proposed_action_custom_values() -> None:
     assert action.rank == 1
     assert action.is_optimal is True
     assert action.outcome_metrics == metrics
+
+
+def test_create_proposed_action_allows_non_float_metrics() -> None:
+    metrics = {"status": "good", "details": {"notes": "ok"}}
+    action = create_proposed_action("ship", outcome_metrics=metrics)
+    assert action.outcome_metrics == metrics


### PR DESCRIPTION
## Summary
- allow action create requests to provide arbitrary outcome metrics without float coercion
- update proposed action model to store metrics with general typing and preserve payload values
- extend API and model tests to cover non-float metrics handling

## Testing
- `poetry run pytest tests/test_decisions_routes.py tests/test_proposed_action_model.py`
- `poetry run ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68e9254bced48326bbbe9fd9087f378f