### PR TITLE
Allow integer timestamps in schemas

### DIFF
--- a/src/ume/schemas/canonical_event.schema.json
+++ b/src/ume/schemas/canonical_event.schema.json
@@ -11,9 +11,18 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp when the event occurred in ISO 8601 format"
+      "description": "Timestamp when the event occurred",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the event occurred in ISO 8601 format"
+        },
+        {
+          "type": "integer",
+          "description": "Timestamp when the event occurred as a Unix epoch in seconds"
+        }
+      ]
     },
     "eventId": {
       "type": "string",

--- a/src/ume/schemas/create_edge.schema.json
+++ b/src/ume/schemas/create_edge.schema.json
@@ -4,7 +4,13 @@
   "description": "Schema for CREATE_EDGE events emitted by UME producers.",
   "version": "1.0.0",
   "type": "object",
-  "required": ["eventType", "timestamp", "node_id", "target_node_id", "label"],
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label"
+  ],
   "properties": {
     "eventType": {
       "type": "string",
@@ -12,10 +18,18 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp when the event occurred in ISO 8601 format"
-
+      "description": "Timestamp when the event occurred",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the event occurred in ISO 8601 format"
+        },
+        {
+          "type": "integer",
+          "description": "Timestamp when the event occurred as a Unix epoch in seconds"
+        }
+      ]
     },
     "eventId": {
       "type": "string",
@@ -27,8 +41,18 @@
     },
     "subjectEntity": {
       "type": "object",
-      "required": ["id", "type"],
-      "properties": {"id": {"type": "string"}, "type": {"type": "string"}},
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
       "description": "Entity this event pertains to"
     },
     "sourceService": {

--- a/src/ume/schemas/create_node.schema.json
+++ b/src/ume/schemas/create_node.schema.json
@@ -12,9 +12,19 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp when the event occurred in ISO 8601 format"
+      "description": "Timestamp when the event occurred",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the event occurred in ISO 8601 format"
+
+        },
+        {
+          "type": "integer",
+          "description": "Timestamp when the event occurred as a Unix epoch in seconds"
+        }
+      ]
 
     },
     "eventId": {

--- a/src/ume/schemas/data_source_queried.schema.json
+++ b/src/ume/schemas/data_source_queried.schema.json
@@ -4,17 +4,77 @@
   "description": "Schema for DATA_SOURCE_QUERIED events emitted by UME producers.",
   "version": "1.0.0",
   "type": "object",
-  "required": ["eventType", "timestamp", "node_id", "target_node_id", "label"],
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label"
+  ],
   "properties": {
-    "eventType": {"type": "string", "minLength": 1, "description": "Type of event"},
-    "timestamp": {"type": "string", "format": "date-time", "description": "Timestamp when the event occurred in ISO 8601 format"},
-    "eventId": {"type": "string", "description": "Unique identifier for this event"},
-    "correlationId": {"type": "string", "description": "Identifier linking related events"},
-    "subjectEntity": {"type": "object", "required": ["id", "type"], "properties": {"id": {"type": "string"}, "type": {"type": "string"}}, "description": "Entity this event pertains to"},
-    "sourceService": {"type": "string", "description": "Originating system of the event"},
-    "node_id": {"type": "string", "description": "Job node identifier"},
-    "target_node_id": {"type": "string", "description": "Data source identifier"},
-    "label": {"type": "string", "description": "Edge label"},
-    "payload": {"type": "object", "description": "Optional edge attributes", "default": {}}
+    "eventType": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Type of event"
+    },
+    "timestamp": {
+      "description": "Timestamp when the event occurred",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the event occurred in ISO 8601 format"
+        },
+        {
+          "type": "integer",
+          "description": "Timestamp when the event occurred as a Unix epoch in seconds"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string",
+      "description": "Unique identifier for this event"
+    },
+    "correlationId": {
+      "type": "string",
+      "description": "Identifier linking related events"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "description": "Entity this event pertains to"
+    },
+    "sourceService": {
+      "type": "string",
+      "description": "Originating system of the event"
+    },
+    "node_id": {
+      "type": "string",
+      "description": "Job node identifier"
+    },
+    "target_node_id": {
+      "type": "string",
+      "description": "Data source identifier"
+    },
+    "label": {
+      "type": "string",
+      "description": "Edge label"
+    },
+    "payload": {
+      "type": "object",
+      "description": "Optional edge attributes",
+      "default": {}
+    }
   }
 }

--- a/src/ume/schemas/delete_edge.schema.json
+++ b/src/ume/schemas/delete_edge.schema.json
@@ -4,7 +4,13 @@
   "description": "Schema for DELETE_EDGE events emitted by UME producers.",
   "version": "1.0.0",
   "type": "object",
