### PR TITLE
Ensure GraphQL API enforces permissions

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -135,12 +135,22 @@ app.include_router(users_router)
 # ``add_route``. Guard the GraphQL route registration so those tests can import
 # this module without the real FastAPI implementation.
 if GraphQLApp is not None and graphql_schema is not None and hasattr(app, "add_route"):
+    async def _graphql_context(request: Request) -> dict[str, Any]:
+        user_id = request.query_params.get("user_id") or request.headers.get("x-user-id")
+        group_id = request.query_params.get("group_id") or request.headers.get("x-group-id")
+        return {
+            "app": app,
+            "request": request,
+            "user_id": user_id,
+            "group_id": group_id,
+        }
+
     app.add_route(
         "/graphql",
         GraphQLApp(
             graphql_schema,
             on_get=make_graphiql_handler(),
-            context_value=lambda request: {"app": app},
+            context_value=_graphql_context,
         ),
         methods=["GET", "POST"],
     )

--- a/src/ume/graphql_api.py
+++ b/src/ume/graphql_api.py
@@ -7,6 +7,12 @@ from typing import Any
 import graphene
 from graphene.types.generic import GenericScalar
 
+from fastapi import HTTPException
+from graphql import GraphQLError
+
+from . import api_deps as deps
+from .permissions_adapter import PermissionsGraphAdapter
+
 
 async def _maybe_call(obj: Any, name: str, *args: Any) -> Any:
     method = getattr(obj, name)
@@ -16,6 +22,32 @@ async def _maybe_call(obj: Any, name: str, *args: Any) -> Any:
     if inspect.isawaitable(result):
         return await result
     return result
+
+
+def _get_permissions_graph(info: graphene.ResolveInfo) -> PermissionsGraphAdapter | None:
+    context = info.context
+    if "permissions_graph" in context:
+        return context["permissions_graph"]
+
+    app = context["app"]
+    graph = getattr(app.state, "graph", None)
+    if graph is None:
+        context["permissions_graph"] = None
+        return None
+
+    user_id = context.get("user_id")
+    group_id = context.get("group_id")
+    try:
+        perm_graph = deps.get_permissions_graph(
+            graph=graph,
+            user_id=user_id,
+            group_id=group_id,
+        )
+    except HTTPException as exc:  # pragma: no cover - converted to GraphQL error
+        raise GraphQLError(exc.detail) from exc
+
+    context["permissions_graph"] = perm_graph
+    return perm_graph
 
 
 class NodeType(graphene.ObjectType):
@@ -32,10 +64,10 @@ class NodeType(graphene.ObjectType):
     async def resolve_edges(
         self, info: graphene.ResolveInfo, label: str | None = None
     ) -> list["EdgeType"]:
-        graph = info.context["app"].state.graph
-        if graph is None:
+        perm_graph = _get_permissions_graph(info)
+        if perm_graph is None:
             return []
-        all_edges = await _maybe_call(graph, "get_all_edges")
+        all_edges = await _maybe_call(perm_graph, "get_all_edges")
         result = []
         for src, tgt, lbl, _ in all_edges:
             if src == self.id and (label is None or lbl == label):
@@ -75,30 +107,30 @@ class Query(graphene.ObjectType):
     )
 
     async def resolve_node(self, info: graphene.ResolveInfo, id: str) -> NodeType | None:
-        graph = info.context["app"].state.graph
-        if graph is None:
+        perm_graph = _get_permissions_graph(info)
+        if perm_graph is None:
             return None
-        data = await _maybe_call(graph, "get_node", id)
+        data = await _maybe_call(perm_graph, "get_node", id)
         if data is None:
             return None
         return NodeType(id=id, attributes=data)
 
     async def resolve_nodes(self, info: graphene.ResolveInfo) -> list[NodeType]:
-        graph = info.context["app"].state.graph
-        if graph is None:
+        perm_graph = _get_permissions_graph(info)
+        if perm_graph is None:
             return []
-        ids = await _maybe_call(graph, "get_all_node_ids")
+        ids = await _maybe_call(perm_graph, "get_all_node_ids")
         result = []
         for nid in ids:
-            data = await _maybe_call(graph, "get_node", nid)
+            data = await _maybe_call(perm_graph, "get_node", nid)
             result.append(NodeType(id=nid, attributes=data or {}))
         return result
 
     async def resolve_edges(self, info: graphene.ResolveInfo) -> list[EdgeType]:
-        graph = info.context["app"].state.graph
-        if graph is None:
+        perm_graph = _get_permissions_graph(info)
+        if perm_graph is None:
             return []
-        edges = await _maybe_call(graph, "get_all_edges")
+        edges = await _maybe_call(perm_graph, "get_all_edges")
         return [EdgeType(source=s, target=t, label=lbl) for s, t, lbl, _ in edges]
 
     async def resolve_path(
@@ -110,11 +142,11 @@ class Query(graphene.ObjectType):
         edge_label: str | None = None,
         since_timestamp: int | None = None,
     ) -> list[str]:
