### PR TITLE
Include type metadata for decision and action payloads

### DIFF
--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -46,6 +46,7 @@ class ActionCreateRequest(BaseModel):
 
 def _analysis_to_dict(analysis: DecisionAnalysis) -> dict[str, Any]:
     return {
+        "type": "DecisionAnalysis",
         "analysis_id": analysis.analysis_id,
         "query": analysis.query,
         "created_at": int(analysis.created_at.timestamp()),
@@ -55,6 +56,7 @@ def _analysis_to_dict(analysis: DecisionAnalysis) -> dict[str, Any]:
 
 def _action_to_dict(action: ProposedAction) -> dict[str, Any]:
     return {
+        "type": "ProposedAction",
         "action_id": action.action_id,
         "description": action.description,
         "rank": action.rank,

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -38,6 +38,7 @@ def test_decision_flow(client_and_graph) -> None:
     assert res.status_code == 200
     analysis = res.json()
     analysis_id = analysis["analysis_id"]
+    assert analysis["type"] == "DecisionAnalysis"
     assert analysis["schema_version"] == SCHEMA_VERSION
     user_attrs = g.get_node("user1")
     assert user_attrs is not None
@@ -55,6 +56,7 @@ def test_decision_flow(client_and_graph) -> None:
     assert res.status_code == 200
     action = res.json()
     action_id = action["action_id"]
+    assert action["type"] == "ProposedAction"
     assert action["schema_version"] == ACTION_SCHEMA_VERSION
 
     res = client.get(
@@ -65,13 +67,21 @@ def test_decision_flow(client_and_graph) -> None:
     assert res.status_code == 200
     data = res.json()
     assert data["analysis"]["analysis_id"] == analysis_id
+    assert data["analysis"]["type"] == "DecisionAnalysis"
     assert data["analysis"]["schema_version"] == SCHEMA_VERSION
     assert len(data["actions"]) == 1
     assert data["actions"][0]["action_id"] == action_id
+    assert data["actions"][0]["type"] == "ProposedAction"
     assert data["actions"][0]["schema_version"] == ACTION_SCHEMA_VERSION
 
+    analysis_attrs = g.get_node(analysis_id)
+    assert analysis_attrs is not None
+    assert analysis_attrs["type"] == "DecisionAnalysis"
     assert g.get_node(analysis_id)["query"] == "Choose option"
-    assert g.get_node(action_id)["description"] == "Option A"
+    action_attrs = g.get_node(action_id)
+    assert action_attrs is not None
+    assert action_attrs["type"] == "ProposedAction"
+    assert action_attrs["description"] == "Option A"
     assert g.find_connected_nodes(analysis_id, edge_label="CONSIDERS") == [action_id]
     # Permission edges created
     edges = g.get_all_edges()


### PR DESCRIPTION
## Summary
- add explicit type fields to serialized decision analyses and proposed actions
- extend decision route tests to assert stored nodes and responses include type metadata

## Testing
- pytest tests/test_decisions_routes.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bccc3e5a48326b120005319e99085)