### PR TITLE
Enforce permissions in vector endpoints

### DIFF
--- a/src/ume/api_deps.py
+++ b/src/ume/api_deps.py
@@ -142,7 +142,39 @@ def get_permissions_graph(
         )
     if user_id is None:
         raise HTTPException(status_code=400, detail="user_id is required")
-    return PermissionsGraphAdapter(graph, user_id=user_id, group_id=group_id)
+
+    base_graph: IGraphAdapter | IAsyncGraphAdapter = graph
+
+    if isinstance(base_graph, PermissionsGraphAdapter):
+        base_graph = base_graph._adapter  # type: ignore[attr-defined]
+
+    # Unwrap adapters that contain asynchronous implementations so that the
+    # permissions wrapper always sees a synchronous :class:`IGraphAdapter`.
+    while True:
+        adapter = getattr(base_graph, "_adapter", None)
+        if adapter is None or adapter is base_graph:
+            break
+        if isinstance(adapter, IAsyncGraphAdapter):
+            base_graph = adapter
+            continue
+        break
+
+    if isinstance(base_graph, IAsyncGraphAdapter):
+        sync_adapter = getattr(base_graph, "_adapter", None)
+        if not isinstance(sync_adapter, IGraphAdapter):
+            raise HTTPException(
+                status_code=500,
+                detail="Async graphs are not supported for permission checks",
+            )
+        base_graph = sync_adapter
+
+    if not isinstance(base_graph, IGraphAdapter):
+        raise HTTPException(
+            status_code=500,
+            detail="Graph does not support permission checks",
+        )
+
+    return PermissionsGraphAdapter(base_graph, user_id=user_id, group_id=group_id)
 
 
 def get_vector_store() -> VectorStore:

--- a/src/ume/vector_routes.py
+++ b/src/ume/vector_routes.py
@@ -11,8 +11,8 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from . import api_deps as deps
+from .permissions_adapter import PermissionsGraphAdapter
 from .vector_store import VectorStore
