### PR TITLE
Remove dataclass decorator from calendar status enum

### DIFF
--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -10,7 +10,6 @@ import uuid
 SCHEMA_VERSION = "3.0.0"
 
 
-@dataclass
 class CalendarEventStatus(str, Enum):
     """Possible participation statuses for a calendar event."""
 

--- a/tests/test_models_calendar_decision.py
+++ b/tests/test_models_calendar_decision.py
@@ -3,6 +3,7 @@ import uuid
 
 from ume.models import (
     CalendarEvent,
+    CalendarEventStatus,
     Decision,
     create_calendar_event,
     create_decision,
@@ -25,6 +26,17 @@ def test_create_calendar_event_defaults_and_schema_version() -> None:
     assert event.visibility is None
     assert event.schema_version == "3.0.0"
     assert event.start_time == start
+
+
+def test_calendar_event_accepts_status_enum() -> None:
+    start = datetime.utcnow()
+    event = create_calendar_event(
+        "Planning Session",
+        start,
+        status=CalendarEventStatus.CONFIRMED,
+    )
+
+    assert event.status is CalendarEventStatus.CONFIRMED
 
 
 def test_create_decision_defaults_and_schema_version() -> None:


### PR DESCRIPTION
## Summary
- remove the dataclass decorator from CalendarEventStatus to keep it a plain Enum
- expand calendar model tests to cover creating events with the status enum

## Testing
- `poetry run pytest tests/test_models_calendar_decision.py`


------
https://chatgpt.com/codex/tasks/task_e_68f64988d8cc83268a91aaa0a98a3580