### PR TITLE
Add schema validation for graph mutations

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 from contextlib import suppress
 from datetime import datetime
-from typing import List
+from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from . import api_deps as deps
-from .graph_schema import get_default_edge_version
 from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .processing import ProcessingError
+from .schema_manager import DEFAULT_SCHEMA_MANAGER
+from .schema_validation import validate_edge, validate_node_attributes
 from .utils import ensure_group_member
 from .models import (
     CalendarEventStatus,
@@ -21,13 +22,26 @@ from .models import (
     create_user,
 )
 
-EDGE_VERSION = get_default_edge_version("OWNED_BY")
 VALID_GROUP_PERMISSION_LEVELS = {"viewer", "editor"}
 
 router = APIRouter(prefix="/v1/calendar")
 
 
-def _ensure_user_node(graph: IGraphAdapter, user_id: str) -> None:
+def _validate_node_or_http(attrs: dict[str, Any], schema) -> str:
+    try:
+        return validate_node_attributes(attrs, schema=schema)
+    except ProcessingError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+def _validate_edge_or_http(label: str, attrs: dict[str, Any] | None, schema) -> str:
+    try:
+        return validate_edge(label, attrs, schema_version=None, schema=schema)
+    except ProcessingError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+def _ensure_user_node(graph: IGraphAdapter, user_id: str, schema) -> None:
     """Create a full user node if one does not already exist."""
     if graph.node_exists(user_id):
         return
@@ -38,8 +52,9 @@ def _ensure_user_node(graph: IGraphAdapter, user_id: str) -> None:
         "name": user.name,
         "email": user.email,
         "created_at": int(user.created_at.timestamp()),
-        "schema_version": user.schema_version,
+        "schema_version": schema.node_types["User"].version,
     }
+    _validate_node_or_http(attrs, schema)
     graph.add_node(user.user_id, attrs)
 
 
