### PR TITLE
Update migrate events for schema v3

### DIFF
--- a/src/ume/migrate_events.py
+++ b/src/ume/migrate_events.py
@@ -11,6 +11,7 @@ from .config import settings
 from .event_ledger import event_ledger, EventLedger
 from .schema_utils import validate_event_dict
 from .utils import ssl_config
+from .schema_manager import DEFAULT_SCHEMA_MANAGER
 
 try:
     from confluent_kafka import Consumer, KafkaError, KafkaException
@@ -21,18 +22,171 @@ except Exception:  # pragma: no cover - optional kafka
 
 logger = logging.getLogger(__name__)
 
-TARGET_VERSION = "2.0.0"
+TARGET_VERSION = "3.0.0"
+
+try:
+    TARGET_SCHEMA = DEFAULT_SCHEMA_MANAGER.get_schema(TARGET_VERSION)
+except Exception:  # pragma: no cover - optional schema resources missing
+    TARGET_SCHEMA = None
+
+_DEPRECATED_EDGE_LABELS = {
+    "REMEMBERS",
+    "ASSOCIATED_WITH",
+    "CAUSES",
+    "LINKS_TO",
+    "CONNECTS_TO",
+    "RELATES_TO",
+}
+
+_EDGE_FALLBACKS: Dict[str, Dict[str, Any]] = {
+    "OWNED_BY": {
+        "permission_level": "editor",
+        "accepted_values": ("viewer", "editor"),
+        "schema_version": TARGET_VERSION,
+    },
+    "SHARED_WITH": {
+        "permission_level": "viewer",
+        "accepted_values": ("viewer", "editor"),
+        "schema_version": TARGET_VERSION,
+    },
+    "TAGGED_AS": {"permission_level": None, "accepted_values": (), "schema_version": TARGET_VERSION},
+    "INVITES": {"permission_level": None, "accepted_values": (), "schema_version": TARGET_VERSION},
+    "CONSIDERS": {
+        "permission_level": None,
+        "accepted_values": (),
+        "schema_version": TARGET_VERSION,
+    },
+}
+
+
+def _ensure_payload(event: Dict[str, Any]) -> Dict[str, Any]:
+    payload = event.get("payload")
+    if not isinstance(payload, dict):
+        payload = {}
+        event["payload"] = payload
+    return payload
+
+
+def _extract_edge_attributes(payload: Dict[str, Any]) -> tuple[Dict[str, Any], Optional[str]]:
+    raw_attrs = payload.get("attributes")
+    permission_hint: Optional[str] = None
+    if isinstance(raw_attrs, dict):
+        attr_dict = dict(raw_attrs)
+        perm_val = attr_dict.get("permission_level")
+        if isinstance(perm_val, str) and perm_val.strip():
+            permission_hint = perm_val.strip()
+    elif isinstance(raw_attrs, str):
+        attr_dict = {}
+        if raw_attrs.strip():
+            permission_hint = raw_attrs.strip()
+    else:
+        attr_dict = {}
+    if permission_hint is None:
+        raw_perm = payload.get("permission_level")
+        if isinstance(raw_perm, str) and raw_perm.strip():
+            permission_hint = raw_perm.strip()
+    attr_dict.pop("version", None)
+    attr_dict.pop("schema_version", None)
+    return attr_dict, permission_hint
+
+
+def _edge_metadata(label: str) -> Optional[tuple[Optional[str], tuple[str, ...], str]]:
+    if TARGET_SCHEMA is not None and label in TARGET_SCHEMA.edge_labels:
+        edge_def = TARGET_SCHEMA.edge_labels[label]
+        return (
+            edge_def.permission_level,
+            edge_def.permission_level_values,
+            edge_def.version,
+        )
+    fallback = _EDGE_FALLBACKS.get(label)
+    if fallback is not None:
+        return (
+            fallback.get("permission_level"),
+            tuple(fallback.get("accepted_values", ())),
+            str(fallback.get("schema_version", TARGET_VERSION)),
+        )
+    return None
+
+
+def _apply_edge_defaults(
+    attrs: Dict[str, Any], label: str
+) -> Dict[str, Any]:
+    metadata = _edge_metadata(label)
+    if metadata is None:
+        return attrs
+
+    updated_attrs = dict(attrs)
+    perm_default, accepted_values, schema_version = metadata
+    perm_value = updated_attrs.get("permission_level")
+    if perm_default is not None:
+        if not isinstance(perm_value, str) or not perm_value.strip():
+            perm_value = perm_default
+        else:
+            accepted = set(accepted_values)
+            if accepted and perm_value not in accepted:
+                perm_value = perm_default
+        updated_attrs["permission_level"] = perm_value
+    else:
+        if not perm_value:
+            updated_attrs.pop("permission_level", None)
+
+    updated_attrs["schema_version"] = schema_version
+    return updated_attrs
+
+
+def _normalize_permission_value(value: Optional[str]) -> Optional[str]:
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if trimmed:
+            return trimmed
+    return None
 
 
 def _migrate_event(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Transform an event dictionary for ``TARGET_VERSION``."""
-    etype = event.get("event_type")
-    if etype in {"CREATE_EDGE", "DELETE_EDGE"}:
-        label = event.get("label")
-        if label == "L":
-            event["label"] = "LINKS_TO"
-        elif label == "TO_DELETE":
-            return None
+
+    etype = event.get("event_type") or event.get("eventType")
+    if etype not in {"CREATE_EDGE", "DELETE_EDGE"}:
+        return event
+
+    label = event.get("label")
+    if not isinstance(label, str):
+        return event
+
+    if label == "TO_DELETE":
+        return None
+    if label == "L":
+        label = "LINKS_TO"
+
+    payload = _ensure_payload(event)
+    attrs, perm_hint = _extract_edge_attributes(payload)
+
+    if label == "NEW_LABEL":
+        label = "TAGGED_AS"
+    elif label == "HAS_PERMISSION":
+        perm_value = attrs.get("permission_level")
+        normalized_perm = _normalize_permission_value(
+            perm_value if isinstance(perm_value, str) else perm_hint
+        )
+        if normalized_perm is not None:
+            attrs["permission_level"] = normalized_perm
+        else:
+            attrs.pop("permission_level", None)
+
+        label = "OWNED_BY" if normalized_perm == "editor" else "SHARED_WITH"
+    event["label"] = label
+
+    if label in _DEPRECATED_EDGE_LABELS:
+        return None
+
+    if _edge_metadata(label) is None:
+        return None
+
+    if etype == "CREATE_EDGE":
+        payload.pop("permission_level", None)
+        normalized_attrs = _apply_edge_defaults(attrs, label)
+        payload["attributes"] = normalized_attrs
+
     return event
 
 

--- a/tests/test_migrate_events.py
+++ b/tests/test_migrate_events.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from ume.migrate_events import TARGET_VERSION, _migrate_event
+
+
+def test_migrate_event_removes_deprecated_edges() -> None:
+    """Events targeting deprecated edge labels should be dropped."""
+
+    event = {"event_type": "CREATE_EDGE", "label": "REMEMBERS"}
+
+    assert _migrate_event(event) is None
+
+    legacy_short = {"event_type": "CREATE_EDGE", "label": "L"}
+
+    assert _migrate_event(legacy_short) is None
+
+
+def test_migrate_event_remaps_new_label() -> None:
+    """Legacy NEW_LABEL edges migrate to TAGGED_AS with schema metadata."""
+
+    event = {"event_type": "CREATE_EDGE", "label": "NEW_LABEL", "payload": {}}
+
+    migrated = _migrate_event(event)
+    assert migrated is not None
+    assert migrated["label"] == "TAGGED_AS"
+    attrs = migrated["payload"]["attributes"]
+    assert attrs == {"schema_version": TARGET_VERSION}
+
+
+def test_migrate_event_converts_has_permission_editor() -> None:
+    """HAS_PERMISSION edges retain custom attributes when mapped to OWNED_BY."""
+
+    event = {
+        "event_type": "CREATE_EDGE",
+        "label": "HAS_PERMISSION",
+        "payload": {"attributes": {"permission_level": "editor", "note": "custom"}},
+    }
+
+    migrated = _migrate_event(event)
+    assert migrated is not None
+    assert migrated["label"] == "OWNED_BY"
+    attrs = migrated["payload"]["attributes"]
+    assert attrs["permission_level"] == "editor"
+    assert attrs["note"] == "custom"
+    assert attrs["schema_version"] == TARGET_VERSION
+
+
+def test_migrate_event_converts_has_permission_default_viewer() -> None:
+    """HAS_PERMISSION edges without metadata fall back to viewer SHARED_WITH."""
+
+    event = {"event_type": "CREATE_EDGE", "label": "HAS_PERMISSION", "payload": {}}
+
+    migrated = _migrate_event(event)
+    assert migrated is not None
+    assert migrated["label"] == "SHARED_WITH"
+    attrs = migrated["payload"]["attributes"]
+    assert attrs["permission_level"] == "viewer"
+    assert attrs["schema_version"] == TARGET_VERSION
+
+
+def test_migrate_delete_event_updates_label_only() -> None:
+    """Delete events with HAS_PERMISSION should map their label to SHARED_WITH by default."""
+
+    event = {"event_type": "DELETE_EDGE", "label": "HAS_PERMISSION"}
+
+    migrated = _migrate_event(event)
+    assert migrated is not None
+    assert migrated["label"] == "SHARED_WITH"


### PR DESCRIPTION
## Summary
- bump the migrate events target to schema version 3.0.0 and provide schema metadata fallbacks when packaged resources are unavailable
- remap legacy edge labels while enforcing permission defaults and dropping deprecated edges
- add unit coverage for the migration logic

## Testing
- pytest tests/test_migrate_events.py
- pytest *(fails: missing optional dependencies such as fastapi, google.protobuf)*
- ruff check


------
https://chatgpt.com/codex/tasks/task_e_690a0f5cd5308326b79074ba2a8af417