-        graph = info.context["app"].state.graph
-        if graph is None:
+        perm_graph = _get_permissions_graph(info)
+        if perm_graph is None:
             return []
         return await _maybe_call(
-            graph,
+            perm_graph,
             "constrained_path",
             source,
             target,
@@ -129,21 +161,21 @@ class Query(graphene.ObjectType):
         topic: str,
         entity: str | None = None,
     ) -> list[NodeType]:
-        graph = info.context["app"].state.graph
-        if graph is None:
+        perm_graph = _get_permissions_graph(info)
+        if perm_graph is None:
             return []
         try:
-            doc_ids = await _maybe_call(graph, "find_connected_nodes", topic)
+            doc_ids = await _maybe_call(perm_graph, "find_connected_nodes", topic)
         except Exception:
             return []
         results: list[NodeType] = []
         for doc_id in doc_ids:
-            data = await _maybe_call(graph, "get_node", doc_id)
+            data = await _maybe_call(perm_graph, "get_node", doc_id)
             if data is None:
                 continue
             if entity is not None:
                 try:
-                    ents = await _maybe_call(graph, "find_connected_nodes", doc_id)
+                    ents = await _maybe_call(perm_graph, "find_connected_nodes", doc_id)
                 except Exception:
                     continue
                 if entity not in ents:
@@ -161,8 +193,10 @@ class CreateNode(graphene.Mutation):
     node = graphene.Field(NodeType)
 
     async def mutate(self, info: graphene.ResolveInfo, id: str, attributes: dict[str, Any] | None = None) -> "CreateNode":
-        graph = info.context["app"].state.graph
-        await _maybe_call(graph, "add_node", id, attributes or {})
+        perm_graph = _get_permissions_graph(info)
+        if perm_graph is None:
+            raise GraphQLError("Graph not configured")
+        await _maybe_call(perm_graph, "add_node", id, attributes or {})
         return CreateNode(ok=True, node=NodeType(id=id, attributes=attributes or {}))
 
 
@@ -175,8 +209,10 @@ class CreateEdge(graphene.Mutation):
     ok = graphene.Boolean()
 
     async def mutate(self, info: graphene.ResolveInfo, source: str, target: str, label: str) -> "CreateEdge":
-        graph = info.context["app"].state.graph
-        await _maybe_call(graph, "add_edge", source, target, label)
+        perm_graph = _get_permissions_graph(info)
+        if perm_graph is None:
+            raise GraphQLError("Graph not configured")
+        await _maybe_call(perm_graph, "add_edge", source, target, label)
         return CreateEdge(ok=True)
 
 

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,31 +1,53 @@
+import pytest
 from fastapi.testclient import TestClient
-from ume.api import app, configure_graph
+
 from ume import MockGraph
+from ume.api import app, configure_graph
 
 
-def setup_module(_):
+def _configure_permissions_graph() -> None:
     g = MockGraph()
-    g.add_node("a", {"x": 1})
-    g.add_node("b", {"y": 2})
-    g.add_edge("a", "b", "ab")
+    g.add_node("doc_visible", {"x": 1})
+    g.add_node("doc_shared", {"z": 3})
+    g.add_node("doc_other", {"y": 2})
+    g.add_node("User.viewer", {})
+    g.add_node("User.other", {})
+    g.add_edge("doc_visible", "User.viewer", "OWNED_BY")
+    g.add_edge("doc_shared", "User.viewer", "OWNED_BY")
+    g.add_edge("doc_other", "User.other", "OWNED_BY")
+    g.add_edge("doc_visible", "doc_shared", "RELATED")
     configure_graph(g)
+
+
+@pytest.fixture(autouse=True)
+def reset_graph() -> None:
+    _configure_permissions_graph()
 
 
 def test_query_nodes() -> None:
     client = TestClient(app)
-    res = client.post("/graphql", json={"query": "{ nodes { id attributes } }"})
+    res = client.post(
+        "/graphql",
+        params={"user_id": "User.viewer"},
+        json={"query": "{ nodes { id attributes } }"},
+    )
     assert res.status_code == 200
     data = res.json()["data"]["nodes"]
-    assert {"id": "a", "attributes": {"x": 1}} in data
-    assert {"id": "b", "attributes": {"y": 2}} in data
+    assert {"id": "doc_visible", "attributes": {"x": 1}} in data
+    assert {"id": "doc_shared", "attributes": {"z": 3}} in data
+    assert all(node["id"] != "doc_other" for node in data)
 
 
 def test_query_edges() -> None:
     client = TestClient(app)