@@ -103,6 +118,7 @@ def create_event(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> CalendarEventResponse:
+    schema = DEFAULT_SCHEMA_MANAGER.get_schema()
     if req.end_time is not None and req.end_time <= req.start_time:
         raise HTTPException(
             status_code=400, detail="end_time must be after start_time"
@@ -133,14 +149,15 @@ def create_event(
         "status": event.status.value if event.status else None,
         "rrule": event.rrule,
         "visibility": event.visibility.value if event.visibility else None,
-        "schema_version": event.schema_version,
+        "schema_version": schema.node_types["CalendarEvent"].version,
     }
+    _validate_node_or_http(attrs, schema)
     graph.add_node(event.event_id, attrs)
     invitee_ids = req.invitee_ids or []
     layer_ids = req.layer_ids or []
-    _ensure_user_node(graph, req.user_id)
+    _ensure_user_node(graph, req.user_id, schema)
     for uid in invitee_ids:
-        _ensure_user_node(graph, uid)
+        _ensure_user_node(graph, uid, schema)
 
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
 
@@ -157,7 +174,13 @@ def create_event(
                 raise HTTPException(status_code=400, detail="Invalid group_permission_level")
         try:
             perm_graph.add_edge(
-                event.event_id, req.user_id, "OWNED_BY", {"permission_level": "editor"}
+                event.event_id,
+                req.user_id,
+                "OWNED_BY",
+                {"permission_level": "editor"},
+                schema_version=_validate_edge_or_http(
+                    "OWNED_BY", {"permission_level": "editor"}, schema
+                ),
             )
         except AccessDeniedError:
             graph.add_edge(
@@ -165,7 +188,9 @@ def create_event(
                 req.user_id,
                 "OWNED_BY",
                 {"permission_level": "editor"},
-                schema_version=EDGE_VERSION,
+                schema_version=_validate_edge_or_http(
+                    "OWNED_BY", {"permission_level": "editor"}, schema
+                ),
             )
             perm_graph.rebuild_index()
 
@@ -175,12 +200,26 @@ def create_event(
                 req.group_id,
                 "SHARED_WITH",
                 {"permission_level": group_permission_level},
+                schema_version=_validate_edge_or_http(
+                    "SHARED_WITH", {"permission_level": group_permission_level}, schema
+                ),
             )
 
         for uid in invitee_ids:
-            perm_graph.add_edge(event.event_id, uid, "INVITES")
             perm_graph.add_edge(
-                event.event_id, uid, "SHARED_WITH", {"permission_level": "viewer"}
+                event.event_id,
+                uid,
+                "INVITES",
+                schema_version=_validate_edge_or_http("INVITES", {}, schema),
+            )
+            perm_graph.add_edge(
+                event.event_id,
+                uid,
+                "SHARED_WITH",
+                {"permission_level": "viewer"},
+                schema_version=_validate_edge_or_http(
+                    "SHARED_WITH", {"permission_level": "viewer"}, schema
+                ),
             )
 
 
@@ -190,7 +229,12 @@ def create_event(
                 raise HTTPException(status_code=400, detail=f"Invalid layer_id: {lid}")
             if not _user_has_editor_access_to_layer(graph, req.user_id, lid):
                 raise HTTPException(status_code=400, detail=f"Invalid layer_id: {lid}")
-            perm_graph.add_edge(event.event_id, lid, "TAGGED_AS")
+            perm_graph.add_edge(
+                event.event_id,
+                lid,
+                "TAGGED_AS",
+                schema_version=_validate_edge_or_http("TAGGED_AS", {}, schema),
+            )
     except HTTPException:
         with suppress(ProcessingError):
             graph.redact_node(event.event_id)
@@ -214,7 +258,7 @@ def create_event(
         status=event.status,
         rrule=event.rrule,
         visibility=event.visibility,
-        schema_version=event.schema_version,
+        schema_version=attrs["schema_version"],
     )
 
 

--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -2,14 +2,18 @@ from __future__ import annotations
 
 from typing import Any
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
-from .graph_schema import get_default_edge_version
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
+from .processing import ProcessingError
+from .schema_manager import DEFAULT_SCHEMA_MANAGER
+from .schema_validation import validate_edge, validate_node_attributes
 from .utils import ensure_group_member
 from .models import (
     DecisionAnalysis,
@@ -22,9 +26,21 @@ from .models import (
 
 VALID_GROUP_PERMISSION_LEVELS = {"viewer", "editor"}
 
-EDGE_VERSION = get_default_edge_version("OWNED_BY")
-
 router = APIRouter(prefix="/v1/decisions")
+
+
+def _validate_node_or_http(attrs: dict[str, Any], schema) -> str:
+    try:
+        return validate_node_attributes(attrs, schema=schema)
+    except ProcessingError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+def _validate_edge_or_http(label: str, attrs: dict[str, Any] | None, schema) -> str:
+    try:
+        return validate_edge(label, attrs, schema_version=None, schema=schema)
+    except ProcessingError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 class DecisionCreateRequest(BaseModel):
@@ -44,17 +60,17 @@ class ActionCreateRequest(BaseModel):
     group_permission_level: str | None = None
 
 
-def _analysis_to_dict(analysis: DecisionAnalysis) -> dict[str, Any]:
+def _analysis_to_dict(analysis: DecisionAnalysis, schema) -> dict[str, Any]:
     return {
         "type": "DecisionAnalysis",
         "analysis_id": analysis.analysis_id,
         "query": analysis.query,
         "created_at": int(analysis.created_at.timestamp()),
-        "schema_version": analysis.schema_version,
+        "schema_version": schema.node_types["DecisionAnalysis"].version,
     }
 
 
-def _action_to_dict(action: ProposedAction) -> dict[str, Any]:
+def _action_to_dict(action: ProposedAction, schema) -> dict[str, Any]:
     return {
         "type": "ProposedAction",
         "action_id": action.action_id,
@@ -62,11 +78,11 @@ def _action_to_dict(action: ProposedAction) -> dict[str, Any]:
         "rank": action.rank,
         "is_optimal": action.is_optimal,
         "outcome_metrics": action.outcome_metrics,
-        "schema_version": action.schema_version,
+        "schema_version": schema.node_types["ProposedAction"].version,
     }
 
 
-def _user_node_defaults(user_id: str) -> dict[str, Any]:
+def _user_node_defaults(user_id: str, schema) -> dict[str, Any]:
     user = create_user(user_id, user_id=user_id)
     return {
         "type": "User",
@@ -74,14 +90,15 @@ def _user_node_defaults(user_id: str) -> dict[str, Any]:
         "name": user.name,
         "email": user.email,
         "created_at": int(user.created_at.timestamp()),
-        "schema_version": user.schema_version,
+        "schema_version": schema.node_types["User"].version,
     }
 
 
-def _ensure_user_node(graph: IGraphAdapter, user_id: str) -> None:
-    defaults = _user_node_defaults(user_id)
+def _ensure_user_node(graph: IGraphAdapter, user_id: str, schema) -> None:
+    defaults = _user_node_defaults(user_id, schema)
     attrs = graph.get_node(user_id)
     if attrs is None:
+        _validate_node_or_http(defaults, schema)
         graph.add_node(user_id, defaults)
         return
     update_attrs: dict[str, Any] = {}
@@ -93,24 +110,26 @@ def _ensure_user_node(graph: IGraphAdapter, user_id: str) -> None:
     if not attrs.get("schema_version"):
         update_attrs["schema_version"] = defaults["schema_version"]
     if update_attrs:
+        _validate_node_or_http({**attrs, **update_attrs}, schema)
         graph.update_node(user_id, update_attrs)
 
 
-def _group_node_defaults(group_id: str) -> dict[str, Any]:
+def _group_node_defaults(group_id: str, schema) -> dict[str, Any]:
     group = create_user_group(group_id, group_id=group_id)
     return {
         "type": "UserGroup",
         "group_id": group.group_id,
         "name": group.name,
         "members": list(group.members),
-        "schema_version": group.schema_version,
+        "schema_version": schema.node_types["UserGroup"].version,
     }
 
 
-def _ensure_group_node(graph: IGraphAdapter, group_id: str) -> None:
-    defaults = _group_node_defaults(group_id)
+def _ensure_group_node(graph: IGraphAdapter, group_id: str, schema) -> None:
+    defaults = _group_node_defaults(group_id, schema)
     attrs = graph.get_node(group_id)
     if attrs is None:
+        _validate_node_or_http(defaults, schema)
         graph.add_node(group_id, defaults)
         return
     update_attrs: dict[str, Any] = {}
@@ -125,6 +144,7 @@ def _ensure_group_node(graph: IGraphAdapter, group_id: str) -> None:
     if not attrs.get("schema_version"):
         update_attrs["schema_version"] = defaults["schema_version"]
     if update_attrs:
+        _validate_node_or_http({**attrs, **update_attrs}, schema)
         graph.update_node(group_id, update_attrs)
 
 
@@ -134,9 +154,10 @@ def create_decision(
     _: str = Depends(deps.get_current_role),
     graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> dict[str, Any]:
+    schema = DEFAULT_SCHEMA_MANAGER.get_schema()
     if req.group_id:
         ensure_group_member(graph, req.user_id, req.group_id)
-        _ensure_group_node(graph, req.group_id)
+        _ensure_group_node(graph, req.group_id, schema)
         group_permission_level = req.group_permission_level or "editor"
         if group_permission_level not in VALID_GROUP_PERMISSION_LEVELS:
             raise HTTPException(status_code=400, detail="Invalid group_permission_level")
@@ -144,17 +165,20 @@ def create_decision(
         graph, user_id=req.user_id, group_id=req.group_id
     )
     analysis = create_decision_analysis(req.query)
-    attrs = _analysis_to_dict(analysis)
+    attrs = _analysis_to_dict(analysis, schema)
+    _validate_node_or_http(attrs, schema)
     perm_graph.add_node(analysis.analysis_id, attrs)
     # Ensure subject nodes exist
-    _ensure_user_node(graph, req.user_id)
+    _ensure_user_node(graph, req.user_id, schema)
     # Link analysis to the owning user
     graph.add_edge(
         analysis.analysis_id,
         req.user_id,
         "OWNED_BY",
         {"permission_level": "editor"},
-        schema_version=EDGE_VERSION,
+        schema_version=_validate_edge_or_http(
+            "OWNED_BY", {"permission_level": "editor"}, schema
+        ),
     )
     perm_graph.rebuild_index()
     if req.group_id:
@@ -163,6 +187,9 @@ def create_decision(
             req.group_id,
             "SHARED_WITH",
             {"permission_level": group_permission_level},
+            schema_version=_validate_edge_or_http(
+                "SHARED_WITH", {"permission_level": group_permission_level}, schema
+            ),
         )
     return attrs
 
@@ -174,9 +201,10 @@ def add_action(
     _: str = Depends(deps.get_current_role),
     graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> dict[str, Any]:
+    schema = DEFAULT_SCHEMA_MANAGER.get_schema()
     if req.group_id:
         ensure_group_member(graph, req.user_id, req.group_id)
-        _ensure_group_node(graph, req.group_id)
+        _ensure_group_node(graph, req.group_id, schema)
         group_permission_level = req.group_permission_level or "viewer"
         if group_permission_level not in VALID_GROUP_PERMISSION_LEVELS:
             raise HTTPException(status_code=400, detail="Invalid group_permission_level")
@@ -191,17 +219,20 @@ def add_action(
         is_optimal=req.is_optimal,
         outcome_metrics=req.outcome_metrics or {},
     )
-    action_attrs = _action_to_dict(action)
+    action_attrs = _action_to_dict(action, schema)
+    _validate_node_or_http(action_attrs, schema)
     perm_graph.add_node(action.action_id, action_attrs)
     # Ensure subject nodes exist
-    _ensure_user_node(graph, req.user_id)
+    _ensure_user_node(graph, req.user_id, schema)
     # Link action to the owning user
     graph.add_edge(
         action.action_id,
         req.user_id,
         "OWNED_BY",
         {"permission_level": "editor"},
-        schema_version=EDGE_VERSION,
+        schema_version=_validate_edge_or_http(
+            "OWNED_BY", {"permission_level": "editor"}, schema
+        ),
     )
     perm_graph.rebuild_index()
     if req.group_id:
@@ -211,6 +242,9 @@ def add_action(
                 req.group_id,
                 "SHARED_WITH",
                 {"permission_level": group_permission_level},
+                schema_version=_validate_edge_or_http(
+                    "SHARED_WITH", {"permission_level": group_permission_level}, schema
+                ),
             )
         except AccessDeniedError:
             raise HTTPException(
@@ -219,7 +253,12 @@ def add_action(
             )
     perm_graph.rebuild_index()
     try:
-        perm_graph.add_edge(analysis_id, action.action_id, "CONSIDERS")
+        perm_graph.add_edge(
+            analysis_id,
+            action.action_id,
+            "CONSIDERS",
+            schema_version=_validate_edge_or_http("CONSIDERS", {}, schema),
+        )
     except AccessDeniedError:
         perm_graph.redact_node(action.action_id)
         perm_graph.rebuild_index()

--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -1,20 +1,35 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from typing import cast
 
 from . import api_deps as deps
-from .graph_schema import get_default_edge_version
 from .graph_adapter import IGraphAdapter
-from .rbac_adapter import AccessDeniedError
 from .permissions_adapter import PermissionsGraphAdapter
+from .rbac_adapter import AccessDeniedError
+from .schema_manager import DEFAULT_SCHEMA_MANAGER
+from .schema_validation import validate_edge, validate_node_attributes
 from .models import create_financial_account, create_user
+from .processing import ProcessingError
 from .utils import ensure_group_member
 
 router = APIRouter(prefix="/v1/accounts")
 
-EDGE_VERSION = get_default_edge_version("OWNED_BY")
+
+def _validate_node_or_http(attrs: dict[str, Any], schema) -> str:
+    try:
+        return validate_node_attributes(attrs, schema=schema)
+    except ProcessingError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+def _validate_edge_or_http(label: str, attrs: dict[str, Any] | None, schema) -> str:
+    try:
+        return validate_edge(label, attrs, schema_version=None, schema=schema)
+    except ProcessingError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 class FinancialAccountCreateRequest(BaseModel):
@@ -41,6 +56,7 @@ def create_account(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> FinancialAccountResponse:
+    schema = DEFAULT_SCHEMA_MANAGER.get_schema()
     if not graph.node_exists(req.user_id):
         user = create_user(req.user_id, user_id=req.user_id)
         user_attrs = {
@@ -49,8 +65,9 @@ def create_account(
             "name": user.name,
             "email": user.email,
             "created_at": int(user.created_at.timestamp()),
-            "schema_version": user.schema_version,
+            "schema_version": schema.node_types["User"].version,
         }
+        _validate_node_or_http(user_attrs, schema)
         graph.add_node(user.user_id, user_attrs)
     if req.group_id:
         group_attrs = graph.get_node(req.group_id)
@@ -70,8 +87,9 @@ def create_account(
         "institution": account.institution,
         "balance": account.balance,
         "currency": account.currency,
-        "schema_version": account.schema_version,
+        "schema_version": schema.node_types["FinancialAccount"].version,
     }
+    _validate_node_or_http(attrs, schema)
     graph.add_node(account.account_id, attrs)
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     try:
@@ -81,7 +99,9 @@ def create_account(
                 req.user_id,
                 "OWNED_BY",
                 {"permission_level": "editor"},
-                schema_version=EDGE_VERSION,
+                schema_version=_validate_edge_or_http(
+                    "OWNED_BY", {"permission_level": "editor"}, schema
+                ),
             )
         if req.group_id:
             perm_graph.add_edge(
@@ -89,6 +109,9 @@ def create_account(
                 req.group_id,
                 "SHARED_WITH",
                 {"permission_level": "viewer"},
+                schema_version=_validate_edge_or_http(
+                    "SHARED_WITH", {"permission_level": "viewer"}, schema
+                ),
             )
     except AccessDeniedError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -99,7 +122,7 @@ def create_account(
         institution=account.institution,
         balance=account.balance,
         currency=account.currency,
-        schema_version=account.schema_version,
+        schema_version=attrs["schema_version"],
     )
 
 

--- a/src/ume/schema_validation.py
+++ b/src/ume/schema_validation.py
@@ -1,0 +1,92 @@
+"""Validation helpers for ensuring graph mutations match the active schema."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from .graph_schema import GraphSchema
+from .processing import ProcessingError
+from .schema_manager import DEFAULT_SCHEMA_MANAGER
+
+
+def _get_schema(schema: GraphSchema | None = None) -> GraphSchema:
+    if schema is not None:
+        return schema
+    return DEFAULT_SCHEMA_MANAGER.get_schema()
+
+
+def validate_node_attributes(
+    attrs: Mapping[str, object], schema: GraphSchema | None = None
+) -> str:
+    """Validate a node payload against the provided :class:`GraphSchema`.
+
+    Returns the expected schema version for the node type so callers can apply
+    it to storage writes.
+    """
+
+    active_schema = _get_schema(schema)
+    node_type = attrs.get("type") if isinstance(attrs, Mapping) else None
+    if not isinstance(node_type, str) or not node_type:
+        raise ProcessingError("Node attributes must include a non-empty 'type'")
+
+    node_def = active_schema.node_types.get(node_type)
+    if node_def is None:
+        raise ProcessingError(f"Unknown node type '{node_type}'")
+
+    missing = [prop for prop in node_def.properties if prop not in attrs]
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise ProcessingError(
+            f"Missing required properties for node type '{node_type}': {missing_list}"
+        )
+
+    expected_version = node_def.version
+    provided_version = attrs.get("schema_version") if isinstance(attrs, Mapping) else None
+    if provided_version not in (None, expected_version):
+        raise ProcessingError(
+            "schema_version does not match the active schema for node type "
+            f"'{node_type}' (expected '{expected_version}')"
+        )
+
+    return expected_version
+
+
+def validate_edge(
+    label: str,
+    attrs: Mapping[str, object] | None = None,
+    schema_version: str | None = None,
+    schema: GraphSchema | None = None,
+) -> str:
+    """Validate an edge against the active schema and return its version."""
+
+    active_schema = _get_schema(schema)
+    if not isinstance(label, str) or not label:
+        raise ProcessingError("Edge label must be a non-empty string")
+
+    edge_def = active_schema.edge_labels.get(label)
+    if edge_def is None:
+        raise ProcessingError(f"Unknown edge label '{label}'")
+
+    expected_version = edge_def.version
+    provided_version = schema_version
+    if provided_version not in (None, expected_version):
+        raise ProcessingError(
+            "schema_version does not match the active schema for edge label "
+            f"'{label}' (expected '{expected_version}')"
+        )
+
+    if attrs is not None and isinstance(attrs, Mapping):
+        perm_level = attrs.get("permission_level")
+        if perm_level is not None and edge_def.permission_level_values:
+            if perm_level not in edge_def.permission_level_values:
+                raise ProcessingError(
+                    f"Invalid permission_level '{perm_level}' for edge label '{label}'"
+                )
+
+    return expected_version
+
+
+__all__ = [
+    "validate_edge",
+    "validate_node_attributes",
+]

--- a/src/ume/users_routes.py
+++ b/src/ume/users_routes.py
@@ -1,21 +1,34 @@
 from __future__ import annotations
 
-from typing import List
+from typing import Any, List
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from . import api_deps as deps
 from .graph_adapter import IGraphAdapter
-from .graph_schema import get_default_edge_version
 from .models import create_user, create_user_group
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
+from .processing import ProcessingError
+from .schema_manager import DEFAULT_SCHEMA_MANAGER
+from .schema_validation import validate_edge, validate_node_attributes
 from .utils import ensure_group_member
 
 router = APIRouter(prefix="/v1")
 
-EDGE_VERSION = get_default_edge_version("OWNED_BY")
+def _validate_node_or_http(attrs: dict[str, Any], schema) -> str:
+    try:
+        return validate_node_attributes(attrs, schema=schema)
+    except ProcessingError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+def _validate_edge_or_http(label: str, attrs: dict[str, Any] | None, schema) -> str:
+    try:
+        return validate_edge(label, attrs, schema_version=None, schema=schema)
+    except ProcessingError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
 
 class UserCreateRequest(BaseModel):
@@ -59,6 +72,7 @@ def create_user_node(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> UserResponse:
+    schema = DEFAULT_SCHEMA_MANAGER.get_schema()
     user = create_user(req.name, email=req.email)
     attrs = {
         "type": "User",
@@ -66,14 +80,15 @@ def create_user_node(
         "name": user.name,
         "email": user.email,
         "created_at": int(user.created_at.timestamp()),
-        "schema_version": user.schema_version,
+        "schema_version": schema.node_types["User"].version,
     }
+    _validate_node_or_http(attrs, schema)
     graph.add_node(user.user_id, attrs)
     return UserResponse(
         id=user.user_id,
         name=user.name,
         email=user.email,
-        schema_version=user.schema_version,
+        schema_version=attrs["schema_version"],
     )
 
 
@@ -83,14 +98,16 @@ def create_user_group_node(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> UserGroupResponse:
+    schema = DEFAULT_SCHEMA_MANAGER.get_schema()
     group = create_user_group(req.name, members=req.members)
     attrs = {
         "type": "UserGroup",
         "group_id": group.group_id,
         "name": group.name,
         "members": group.members,
-        "schema_version": group.schema_version,
+        "schema_version": schema.node_types["UserGroup"].version,
     }
+    _validate_node_or_http(attrs, schema)
     graph.add_node(group.group_id, attrs)
     if req.user_id:
         perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
@@ -101,7 +118,9 @@ def create_user_group_node(
                     req.user_id,
                     "OWNED_BY",
                     {"permission_level": "editor"},
-                    schema_version=EDGE_VERSION,
+                    schema_version=_validate_edge_or_http(
+                        "OWNED_BY", {"permission_level": "editor"}, schema
+                    ),
                 )
         except AccessDeniedError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -109,7 +128,7 @@ def create_user_group_node(
         id=group.group_id,
         name=group.name,
         members=group.members,
-        schema_version=group.schema_version,
+        schema_version=attrs["schema_version"],
     )
 
 
@@ -119,6 +138,7 @@ def create_owned_by_edge(
     graph: IGraphAdapter = Depends(deps.get_graph),
     _: str = Depends(deps.get_current_role),
 ) -> dict[str, str]:
+    schema = DEFAULT_SCHEMA_MANAGER.get_schema()
     owner_attrs = graph.get_node(req.owner_id) or {}
     if owner_attrs.get("type") == "UserGroup":
         perm_graph = PermissionsGraphAdapter(graph, group_id=req.owner_id)
@@ -129,6 +149,9 @@ def create_owned_by_edge(
         req.owner_id,
         "OWNED_BY",
         {"permission_level": req.permission_level},
+        schema_version=_validate_edge_or_http(
+            "OWNED_BY", {"permission_level": req.permission_level}, schema
+        ),
     )
     return {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- add reusable schema validation helpers for nodes and edges
- validate and version calendar, decisions, financial account, and user creation requests against the active graph schema
- return HTTP 400 responses when schema validation fails to aid migrations

## Testing
- python -m compileall src/ume
- pytest tests/test_ingest_schema_version.py *(fails: missing google.protobuf.json_format dependency in test environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bd079871c832686987508b406e5a6)