### PR TITLE
Adjust delete_edge editor checks

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -191,7 +191,8 @@ class PermissionsGraphAdapter(IGraphAdapter):
         attrs: Dict[str, Any] | None = None,
     ) -> None:
         self._require_editor(source_node_id)
-        self._require_editor(target_node_id)
+        if label not in {"OWNED_BY", "SHARED_WITH", "INVITES"}:
+            self._require_editor(target_node_id)
         self._adapter.delete_edge(source_node_id, target_node_id, label, attrs)
         self.rebuild_index()
 


### PR DESCRIPTION
## Summary
- allow deleting OWNED_BY, SHARED_WITH, and INVITES edges without requiring editor rights on the target node
- keep other safety checks, including source editor requirement and index rebuild

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68ee6535a9408326ba56236a89800df2