-  "required": ["eventType", "timestamp", "node_id", "target_node_id", "label"],
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label"
+  ],
   "properties": {
     "eventType": {
       "type": "string",
@@ -12,10 +18,18 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp when the event occurred in ISO 8601 format"
-
+      "description": "Timestamp when the event occurred",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the event occurred in ISO 8601 format"
+        },
+        {
+          "type": "integer",
+          "description": "Timestamp when the event occurred as a Unix epoch in seconds"
+        }
+      ]
     },
     "eventId": {
       "type": "string",
@@ -27,8 +41,18 @@
     },
     "subjectEntity": {
       "type": "object",
-      "required": ["id", "type"],
-      "properties": {"id": {"type": "string"}, "type": {"type": "string"}},
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
       "description": "Entity this event pertains to"
     },
     "sourceService": {

--- a/src/ume/schemas/document_archived.schema.json
+++ b/src/ume/schemas/document_archived.schema.json
@@ -4,17 +4,75 @@
   "description": "Schema for DOCUMENT_ARCHIVED events emitted by UME producers.",
   "version": "1.0.0",
   "type": "object",
-  "required": ["eventType", "timestamp", "node_id", "payload"],
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "payload"
+  ],
   "properties": {
-    "eventType": {"type": "string", "minLength": 1, "description": "Type of event"},
-    "timestamp": {"type": "string", "format": "date-time", "description": "Timestamp when the event occurred in ISO 8601 format"},
-    "eventId": {"type": "string", "description": "Unique identifier for this event"},
-    "correlationId": {"type": "string", "description": "Identifier linking related events"},
-    "subjectEntity": {"type": "object", "required": ["id", "type"], "properties": {"id": {"type": "string"}, "type": {"type": "string"}}, "description": "Entity this event pertains to"},
-    "sourceService": {"type": "string", "description": "Originating system of the event"},
-    "node_id": {"type": "string", "description": "Identifier of the document node"},
-    "payload": {"type": "object", "description": "Attributes to merge into the node"},
-    "target_node_id": {"type": "string", "description": "Unused for this event type"},
-    "label": {"type": "string", "description": "Unused for this event type"}
+    "eventType": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Type of event"
+    },
+    "timestamp": {
+      "description": "Timestamp when the event occurred",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the event occurred in ISO 8601 format"
+        },
+        {
+          "type": "integer",
+          "description": "Timestamp when the event occurred as a Unix epoch in seconds"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string",
+      "description": "Unique identifier for this event"
+    },
+    "correlationId": {
+      "type": "string",
+      "description": "Identifier linking related events"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "description": "Entity this event pertains to"
+    },
+    "sourceService": {
+      "type": "string",
+      "description": "Originating system of the event"
+    },
+    "node_id": {
+      "type": "string",
+      "description": "Identifier of the document node"
+    },
+    "payload": {
+      "type": "object",
+      "description": "Attributes to merge into the node"
+    },
+    "target_node_id": {
+      "type": "string",
+      "description": "Unused for this event type"
+    },
+    "label": {
+      "type": "string",
+      "description": "Unused for this event type"
+    }
   }
 }

--- a/src/ume/schemas/entity_discovered.schema.json
+++ b/src/ume/schemas/entity_discovered.schema.json
@@ -4,17 +4,77 @@
   "description": "Schema for ENTITY_DISCOVERED events emitted by UME producers.",
   "version": "1.0.0",
   "type": "object",
-  "required": ["eventType", "timestamp", "node_id", "target_node_id", "label", "payload"],
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label",
+    "payload"
+  ],
   "properties": {
-    "eventType": {"type": "string", "minLength": 1, "description": "Type of event"},
-    "timestamp": {"type": "string", "format": "date-time", "description": "Timestamp when the event occurred in ISO 8601 format"},
-    "eventId": {"type": "string", "description": "Unique identifier for this event"},
-    "correlationId": {"type": "string", "description": "Identifier linking related events"},
-    "subjectEntity": {"type": "object", "required": ["id", "type"], "properties": {"id": {"type": "string"}, "type": {"type": "string"}}, "description": "Entity this event pertains to"},
-    "sourceService": {"type": "string", "description": "Originating system of the event"},
-    "node_id": {"type": "string", "description": "Job node identifier"},
-    "target_node_id": {"type": "string", "description": "Discovered entity identifier"},
-    "label": {"type": "string", "description": "Edge label"},
-    "payload": {"type": "object", "description": "Attributes for the discovered entity"}
+    "eventType": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Type of event"
+    },
+    "timestamp": {
+      "description": "Timestamp when the event occurred",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the event occurred in ISO 8601 format"
+        },
+        {
+          "type": "integer",
+          "description": "Timestamp when the event occurred as a Unix epoch in seconds"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string",
+      "description": "Unique identifier for this event"
+    },
+    "correlationId": {
+      "type": "string",
+      "description": "Identifier linking related events"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "description": "Entity this event pertains to"
+    },
+    "sourceService": {
+      "type": "string",
+      "description": "Originating system of the event"
+    },
+    "node_id": {
+      "type": "string",
+      "description": "Job node identifier"
+    },
+    "target_node_id": {
+      "type": "string",
+      "description": "Discovered entity identifier"
+    },
+    "label": {
+      "type": "string",
+      "description": "Edge label"
+    },
+    "payload": {
+      "type": "object",
+      "description": "Attributes for the discovered entity"
+    }
   }
 }