-    res = client.post("/graphql", json={"query": "{ edges { source target label } }"})
+    res = client.post(
+        "/graphql",
+        params={"user_id": "User.viewer"},
+        json={"query": "{ edges { source target label } }"},
+    )
     assert res.status_code == 200
     data = res.json()["data"]["edges"]
-    assert {"source": "a", "target": "b", "label": "ab"} in data
+    assert data == [{"source": "doc_visible", "target": "doc_shared", "label": "RELATED"}]
 
 
 def test_create_node_mutation() -> None:
@@ -37,11 +59,19 @@ def test_create_node_mutation() -> None:
     )
     res = client.post(
         "/graphql",
-        json={"query": mutation, "variables": {"id": "c", "attrs": {"z": 3}}},
+        params={"user_id": "User.viewer"},
+        json={"query": mutation, "variables": {"id": "doc_new", "attrs": {"z": 3}}},
     )
     assert res.status_code == 200
     assert res.json()["data"]["createNode"]["ok"] is True
-    assert app.state.graph.get_node("c") == {"z": 3}
+    assert app.state.graph.get_node("doc_new") == {"z": 3}
+
+
+def _edge_exists(source: str, target: str, label: str) -> bool:
+    for s, t, lbl, _ in app.state.graph.get_all_edges():
+        if s == source and t == target and lbl == label:
+            return True
+    return False
 
 
 def test_create_edge_mutation() -> None:
@@ -53,25 +83,67 @@ def test_create_edge_mutation() -> None:
     )
     res = client.post(
         "/graphql",
-        json={"query": mutation, "variables": {"s": "b", "t": "a", "lbl": "ba"}},
+        params={"user_id": "User.viewer"},
+        json={
+            "query": mutation,
+            "variables": {"s": "doc_shared", "t": "doc_visible", "lbl": "LINKS"},
+        },
     )
     assert res.status_code == 200
     assert res.json()["data"]["createEdge"]["ok"] is True
-    assert ("b", "a", "ba", {}) in app.state.graph.get_all_edges()
+    assert _edge_exists("doc_shared", "doc_visible", "LINKS")
 
 
 def test_edges_for_node() -> None:
     client = TestClient(app)
-    query = "{ node(id: \"a\") { edges { source target label } } }"
-    res = client.post("/graphql", json={"query": query})
+    query = "{ node(id: \"doc_visible\") { edges { source target label } } }"
+    res = client.post(
+        "/graphql",
+        params={"user_id": "User.viewer"},
+        json={"query": query},
+    )
     assert res.status_code == 200
     edges = res.json()["data"]["node"]["edges"]
-    assert edges == [{"source": "a", "target": "b", "label": "ab"}]
+    assert edges == [{"source": "doc_visible", "target": "doc_shared", "label": "RELATED"}]
 
 
 def test_path_query() -> None:
     client = TestClient(app)
-    query = "{ path(source: \"a\", target: \"b\") }"
-    res = client.post("/graphql", json={"query": query})
+    query = "{ path(source: \"doc_visible\", target: \"doc_shared\") }"
+    res = client.post(
+        "/graphql",
+        params={"user_id": "User.viewer"},
+        json={"query": query},
+    )
     assert res.status_code == 200
-    assert res.json()["data"]["path"] == ["a", "b"]
+    assert res.json()["data"]["path"] == ["doc_visible", "doc_shared"]
+
+
+def test_unauthorized_user_cannot_read_inaccessible_node() -> None:
+    client = TestClient(app)
+    query = "{ node(id: \"doc_visible\") { id attributes } }"
+    res = client.post(
+        "/graphql",
+        params={"user_id": "User.other"},
+        json={"query": query},
+    )
+    assert res.status_code == 200
+    assert res.json()["data"]["node"] is None
+
+
+def test_unauthorized_user_cannot_mutate_without_editor() -> None:
+    client = TestClient(app)
+    mutation = (
+        "mutation {"
+        "  createEdge(source: \"doc_visible\", target: \"doc_shared\", label: \"FAIL\") { ok }"
+        "}"
+    )
+    res = client.post(
+        "/graphql",
+        params={"user_id": "User.other"},
+        json={"query": mutation},
+    )
+    body = res.json()
+    assert "errors" in body
+    assert any("Editor permission required" in err["message"] for err in body["errors"])
+    assert not _edge_exists("doc_visible", "doc_shared", "FAIL")


### PR DESCRIPTION
## Summary
- wrap GraphQL resolvers and mutations with a request-scoped `PermissionsGraphAdapter`
- expose user and group identifiers through the GraphQL context so permission checks can succeed
- add GraphQL tests that cover allowed access as well as unauthorized read and mutation attempts

## Testing
- pytest tests/test_graphql.py
- poetry run ruff check src/ume/graphql_api.py tests/test_graphql.py

------
https://chatgpt.com/codex/tasks/task_e_68f8de9bc6ec832695c458c34c5cf6bd