### PR TITLE
Add migrate_events v3 regression tests

### DIFF
--- a/tests/test_migrate_events_v3.py
+++ b/tests/test_migrate_events_v3.py
@@ -44,6 +44,10 @@ def test_migrate_events_ledger_path(monkeypatch: pytest.MonkeyPatch) -> None:
     assert owned["payload"]["attributes"]["permission_level"] == "editor"
     assert shared["label"] == "SHARED_WITH"
     assert shared["payload"]["attributes"]["permission_level"] == "viewer"
+    assert {owned["target_node_id"], shared["target_node_id"]} == {
+        "user_editor",
+        "user_viewer",
+    }
 
 
 def test_migrate_events_kafka_envelopes(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -64,5 +68,6 @@ def test_migrate_events_kafka_envelopes(monkeypatch: pytest.MonkeyPatch) -> None
     assert envelope["schema_version"] == "3.0.0"
     event = envelope["event"]
     assert event["label"] == "SHARED_WITH"
+    assert event["target_node_id"] == "user_default"
     attrs = event["payload"]["attributes"]
     assert attrs["permission_level"] == "viewer"


### PR DESCRIPTION
## Summary
- add coverage for migrate_events to verify ledger and kafka inputs are emitted as v3 schema envelopes
- assert legacy HAS_PERMISSION edges are remapped and deprecated edge labels are filtered out

## Testing
- poetry run pytest tests/test_migrate_events_v3.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163e56097083268b740c1a11cba66e)