### PR TITLE
Use default schema versions in route creation

### DIFF
--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -15,6 +15,8 @@ from .graph_schema import get_default_edge_version
 
 router = APIRouter(prefix="/v1/calendar")
 
+EDGE_VERSION = get_default_edge_version("OWNED_BY")
+
 
 class CalendarLayerCreateRequest(BaseModel):
     layer_name: str

--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from . import api_deps as deps
+from .graph_schema import get_default_edge_version
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
@@ -20,7 +21,7 @@ from .models import (
     create_user,
 )
 
-EDGE_VERSION = "3.0.0"
+EDGE_VERSION = get_default_edge_version("OWNED_BY")
 VALID_GROUP_PERMISSION_LEVELS = {"viewer", "editor"}
 
 router = APIRouter(prefix="/v1/calendar")

--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -14,6 +14,8 @@ from .utils import ensure_group_member
 
 router = APIRouter(prefix="/v1/accounts")
 
+EDGE_VERSION = get_default_edge_version("OWNED_BY")
+
 
 class FinancialAccountCreateRequest(BaseModel):
     account_type: str

--- a/src/ume/models/calendar.py
+++ b/src/ume/models/calendar.py
@@ -7,7 +7,9 @@ from datetime import datetime
 from enum import Enum
 import uuid
 
-SCHEMA_VERSION = "3.0.0"
+from ..graph_schema import get_default_node_version
+
+SCHEMA_VERSION = get_default_node_version("CalendarEvent")
 
 
 class CalendarEventStatus(str, Enum):

--- a/src/ume/models/decisions.py
+++ b/src/ume/models/decisions.py
@@ -6,7 +6,9 @@ from dataclasses import dataclass, field
 from datetime import datetime
 import uuid
 
-SCHEMA_VERSION = "1.0"
+from ..graph_schema import get_default_node_version
+
+SCHEMA_VERSION = get_default_node_version("Decision")
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- derive calendar and decision node schema versions from the default graph schema helpers
- reuse default edge versions for calendar, calendar layer, and financial account ownership edges

## Testing
- poetry run ruff check src tests
- poetry run pytest *(fails: missing optional test dependencies such as fastapi.testclient, google.protobuf, nbconvert, networkx)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693829539e388326a9030d1b17566637)