### PR TITLE
Add schema version plumbing to ingest helpers

### DIFF
--- a/src/ume/async_graph_adapter.py
+++ b/src/ume/async_graph_adapter.py
@@ -221,10 +221,22 @@ async def apply_event_to_async_graph(
         raise ProcessingError(f"Unknown event_type '{event.event_type}'")
 
 
-async def ingest_event_async(data: Dict[str, Any], graph: IAsyncGraphAdapter) -> None:
+async def ingest_event_async(
+    data: Dict[str, Any],
+    graph: IAsyncGraphAdapter,
+    *,
+    schema_version: str | None = None,
+) -> None:
     """Validate ``data`` and apply the resulting event to ``graph`` asynchronously."""
-    event = parse_event(data)
-    await apply_event_to_async_graph(event, graph)
+    if "event" in data and isinstance(data["event"], dict):
+        event_dict = cast(Dict[str, Any], data["event"])
+        detected_version = cast(str | None, data.get("schema_version"))
+    else:
+        event_dict = data
+        detected_version = cast(str | None, data.get("schema_version"))
+    event = parse_event(event_dict)
+    effective_version = schema_version or detected_version or DEFAULT_VERSION
+    await apply_event_to_async_graph(event, graph, schema_version=effective_version)
 
 
 __all__ = [

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -8,7 +8,7 @@ from google.protobuf.json_format import MessageToDict
 from ume_client import events_pb2 as _events_pb2
 from google.protobuf import struct_pb2
 from ..event import Event, EventError, EventType, parse_event
-from ..processing import apply_event_to_graph
+from ..processing import DEFAULT_VERSION, apply_event_to_graph
 from ..graph_adapter import IGraphAdapter
 from ..async_graph_adapter import IAsyncGraphAdapter, ingest_event_async
 from ..classification import classify_event
@@ -35,19 +35,36 @@ __all__ = [
 ]
 
 
+def _unwrap_envelope(data: Dict[str, Any]) -> tuple[Dict[str, Any], str | None]:
+    """Return the canonical event dictionary and optional schema version."""
+
+    if "event" in data and isinstance(data["event"], dict):
+        return cast(Dict[str, Any], data["event"]), cast(
+            str | None, data.get("schema_version")
+        )
+    return data, cast(str | None, data.get("schema_version"))
+
+
 def validate_event(data: Dict[str, Any]) -> Event:
     """Parse ``data`` into an :class:`~ume.event.Event`."""
     return parse_event(data)
 
 
-def apply_event(event: Event, graph: IGraphAdapter) -> None:
+def apply_event(
+    event: Event, graph: IGraphAdapter, *, schema_version: str | None = None
+) -> None:
     """Apply ``event`` to ``graph`` using :func:`~ume.processing.apply_event_to_graph`."""
-    apply_event_to_graph(event, graph)
+    effective_version = schema_version or DEFAULT_VERSION
+    apply_event_to_graph(event, graph, schema_version=effective_version)
 
 
-def ingest_event(data: Dict[str, Any], graph: IGraphAdapter) -> None:
+def ingest_event(
+    data: Dict[str, Any], graph: IGraphAdapter, *, schema_version: str | None = None
+) -> None:
     """Validate ``data``, classify it, and apply the resulting event to ``graph``."""
-    event = validate_event(data)
+    event_dict, detected_version = _unwrap_envelope(data)
+    event = validate_event(event_dict)
+    effective_version = schema_version or detected_version or DEFAULT_VERSION
 
     tag_results = classify_event(event)
     event.payload["classification"] = [
@@ -72,7 +89,7 @@ def ingest_event(data: Dict[str, Any], graph: IGraphAdapter) -> None:
             if r.sensitivity and "sensitivity" not in attributes:
                 attributes["sensitivity"] = r.sensitivity
 
-    apply_event(event, graph)
+    apply_event(event, graph, schema_version=effective_version)
 
     anomaly_event = _anomaly_detector.process_event(event)
     if anomaly_event is not None:
@@ -84,18 +101,25 @@ def ingest_event(data: Dict[str, Any], graph: IGraphAdapter) -> None:
                 "sourceService": anomaly_event.source,
             },
             graph,
+            schema_version=effective_version,
         )
 
 
-def ingest_events_batch(events: Iterable[Dict[str, Any]], graph: IGraphAdapter) -> None:
+def ingest_events_batch(
+    events: Iterable[Dict[str, Any]],
+    graph: IGraphAdapter,
+    *,
+    schema_version: str | None = None,
+) -> None:
     """Sequentially ingest multiple events into ``graph``."""
     for data in events:
-        ingest_event(data, graph)
+        ingest_event(data, graph, schema_version=schema_version)
 
 
 def dict_to_envelope(data: Dict[str, Any]) -> Any:
     """Convert a raw event dictionary to :class:`~ume_client.events_pb2.EventEnvelope`."""
-    evt = validate_event(data)
+    event_dict, schema_version = _unwrap_envelope(data)
+    evt = validate_event(event_dict)
     struct_payload = struct_pb2.Struct()
     struct_payload.update(evt.payload)
     meta = events_pb2.BaseEvent(
@@ -108,16 +132,22 @@ def dict_to_envelope(data: Dict[str, Any]) -> Any:
         label=evt.label or "",
         payload=struct_payload,
     )
+    envelope_kwargs = {"schema_version": schema_version or DEFAULT_VERSION}
+    envelope = events_pb2.EventEnvelope(**envelope_kwargs)
     if evt.event_type == EventType.CREATE_NODE.value:
-        return events_pb2.EventEnvelope(create_node=events_pb2.CreateNode(meta=meta))
+        envelope.create_node.CopyFrom(events_pb2.CreateNode(meta=meta))
+        return envelope
     if evt.event_type == EventType.UPDATE_NODE_ATTRIBUTES.value:
-        return events_pb2.EventEnvelope(
-            update_node_attributes=events_pb2.UpdateNodeAttributes(meta=meta)
+        envelope.update_node_attributes.CopyFrom(
+            events_pb2.UpdateNodeAttributes(meta=meta)
         )
+        return envelope
     if evt.event_type == EventType.CREATE_EDGE.value:
-        return events_pb2.EventEnvelope(create_edge=events_pb2.CreateEdge(meta=meta))
+        envelope.create_edge.CopyFrom(events_pb2.CreateEdge(meta=meta))
+        return envelope
     if evt.event_type == EventType.DELETE_EDGE.value:
-        return events_pb2.EventEnvelope(delete_edge=events_pb2.DeleteEdge(meta=meta))
+        envelope.delete_edge.CopyFrom(events_pb2.DeleteEdge(meta=meta))
+        return envelope
     raise ValueError(evt.event_type)
 
 
@@ -134,7 +164,7 @@ def envelope_to_event_dict(envelope: Any) -> Dict[str, Any]:
     else:
         raise EventError("Envelope missing payload")
 
-    return {
+    event_dict = {
         "eventId": meta.event_id,
         "eventType": meta.event_type,
         "timestamp": meta.timestamp,
@@ -144,15 +174,30 @@ def envelope_to_event_dict(envelope: Any) -> Dict[str, Any]:
         "target_node_id": meta.target_node_id or None,
         "label": meta.label or None,
     }
+    schema_version = envelope.schema_version or DEFAULT_VERSION
+    return {"schema_version": schema_version, "event": event_dict}
 
 
-def ingest_envelope(envelope: Any, graph: IGraphAdapter) -> None:
+def ingest_envelope(
+    envelope: Any, graph: IGraphAdapter, *, schema_version: str | None = None
+) -> None:
     """Ingest an :class:`EventEnvelope` into ``graph``."""
-    ingest_event(envelope_to_event_dict(envelope), graph)
+    ingest_event(
+        envelope_to_event_dict(envelope),
+        graph,
+        schema_version=schema_version,
+    )
 
 
 async def ingest_envelope_async(
-    envelope: Any, graph: IAsyncGraphAdapter
+    envelope: Any,
+    graph: IAsyncGraphAdapter,
+    *,
+    schema_version: str | None = None,
 ) -> None:
     """Asynchronously ingest an :class:`EventEnvelope` into ``graph``."""
-    await ingest_event_async(envelope_to_event_dict(envelope), graph)
+    await ingest_event_async(
+        envelope_to_event_dict(envelope),
+        graph,
+        schema_version=schema_version,
+    )

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -10,9 +10,9 @@ def test_ingest_event_classifies_and_persists_tags(monkeypatch) -> None:
     graph = MockGraph()
     captured: dict[str, object] = {}
 
-    def fake_apply_event(event, g):
+    def fake_apply_event(event, g, *, schema_version=None):
         captured["event"] = event
-        apply_event_to_graph(event, g)
+        apply_event_to_graph(event, g, schema_version=schema_version)
 
     monkeypatch.setattr(ingest_module, "apply_event", fake_apply_event)
 


### PR DESCRIPTION
## Summary
- allow `apply_event`, `ingest_event`, and the batch/envelope helpers to accept schema version overrides and unwrap envelope-shaped payloads
- preserve `schema_version` when translating dictionaries to/from protobuf envelopes so replayed events retain the original version
- extend the async ingest helper and the classification test stub to understand the new optional parameter

## Testing
- `ruff check src/ume/services/ingest.py src/ume/async_graph_adapter.py tests/test_classification.py`
- `pytest tests/test_classification.py tests/test_async_graph_adapter.py` *(fails: classification fixtures expect fully mocked HTTP responses that are unavailable in this environment)*
- `pytest tests/test_async_graph_adapter.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddfc25ed48326a382421fbf4d496a)