### PR TITLE
Include node identifiers in stored node attributes

### DIFF
--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -43,6 +43,7 @@ def create_layer(
     )
     attrs = {
         "type": "CalendarLayer",
+        "layer_id": layer.layer_id,
         "layer_name": layer.layer_name,
         "color": layer.color,
         "schema_version": layer.schema_version,
@@ -75,8 +76,8 @@ def create_layer(
     return CalendarLayerResponse(
         layer_id=layer.layer_id,
         layer_name=layer.layer_name,
-       color=layer.color,
-       schema_version=layer.schema_version,
+        color=layer.color,
+        schema_version=layer.schema_version,
     )
 
 

--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -122,6 +122,7 @@ def create_event(
     layer_ids = list(req.layer_ids or [])
     attrs = {
         "type": "CalendarEvent",
+        "event_id": event.event_id,
         "title": event.title,
         "start_time": int(event.start_time.timestamp()),
         "end_time": int(event.end_time.timestamp()) if event.end_time else None,

--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -63,6 +63,7 @@ def create_account(
     )
     attrs = {
         "type": "FinancialAccount",
+        "account_id": account.account_id,
         "account_type": account.account_type,
         "institution": account.institution,
         "balance": account.balance,

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -113,6 +113,7 @@ def test_calendar_event_permissions(client_and_graph) -> None:
 
     attrs = graph.get_node(event_id)
     assert attrs["type"] == "CalendarEvent"
+    assert attrs["event_id"] == event_id
     assert attrs["title"] == "Meeting"
     assert attrs["start_time"] == start_ts
     assert attrs["end_time"] == end_ts

--- a/tests/test_calendar_layer_routes.py
+++ b/tests/test_calendar_layer_routes.py
@@ -51,6 +51,7 @@ def test_create_calendar_layer(client_and_graph) -> None:
     attrs = graph.get_node(layer_id)
     assert attrs == {
         "type": "CalendarLayer",
+        "layer_id": layer_id,
         "layer_name": "Work",
         "color": "blue",
         "schema_version": SCHEMA_VERSION,

--- a/tests/test_financial_account_routes.py
+++ b/tests/test_financial_account_routes.py
@@ -60,6 +60,7 @@ def test_create_and_get_financial_account(client_and_graph) -> None:
         "schema_version": SCHEMA_VERSION,
     }
     attrs = graph.get_node(account_id)
+    assert attrs["account_id"] == account_id
     assert attrs["schema_version"] == SCHEMA_VERSION
     edges = graph.get_all_edges()
     assert (


### PR DESCRIPTION
## Summary
- add identifier fields to calendar event, calendar layer, and financial account node attribute dictionaries
- update API tests to validate the stored graph nodes now retain their identifiers

## Testing
- pytest tests/test_calendar_decision_api.py tests/test_calendar_layer_routes.py tests/test_financial_account_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68f649856750832689361e70f0817dfd