### PR TITLE
Add OWNED_BY owner edge on group creation and tests

### DIFF
--- a/src/ume/users_routes.py
+++ b/src/ume/users_routes.py
@@ -7,11 +7,15 @@ from pydantic import BaseModel
 
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
+from .graph_schema import get_default_edge_version
 from .models import create_user, create_user_group
 from .permissions_adapter import PermissionsGraphAdapter
+from .rbac_adapter import AccessDeniedError
 from .utils import ensure_group_member
 
 router = APIRouter(prefix="/v1")
+
+EDGE_VERSION = get_default_edge_version("OWNED_BY")
 
 
 class UserCreateRequest(BaseModel):
@@ -29,6 +33,7 @@ class UserResponse(BaseModel):
 class UserGroupCreateRequest(BaseModel):
     name: str
     members: List[str] | None = None
+    user_id: str | None = None
 
 
 class UserGroupResponse(BaseModel):
@@ -87,6 +92,19 @@ def create_user_group_node(
         "schema_version": group.schema_version,
     }
     graph.add_node(group.group_id, attrs)
+    if req.user_id:
+        perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
+        try:
+            with perm_graph.bootstrap_owner(group.group_id):
+                perm_graph.add_edge(
+                    group.group_id,
+                    req.user_id,
+                    "OWNED_BY",
+                    {"permission_level": "editor"},
+                    schema_version=EDGE_VERSION,
+                )
+        except AccessDeniedError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
     return UserGroupResponse(
         id=group.group_id,
         name=group.name,

--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -241,6 +241,59 @@ def test_calendar_event_group_permissions(client_and_graph) -> None:
     )
 
 
+def test_calendar_event_group_sharing_without_seeded_ownership(
+    client_and_graph,
+) -> None:
+    client, _ = client_and_graph
+    token = _token(client)
+
+    user1_res = client.post(
+        "/v1/users",
+        json={"name": "Owner"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert user1_res.status_code == 200
+    user1 = user1_res.json()["id"]
+    user2_res = client.post(
+        "/v1/users",
+        json={"name": "Member"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert user2_res.status_code == 200
+    user2 = user2_res.json()["id"]
+
+    group_res = client.post(
+        "/v1/groups",
+        json={"name": "Team", "members": [user1, user2], "user_id": user1},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert group_res.status_code == 200
+    group_id = group_res.json()["id"]
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+    event_res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Shared",
+            "start_time": start,
+            "user_id": user1,
+            "group_id": group_id,
+            "visibility": CalendarEventVisibility.PUBLIC_TO_GROUP.value,
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert event_res.status_code == 200
+    event_data = event_res.json()
+
+    res = client.get(
+        "/v1/calendar/events",
+        params={"user_id": user2, "group_id": group_id},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    assert res.json() == [event_data]
+
+
 def test_calendar_event_group_membership_required(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)

--- a/tests/test_users_routes.py
+++ b/tests/test_users_routes.py
@@ -6,6 +6,7 @@ from ume import MockGraph
 from ume.config import settings
 from ume.models.users import SCHEMA_VERSION as USER_SCHEMA_VERSION
 from ume.models.user_group import SCHEMA_VERSION as GROUP_SCHEMA_VERSION
+from ume.graph_schema import get_default_edge_version
 
 
 def _token(client: TestClient) -> str:
@@ -29,6 +30,7 @@ def client_and_graph():
 def test_user_group_and_owned_by(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)
+    edge_version = get_default_edge_version("OWNED_BY")
 
     # Create a user
     res = client.post(
@@ -51,7 +53,7 @@ def test_user_group_and_owned_by(client_and_graph) -> None:
     # Create a user group containing the user
     res = client.post(
         "/v1/groups",
-        json={"name": "Team", "members": [user_id]},
+        json={"name": "Team", "members": [user_id], "user_id": user_id},
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 200
@@ -64,6 +66,13 @@ def test_user_group_and_owned_by(client_and_graph) -> None:
     assert attrs["name"] == "Team"
     assert attrs["members"] == [user_id]
     assert attrs["schema_version"] == GROUP_SCHEMA_VERSION
+    edges = graph.get_all_edges()
+    assert (
+        group_id,
+        user_id,
+        "OWNED_BY",
+        {"permission_level": "editor", "schema_version": edge_version},
+    ) in edges
 
     # Prepare a resource node and create OWNED_BY edges
     graph.add_node("doc1", {"type": "Document"})
@@ -79,7 +88,6 @@ def test_user_group_and_owned_by(client_and_graph) -> None:
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 403
-    edges = graph.get_all_edges()
     assert (
         "doc1",
         user_id,


### PR DESCRIPTION
### Motivation

- Allow specifying a creator/owner when creating a user group so the creator is automatically granted ownership rights.  
- Ensure the initial `OWNED_BY` edge uses `permission_level = "editor"` and includes the correct `schema_version`.  
- Prevent clients from needing to manually seed group ownership in order to share resources with the group.  

### Description

- Extend `UserGroupCreateRequest` to accept an optional `user_id` and export `EDGE_VERSION = get_default_edge_version("OWNED_BY")`.  
- After creating a group node, create an `OWNED_BY` edge from the group to the creator inside `PermissionsGraphAdapter.bootstrap_owner(...)` with `{"permission_level": "editor"}` and `schema_version=EDGE_VERSION`.  
- Import and handle `AccessDeniedError` by converting it to an HTTP 400 with `HTTPException` when bootstrap edge creation fails.  
- Update tests: assert the `OWNED_BY` edge is present in `tests/test_users_routes.py` and add `test_calendar_event_group_sharing_without_seeded_ownership` to `tests/test_calendar_decision_api.py` to cover the regression scenario where group ownership is created at group creation time.  

### Testing

- Ran `poetry run pytest tests/test_users_routes.py tests/test_calendar_decision_api.py`, which failed during collection due to `ModuleNotFoundError: No module named 'fastapi.testclient'` in the environment.  
- Ran `poetry run ruff check .`, which completed successfully.  
- Ran `poetry run mypy src tests`, which reported existing type-checking errors in the repository (not introduced by these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a9f31524c8326bdd4958a5e956bab)