### PR TITLE
Validate permission levels during access checks

### DIFF
--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -47,11 +47,24 @@ class PermissionsGraphAdapter(IGraphAdapter):
             if tgt != subject or lbl not in {"OWNED_BY", "SHARED_WITH"}:
                 continue
             perm_level = attrs.get("permission_level") if isinstance(attrs, dict) else attrs
+            if not self._is_valid_permission_level(lbl, perm_level):
+                continue
             if perm_level == perm:
                 return True
             if perm == "viewer" and perm_level == "editor":
                 return True
         return False
+
+    def _is_valid_permission_level(self, label: str, perm_level: Any) -> bool:
+        if not isinstance(perm_level, str) or not perm_level:
+            return False
+        edge_def = DEFAULT_SCHEMA.edge_labels.get(label)
+        if edge_def is None:
+            return False
+        accepted = set(edge_def.permission_level_values)
+        if not accepted and edge_def.permission_level is not None:
+            accepted.add(edge_def.permission_level)
+        return bool(accepted) and perm_level in accepted
 
     def _has_permission(self, node_id: str, perm: str) -> bool:
         for subject in self._subjects():
@@ -113,7 +126,7 @@ class PermissionsGraphAdapter(IGraphAdapter):
             if lbl not in labels:
                 continue
             perm_level = attrs.get("permission_level") if isinstance(attrs, dict) else attrs
-            if perm_level:
+            if self._is_valid_permission_level(lbl, perm_level):
                 nodes.add(src)
         return list(nodes)
 

--- a/tests/test_permissions_adapter.py
+++ b/tests/test_permissions_adapter.py
@@ -190,6 +190,33 @@ def test_get_nodes_shared_with_multiple_groups_and_mixed_permissions() -> None:
         "Document.mixed_groups",
     }
 
+
+def test_invalid_owned_by_permission_level_denies_access() -> None:
+    g = MockGraph()
+    g.add_node("User.u1", {})
+    g.add_node("Document.d1", {"title": "doc1"})
+    g._edges["Document.d1"].append(
+        ("User.u1", "OWNED_BY", {"permission_level": "admin"})
+    )
+
+    adapter = PermissionsGraphAdapter(g, user_id="User.u1")
+    assert adapter.get_node("Document.d1") is None
+    with pytest.raises(AccessDeniedError):
+        adapter.update_node("Document.d1", {"title": "nope"})
+
+
+def test_invalid_shared_with_permission_level_denies_access() -> None:
+    g = MockGraph()
+    g.add_node("User.u1", {})
+    g.add_node("Document.d1", {"title": "doc1"})
+    g._edges["Document.d1"].append(
+        ("User.u1", "SHARED_WITH", {"permission_level": "owner"})
+    )
+
+    adapter = PermissionsGraphAdapter(g, user_id="User.u1")
+    assert adapter.get_node("Document.d1") is None
+    assert adapter.get_nodes_by_user("User.u1") == []
+
 def test_add_edge_requires_editor_and_preserves_attrs() -> None:
     g = MockGraph()
     g.add_node("User.u1", {})


### PR DESCRIPTION
### Motivation

- Prevent improperly-formed or unknown `permission_level` values on `OWNED_BY`/`SHARED_WITH` edges from granting viewer/editor access.
- Rely on the schema (`DEFAULT_SCHEMA`) accepted values for edge permission levels so only sanctioned values influence visibility and edit rights.

### Description

- Add helper `._is_valid_permission_level(label, perm_level)` that checks that `perm_level` is a non-empty string and is accepted by the `DEFAULT_SCHEMA` edge definition (including default values).
- Use `._is_valid_permission_level` in `._has_permission_edge` to ignore ownership/sharing edges with invalid permission values so they no longer grant access.
- Use the same validation in `._get_nodes_for_subject` so subject lookups ignore edges with invalid permission levels.
- Add two unit tests: `test_invalid_owned_by_permission_level_denies_access` and `test_invalid_shared_with_permission_level_denies_access` to cover these cases.

### Testing

- Ran `ruff check .` — all checks passed.
- Ran `mypy .` — failed due to a duplicate module name for `events_pb2` (environment/test harness configuration), unrelated to these changes.
- Ran `pytest` — test collection failed with import errors for optional/missing test dependencies (e.g. `fastapi`, `google.protobuf`, `networkx`); the failures are from test environment dependencies rather than the permission adapter changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69459fec7e548326a607a59257e667ba)