### PR TITLE
Silence pydantic Extra deprecation warnings

### DIFF
--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -1,7 +1,7 @@
-from pydantic_settings import BaseSettings, SettingsConfigDict
-from pydantic import Extra
-from typing import Any
 import logging
+from typing import Any
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 DEFAULT_AUDIT_SIGNING_KEY = "default-key"
@@ -9,7 +9,7 @@ DEFAULT_AUDIT_SIGNING_KEY = "default-key"
 
 class Settings(BaseSettings):  # type: ignore[misc]
     model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", extra=Extra.ignore
+        env_file=".env", env_file_encoding="utf-8", extra="ignore"
     )
 
     # UME Core


### PR DESCRIPTION
## Summary
- update settings model_config to use literal `extra="ignore"` to avoid pydantic deprecation warnings
- tidy imports in the settings module

## Testing
- pytest -q tests/test_analytics.py
- ruff check src/ume/config/__init__.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693989f2ec18832693efe9db7e586d81)