### PR TITLE
Add schema v3 migrate tests and update event conversion logic

### DIFF
--- a/src/ume/migrate_events.py
+++ b/src/ume/migrate_events.py
@@ -21,17 +21,51 @@ except Exception:  # pragma: no cover - optional kafka
 
 logger = logging.getLogger(__name__)
 
-TARGET_VERSION = "2.0.0"
+TARGET_VERSION = "3.0.0"
+
+_DEPRECATED_EDGE_LABELS = {
+    "REMEMBERS",
+    "ASSOCIATED_WITH",
+    "CAUSES",
+    "LINKS_TO",
+    "CONNECTS_TO",
+    "RELATES_TO",
+}
 
 
 def _migrate_event(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Transform an event dictionary for ``TARGET_VERSION``."""
-    etype = event.get("event_type")
+    etype = event.get("event_type") or event.get("eventType")
     if etype in {"CREATE_EDGE", "DELETE_EDGE"}:
         label = event.get("label")
         if label == "L":
-            event["label"] = "LINKS_TO"
-        elif label == "TO_DELETE":
+            label = "LINKS_TO"
+            event["label"] = label
+
+        if label == "NEW_LABEL":
+            label = "TAGGED_AS"
+            event["label"] = label
+
+        if label == "HAS_PERMISSION":
+            payload = event.get("payload")
+            if not isinstance(payload, dict):
+                payload = {}
+            attrs = payload.get("attributes")
+            if not isinstance(attrs, dict):
+                attrs = {}
+
+            perm_level = attrs.get("permission_level")
+            if not isinstance(perm_level, str) or not perm_level:
+                perm_level = "viewer"
+            new_label = "OWNED_BY" if perm_level == "editor" else "SHARED_WITH"
+
+            attrs["permission_level"] = perm_level
+            payload["attributes"] = attrs
+            event["payload"] = payload
+            event["label"] = new_label
+            label = new_label
+
+        if label in _DEPRECATED_EDGE_LABELS or label == "TO_DELETE":
             return None
     return event
 
@@ -82,6 +116,8 @@ def migrate_events(source: str = "ledger") -> Iterable[Dict[str, Any]]:
         events = _iter_ledger_events(event_ledger)
 
     for evt in events:
+        if isinstance(evt, dict) and "event" in evt and isinstance(evt["event"], dict):
+            evt = evt["event"]
         new_evt = _migrate_event(evt)
         if new_evt is None:
             continue

--- a/tests/test_migrate_events_v3.py
+++ b/tests/test_migrate_events_v3.py
@@ -1,0 +1,68 @@
+import itertools
+from typing import Iterable
+
+import pytest
+
+from ume import migrate_events
+
+
+ISO_TS = "2024-01-01T00:00:00Z"
+
+
+def _legacy_edge(label: str, target: str, permission: str | None = None) -> dict[str, object]:
+    payload: dict[str, object] = {}
+    if permission is not None:
+        payload = {"attributes": {"permission_level": permission}}
+    return {
+        "eventType": "CREATE_EDGE",
+        "timestamp": ISO_TS,
+        "node_id": "doc",
+        "target_node_id": target,
+        "label": label,
+        "payload": payload,
+    }
+
+
+def test_migrate_events_ledger_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    ledger_events = [
+        _legacy_edge("HAS_PERMISSION", "user_editor", "editor"),
+        _legacy_edge("HAS_PERMISSION", "user_viewer", "viewer"),
+        _legacy_edge("REMEMBERS", "user_ignore"),
+    ]
+
+    def fake_iter_ledger(_ledger: object) -> Iterable[dict[str, object]]:
+        return iter(itertools.chain(ledger_events))
+
+    monkeypatch.setattr(migrate_events, "_iter_ledger_events", fake_iter_ledger)
+
+    envelopes = list(migrate_events.migrate_events("ledger"))
+
+    assert [env["schema_version"] for env in envelopes] == ["3.0.0", "3.0.0"]
+
+    owned, shared = [env["event"] for env in envelopes]
+    assert owned["label"] == "OWNED_BY"
+    assert owned["payload"]["attributes"]["permission_level"] == "editor"
+    assert shared["label"] == "SHARED_WITH"
+    assert shared["payload"]["attributes"]["permission_level"] == "viewer"
+
+
+def test_migrate_events_kafka_envelopes(monkeypatch: pytest.MonkeyPatch) -> None:
+    kafka_messages = [
+        {"event": _legacy_edge("HAS_PERMISSION", "user_default")},
+        {"event": _legacy_edge("LINKS_TO", "other")},
+    ]
+
+    def fake_iter_kafka() -> Iterable[dict[str, object]]:
+        return iter(kafka_messages)
+
+    monkeypatch.setattr(migrate_events, "_iter_kafka_events", fake_iter_kafka)
+
+    envelopes = list(migrate_events.migrate_events("kafka"))
+
+    assert len(envelopes) == 1
+    envelope = envelopes[0]
+    assert envelope["schema_version"] == "3.0.0"
+    event = envelope["event"]
+    assert event["label"] == "SHARED_WITH"
+    attrs = event["payload"]["attributes"]
+    assert attrs["permission_level"] == "viewer"


### PR DESCRIPTION
## Summary
- update the migration helper to target schema version 3.0.0, remap legacy permission labels, and drop deprecated edges
- allow migrate_events to unwrap nested event payloads before validation
- add tests covering ledger and Kafka migration paths for the v3 schema expectations

## Testing
- pytest tests/test_migrate_events_v3.py
- ruff check src/ume/migrate_events.py tests/test_migrate_events_v3.py

------
https://chatgpt.com/codex/tasks/task_e_690a0f5dcc948326b517a3bba1c86929