### PR TITLE
Route calendar and financial edges through permissions adapter

### DIFF
--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -50,20 +50,20 @@ def create_layer(
     }
     graph.add_node(layer.layer_id, attrs)
     _ensure_user_node(graph, req.user_id)
-    graph.add_edge(
-        layer.layer_id,
-        req.user_id,
-        "OWNED_BY",
-        {"permission_level": "editor"},
-        schema_version=EDGE_VERSION,
-    )
+    perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
+    with perm_graph.bootstrap_owner(layer.layer_id):
+        perm_graph.add_edge(
+            layer.layer_id,
+            req.user_id,
+            "OWNED_BY",
+            {"permission_level": "editor"},
+            schema_version=EDGE_VERSION,
+        )
     if req.group_id:
         group = graph.get_node(req.group_id)
         if group is None:
             raise HTTPException(status_code=404, detail="Group not found")
         ensure_group_member(graph, req.user_id, req.group_id)
-
-        perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
         try:
             perm_graph.add_edge(
                 layer.layer_id,

--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -71,14 +71,15 @@ def create_account(
         "schema_version": account.schema_version,
     }
     graph.add_node(account.account_id, attrs)
-    graph.add_edge(
-        account.account_id,
-        req.user_id,
-        "OWNED_BY",
-        {"permission_level": "editor"},
-        schema_version=EDGE_VERSION,
-    )
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
+    with perm_graph.bootstrap_owner(account.account_id):
+        perm_graph.add_edge(
+            account.account_id,
+            req.user_id,
+            "OWNED_BY",
+            {"permission_level": "editor"},
+            schema_version=EDGE_VERSION,
+        )
     if req.group_id:
         perm_graph.add_edge(
             account.account_id,

--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from contextlib import contextmanager
 from typing import Any, DefaultDict, Dict, List, Optional
 
 from .graph_adapter import IGraphAdapter
@@ -25,6 +26,7 @@ class PermissionsGraphAdapter(IGraphAdapter):
         self.group_id = group_id
         self._edges_by_source: DefaultDict[str, List[tuple[str, str, Any]]] = defaultdict(list)
         self._edges_by_target: DefaultDict[str, List[tuple[str, str, Any]]] = defaultdict(list)
+        self._bootstrap_owner_nodes: set[str] = set()
         self.rebuild_index()
 
     # ------------------------------------------------------------------
@@ -133,6 +135,16 @@ class PermissionsGraphAdapter(IGraphAdapter):
         connected = self._adapter.find_connected_nodes(node_id, edge_label)
         return self._filter_visible(connected)
 
+    @contextmanager
+    def bootstrap_owner(self, node_id: str):
+        """Temporarily allow setting the initial OWNED_BY edge for a node."""
+
+        self._bootstrap_owner_nodes.add(node_id)
+        try:
+            yield
+        finally:
+            self._bootstrap_owner_nodes.discard(node_id)
+
     def add_edge(
         self,
         source_node_id: str,
@@ -141,11 +153,18 @@ class PermissionsGraphAdapter(IGraphAdapter):
         attrs: Dict[str, Any] | None = None,
         schema_version: str | None = None,
     ) -> None:
-        self._require_editor(source_node_id)
+        is_bootstrap_owner = (
+            label == "OWNED_BY" and source_node_id in self._bootstrap_owner_nodes
+        )
+        if not is_bootstrap_owner:
+            self._require_editor(source_node_id)
         if label not in {"OWNED_BY", "SHARED_WITH", "INVITES"}:
-            self._require_editor(target_node_id)
+            if not is_bootstrap_owner:
+                self._require_editor(target_node_id)
         edge_def = DEFAULT_SCHEMA.edge_labels.get(label)
         version = edge_def.version if edge_def else schema_version
+        if attrs is not None and not isinstance(attrs, dict):
+            raise AccessDeniedError("Edge attributes must be a mapping when provided")
         attrs = dict(attrs or {})
         perm_level = attrs.get("permission_level")
         if label in {"OWNED_BY", "SHARED_WITH"}:
@@ -158,6 +177,8 @@ class PermissionsGraphAdapter(IGraphAdapter):
                 raise AccessDeniedError(
                     "permission_level must be a non-empty string when provided"
                 )
+            if edge_def is None:
+                raise AccessDeniedError("permission_level not allowed for unknown edge")
             accepted = set(edge_def.permission_level_values)
             if not accepted and edge_def.permission_level is not None:
                 accepted.add(edge_def.permission_level)


### PR DESCRIPTION
## Summary
- add a bootstrap_owner hook to PermissionsGraphAdapter and tighten permission_level validation
- route calendar layer and financial account edge mutations through the permissions adapter for consistent checks
- continue provisioning group sharing through the adapter after initial owner bootstrapping

## Testing
- pytest tests/test_calendar_layer_routes.py tests/test_financial_account_routes.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692478b2ef4483268bc9732b45e34f9d)