--- a/src/ume/schemas/research_job_started.schema.json
+++ b/src/ume/schemas/research_job_started.schema.json
@@ -4,7 +4,12 @@
   "description": "Schema for RESEARCH_JOB_STARTED events emitted by UME producers.",
   "version": "1.0.0",
   "type": "object",
-  "required": ["eventType", "timestamp", "node_id", "payload"],
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "payload"
+  ],
   "properties": {
     "eventType": {
       "type": "string",
@@ -12,22 +17,62 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp when the event occurred in ISO 8601 format"
+      "description": "Timestamp when the event occurred",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the event occurred in ISO 8601 format"
+        },
+        {
+          "type": "integer",
+          "description": "Timestamp when the event occurred as a Unix epoch in seconds"
+        }
+      ]
     },
-    "eventId": {"type": "string", "description": "Unique identifier for this event"},
-    "correlationId": {"type": "string", "description": "Identifier linking related events"},
+    "eventId": {
+      "type": "string",
+      "description": "Unique identifier for this event"
+    },
+    "correlationId": {
+      "type": "string",
+      "description": "Identifier linking related events"
+    },
     "subjectEntity": {
       "type": "object",
-      "required": ["id", "type"],
-      "properties": {"id": {"type": "string"}, "type": {"type": "string"}},
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
       "description": "Entity this event pertains to"
     },
-    "sourceService": {"type": "string", "description": "Originating system of the event"},
-    "node_id": {"type": "string", "description": "Identifier of the job node"},
-    "payload": {"type": "object", "description": "Attributes for the job node"},
-    "target_node_id": {"type": "string", "description": "Unused for this event type"},
-    "label": {"type": "string", "description": "Unused for this event type"}
+    "sourceService": {
+      "type": "string",
+      "description": "Originating system of the event"
+    },
+    "node_id": {
+      "type": "string",
+      "description": "Identifier of the job node"
+    },
+    "payload": {
+      "type": "object",
+      "description": "Attributes for the job node"
+    },
+    "target_node_id": {
+      "type": "string",
+      "description": "Unused for this event type"
+    },
+    "label": {
+      "type": "string",
+      "description": "Unused for this event type"
+    }
   }
 }

--- a/src/ume/schemas/update_node_attributes.schema.json
+++ b/src/ume/schemas/update_node_attributes.schema.json
@@ -4,7 +4,12 @@
   "description": "Schema for UPDATE_NODE_ATTRIBUTES events emitted by UME producers.",
   "version": "1.0.0",
   "type": "object",
-  "required": ["eventType", "timestamp", "node_id", "payload"],
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "payload"
+  ],
   "properties": {
     "eventType": {
       "type": "string",
@@ -12,10 +17,18 @@
       "description": "Type of event"
     },
     "timestamp": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp when the event occurred in ISO 8601 format"
-
+      "description": "Timestamp when the event occurred",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the event occurred in ISO 8601 format"
+        },
+        {
+          "type": "integer",
+          "description": "Timestamp when the event occurred as a Unix epoch in seconds"
+        }
+      ]
     },
     "eventId": {
       "type": "string",
@@ -27,8 +40,18 @@
     },
     "subjectEntity": {
       "type": "object",
-      "required": ["id", "type"],
-      "properties": {"id": {"type": "string"}, "type": {"type": "string"}},
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
       "description": "Entity this event pertains to"
     },
     "sourceService": {


### PR DESCRIPTION
## Summary
- allow event timestamp fields to validate integer Unix epoch values alongside ISO8601 strings
- update canonical and event-specific event schemas to share the relaxed timestamp definition

## Testing
- pytest tests/test_client_module.py -q
- ruff check src/ume/schema_utils.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694161b4e1108326a62e930f03a4a3a4)