### PR TITLE
Allow deleting shared and invite edges without target editor

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -191,7 +191,8 @@ class PermissionsGraphAdapter(IGraphAdapter):
         attrs: Dict[str, Any] | None = None,
     ) -> None:
         self._require_editor(source_node_id)
-        self._require_editor(target_node_id)
+        if label not in {"OWNED_BY", "SHARED_WITH", "INVITES"}:
+            self._require_editor(target_node_id)
         self._adapter.delete_edge(source_node_id, target_node_id, label, attrs)
         self.rebuild_index()
 

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -341,3 +341,32 @@ def test_add_edge_invalid_permission_level_on_non_permission_edge() -> None:
             "TAGGED_AS",
             {"permission_level": "owner"},
         )
+
+
+def test_delete_shared_with_and_invites_without_target_editor() -> None:
+    g = MockGraph()
+    g.add_node("User.u1", {})
+    g.add_node("User.u2", {})
+    g.add_node("Group.g1", {})
+    g.add_node("Document.d1", {})
+    g._edges["Document.d1"].append(
+        ("User.u1", "OWNED_BY", {"permission_level": "editor"})
+    )
+    g._edges["Document.d1"].append(
+        ("Group.g1", "SHARED_WITH", {"permission_level": "viewer"})
+    )
+    g._edges["Document.d1"].append(("User.u2", "INVITES", {}))
+
+    adapter = PermissionsGraphAdapter(g, user_id="User.u1")
+
+    adapter.delete_edge("Document.d1", "Group.g1", "SHARED_WITH")
+    assert not any(
+        s == "Document.d1" and t == "Group.g1" and lbl == "SHARED_WITH"
+        for s, t, lbl, _ in g.get_all_edges()
+    )
+
+    adapter.delete_edge("Document.d1", "User.u2", "INVITES")
+    assert not any(
+        s == "Document.d1" and t == "User.u2" and lbl == "INVITES"
+        for s, t, lbl, _ in g.get_all_edges()
+    )


### PR DESCRIPTION
## Summary
- relax the target editor requirement when deleting OWNED_WITH, SHARED_WITH, and INVITES edges
- add a regression test covering SHARED_WITH and INVITES edge deletions without target ownership

## Testing
- pytest tests/test_permissions_adapter.py *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68ee65368d408326a6a8e5831f198d10