-from .graph_adapter import IGraphAdapter
 from .graph_routes import _maybe_call
 from . import embedding
 from .metrics import (
@@ -67,7 +67,7 @@ async def api_semantic_search(
     req: SemanticSearchRequest,
     _: str = Depends(deps.get_current_role),
     store: VectorStore = Depends(deps.get_vector_store),
-    graph: IGraphAdapter = Depends(deps.get_graph),
+    perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
 ) -> Dict[str, Any]:
     """Return attributes for the ``k`` nearest nodes to ``req.query``."""
     start = time.perf_counter()
@@ -79,7 +79,7 @@ async def api_semantic_search(
     ids = store.query(vector, k=req.k)
     nodes = []
     for node_id in ids:
-        attrs = await _maybe_call(graph, "get_node", node_id)
+        attrs = await _maybe_call(perm_graph, "get_node", node_id)
         if attrs is not None:
             nodes.append({"id": node_id, "attributes": attrs})
     SEMANTIC_SEARCH_LATENCY.observe(time.perf_counter() - start)
@@ -93,7 +93,7 @@ async def api_recall(
     k: int = 5,
     _: str = Depends(deps.get_current_role),
     store: VectorStore = Depends(deps.get_vector_store),
-    graph: IGraphAdapter = Depends(deps.get_graph),
+    perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
 ) -> Dict[str, Any]:
     """Return attributes for the ``k`` nearest nodes to ``query`` or ``vector``."""
     if query is None and vector is None:
@@ -107,15 +107,16 @@ async def api_recall(
     ids = store.query(vector, k=k)
     nodes = []
     for node_id in ids:
-        attrs = await _maybe_call(graph, "get_node", node_id)
-        if attrs is not None:
-            emb = attrs.get("embedding")
-            if isinstance(emb, list) and len(emb) == len(vector):
-                try:
-                    RECALL_SCORE.observe(math.dist(vector, emb))
-                except TypeError:
-                    pass
-            nodes.append({"id": node_id, "attributes": attrs})
+        attrs = await _maybe_call(perm_graph, "get_node", node_id)
+        if attrs is None:
+            continue
+        emb = attrs.get("embedding")
+        if isinstance(emb, list) and len(emb) == len(vector):
+            try:
+                RECALL_SCORE.observe(math.dist(vector, emb))
+            except TypeError:
+                pass
+        nodes.append({"id": node_id, "attributes": attrs})
     duration = time.perf_counter() - start
     RECALL_LATENCY.observe(duration)
     RECALL_LATENCY_MS.observe(duration * 1000)
@@ -129,7 +130,7 @@ async def api_recall_stream(
     k: int = 5,
     _: str = Depends(deps.get_current_role),
     store: VectorStore = Depends(deps.get_vector_store),
-    graph: IGraphAdapter = Depends(deps.get_graph),
+    perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
 ) -> StreamingResponse:
     """Stream nearest nodes one by one as they are found."""
     if query is None and vector is None:
@@ -144,16 +145,18 @@ async def api_recall_stream(
         start = time.perf_counter()
         ids = store.query(vector, k=k)
         for node_id in ids:
-            attrs = await _maybe_call(graph, "get_node", node_id)
-            if attrs is not None:
-                emb = attrs.get("embedding")
-                if isinstance(emb, list) and len(emb) == len(vector):
-                    try:
-                        RECALL_SCORE.observe(math.dist(vector, emb))
-                    except TypeError:
-                        pass
-                payload = {"id": node_id, "attributes": attrs}
-                yield f"data: {json.dumps(payload)}\n\n"
+            attrs = await _maybe_call(perm_graph, "get_node", node_id)
+            if attrs is None:
+                await asyncio.sleep(0)
+                continue
+            emb = attrs.get("embedding")
+            if isinstance(emb, list) and len(emb) == len(vector):
+                try:
+                    RECALL_SCORE.observe(math.dist(vector, emb))
+                except TypeError:
+                    pass
+            payload = {"id": node_id, "attributes": attrs}
+            yield f"data: {json.dumps(payload)}\n\n"
             await asyncio.sleep(0)
         duration = time.perf_counter() - start
         RECALL_LATENCY.observe(duration)

--- a/tests/test_vector_api.py
+++ b/tests/test_vector_api.py
@@ -8,6 +8,10 @@ from ume.vector_backends import get_backend
 from ume.api import app, configure_vector_store
 from ume.config import settings
 
+USER_ID = "User.alice"
+OTHER_USER_ID = "User.bob"
+GROUP_ID = "Group.collab"
+
 faiss = pytest.importorskip("faiss")
 if not hasattr(faiss, "IndexFlatL2"):
     pytest.skip("faiss is missing required functionality", allow_module_level=True)
@@ -126,6 +130,9 @@ def test_recall_by_query(monkeypatch, store_cls) -> None:
     graph = MockGraph()
     graph.add_node("a", {"val": 1})
     graph.add_node("b", {"val": 2})
+    graph.add_node(USER_ID, {})
+    graph.add_edge("a", USER_ID, "OWNED_BY", {"permission_level": "viewer"})
+    graph.add_edge("b", USER_ID, "OWNED_BY", {"permission_level": "viewer"})
     configure_graph(graph)
     store = app.state.vector_store
     store.add("a", [1.0, 0.0])
@@ -139,7 +146,7 @@ def test_recall_by_query(monkeypatch, store_cls) -> None:
     ).json()["access_token"]
     res = client.get(
         "/recall",
-        params={"query": "foo", "k": 1},
+        params={"query": "foo", "k": 1, "user_id": USER_ID},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
@@ -154,6 +161,7 @@ def test_recall_invalid_dimension(store_cls) -> None:
 
     graph = MockGraph()
     graph.add_node("a", {})
+    graph.add_node(USER_ID, {})
     configure_graph(graph)
     client = TestClient(app)
     token = client.post(
@@ -162,7 +170,7 @@ def test_recall_invalid_dimension(store_cls) -> None:
     ).json()["access_token"]
     res = client.get(
         "/recall",
-        params=[("vector", 0.0)],
+        params=[("vector", 0.0), ("user_id", USER_ID)],
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 400
@@ -189,6 +197,8 @@ def test_recall_stream(store_cls, monkeypatch) -> None:
 
     graph = MockGraph()
     graph.add_node("a", {"val": 1})
+    graph.add_node(USER_ID, {})
+    graph.add_edge("a", USER_ID, "OWNED_BY", {"permission_level": "viewer"})
     configure_graph(graph)
     store = app.state.vector_store
     store.add("a", [1.0, 0.0])
@@ -201,12 +211,81 @@ def test_recall_stream(store_cls, monkeypatch) -> None:
         with client.stream(
             "GET",
             "/recall/stream",
-            params={"query": "foo", "k": 1},
+            params={"query": "foo", "k": 1, "user_id": USER_ID},
             headers={"Authorization": f"Bearer {token}"},
         ) as res:
             assert res.status_code == 200
             lines = [line for line in res.iter_lines() if line.startswith("data:")]
         assert lines
+
+
+def test_semantic_search_hides_inaccessible_nodes(monkeypatch, store_cls) -> None:
+    configure_vector_store(store_cls(dim=2, use_gpu=False))
+    from ume import MockGraph
+    from ume.api import configure_graph
+
+    graph = MockGraph()
+    graph.add_node("a", {"val": 1})
+    graph.add_node("b", {"val": 2})
+    graph.add_node(USER_ID, {})
+    graph.add_node(OTHER_USER_ID, {})
+    graph.add_edge("a", USER_ID, "OWNED_BY", {"permission_level": "viewer"})
+    graph.add_edge("b", OTHER_USER_ID, "OWNED_BY", {"permission_level": "viewer"})
+    configure_graph(graph)
+    store = app.state.vector_store
+    store.add("a", [1.0, 0.0])
+    store.add("b", [0.0, 1.0])
+
+    monkeypatch.setattr("ume.embedding.generate_embedding", lambda q: [1.0, 0.0])
+    client = TestClient(app)
+    token = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    ).json()["access_token"]
+    res = client.post(
+        "/search/semantic",
+        json={"query": "foo", "k": 2},
+        params={"user_id": USER_ID},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"nodes": [{"id": "a", "attributes": {"val": 1}}]}
+
+
+def test_recall_includes_group_shares(monkeypatch, store_cls) -> None:
+    configure_vector_store(store_cls(dim=2, use_gpu=False))
+    from ume import MockGraph
+    from ume.api import configure_graph
+
+    graph = MockGraph()
+    graph.add_node("shared", {"val": 5})
+    graph.add_node(USER_ID, {})
+    graph.add_node(OTHER_USER_ID, {})
+    graph.add_node(GROUP_ID, {})
+    graph.add_edge("shared", OTHER_USER_ID, "OWNED_BY", {"permission_level": "editor"})
+    graph.add_edge("shared", GROUP_ID, "SHARED_WITH", {"permission_level": "viewer"})
+    configure_graph(graph)
+    store = app.state.vector_store
+    store.add("shared", [1.0, 0.0])
+
+    monkeypatch.setattr("ume.embedding.generate_embedding", lambda q: [1.0, 0.0])
+    client = TestClient(app)
+    token = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    ).json()["access_token"]
+    res = client.get(
+        "/recall",
+        params={
+            "query": "foo",
+            "k": 1,
+            "user_id": USER_ID,
+            "group_id": GROUP_ID,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == {"nodes": [{"id": "shared", "attributes": {"val": 5}}]}
 
 
 def test_semantic_search_async_adapter(store_cls, monkeypatch) -> None:
@@ -217,6 +296,10 @@ def test_semantic_search_async_adapter(store_cls, monkeypatch) -> None:
 
     graph = AsyncGraphAdapterWrapper(MockGraph())
     graph._adapter.add_node("a", {"val": 1})  # type: ignore[attr-defined]
+    graph._adapter.add_node(USER_ID, {})  # type: ignore[attr-defined]
+    graph._adapter.add_edge(
+        "a", USER_ID, "OWNED_BY", {"permission_level": "viewer"}
+    )  # type: ignore[attr-defined]
     configure_graph(graph)
     store = app.state.vector_store
     store.add("a", [1.0, 0.0])
@@ -229,6 +312,7 @@ def test_semantic_search_async_adapter(store_cls, monkeypatch) -> None:
     res = client.post(
         "/search/semantic",
         json={"query": "foo", "k": 1},
+        params={"user_id": USER_ID},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
@@ -243,6 +327,10 @@ def test_recall_async_adapter(store_cls, monkeypatch) -> None:
 
     graph = AsyncGraphAdapterWrapper(MockGraph())
     graph._adapter.add_node("a", {"val": 1})  # type: ignore[attr-defined]
+    graph._adapter.add_node(USER_ID, {})  # type: ignore[attr-defined]
+    graph._adapter.add_edge(
+        "a", USER_ID, "OWNED_BY", {"permission_level": "viewer"}
+    )  # type: ignore[attr-defined]
     configure_graph(graph)
     store = app.state.vector_store
     store.add("a", [1.0, 0.0])
@@ -254,7 +342,7 @@ def test_recall_async_adapter(store_cls, monkeypatch) -> None:
     ).json()["access_token"]
     res = client.get(
         "/recall",
-        params={"query": "foo", "k": 1},
+        params={"query": "foo", "k": 1, "user_id": USER_ID},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200


### PR DESCRIPTION
## Summary
- require the permissions graph for vector search and recall endpoints so that hidden nodes are filtered out of responses
- ensure the permissions dependency unwraps async adapters before wrapping so permissions checks work with async graphs
- expand vector API tests to supply user context and cover hidden-node and shared-node visibility cases

## Testing
- `poetry run pytest tests/test_vector_api.py`
- `poetry run ruff check src/ume/vector_routes.py tests/test_vector_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68f8e5c6d6f083268028c9cd8573812d