### PR TITLE
Fix permissions adapter default dict usage

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Optional
 
 from .graph_adapter import IGraphAdapter
@@ -22,8 +23,8 @@ class PermissionsGraphAdapter(IGraphAdapter):
         self._adapter = adapter
         self.user_id = user_id
         self.group_id = group_id
-        self._edges_by_source: DefaultDict[str, List[tuple[str, str, Any]]] = DefaultDict(list)
-        self._edges_by_target: DefaultDict[str, List[tuple[str, str, Any]]] = DefaultDict(list)
+        self._edges_by_source: DefaultDict[str, List[tuple[str, str, Any]]] = defaultdict(list)
+        self._edges_by_target: DefaultDict[str, List[tuple[str, str, Any]]] = defaultdict(list)
         self.rebuild_index()
 
     # ------------------------------------------------------------------

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -12,6 +12,27 @@ def build_graph() -> MockGraph:
     return g
 
 
+def test_get_nodes_by_user_handles_empty_and_rebuilt_indices() -> None:
+    graph = build_graph()
+    adapter = PermissionsGraphAdapter(graph, user_id="User.u1")
+
+    # Initially only d1 is owned by the user.
+    assert adapter.get_nodes_by_user("User.u1") == ["Document.d1"]
+
+    # Add another ownership edge directly on the underlying graph and rebuild the index.
+    graph._edges["Document.d2"].append(
+        ("User.u1", "OWNED_BY", {"permission_level": "viewer"})
+    )
+    adapter.rebuild_index()
+    assert set(adapter.get_nodes_by_user("User.u1")) == {"Document.d1", "Document.d2"}
+
+    # Remove all edges and ensure rebuild clears the cached lookups.
+    graph._edges["Document.d1"].clear()
+    graph._edges["Document.d2"].clear()
+    adapter.rebuild_index()
+    assert adapter.get_nodes_by_user("User.u1") == []
+
+
 def test_update_requires_editor_permission() -> None:
     graph = build_graph()
     graph._edges["Document.d2"].append(


### PR DESCRIPTION
## Summary
- initialize permission edge caches with `collections.defaultdict` while keeping type annotations
- extend permission adapter tests to exercise `get_nodes_by_user` after rebuilds to ensure dictionaries are refreshed

## Testing
- pytest tests/test_permissions_adapter.py *(fails: missing dependency fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68f6370be658832688cb26dafd107d8b