### PR TITLE
Add permission edge enforcement tests

### DIFF
--- a/tests/test_calendar_decision_api.py
+++ b/tests/test_calendar_decision_api.py
@@ -135,6 +135,54 @@ def test_calendar_event_permissions(client_and_graph) -> None:
     )
 
 
+def test_viewer_cannot_assign_permission_edges_to_calendar_event(
+    client_and_graph,
+) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("owner", {"type": "User"})
+    graph.add_node("viewer", {"type": "User"})
+    graph.add_node("other_user", {"type": "User"})
+
+    start = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc).isoformat()
+    res = client.post(
+        "/v1/calendar/events",
+        json={
+            "title": "Blocked",
+            "start_time": start,
+            "user_id": "owner",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    event_id = res.json()["event_id"]
+    assert res.json()["schema_version"] == SCHEMA_VERSION
+
+    graph.add_edge(
+        event_id,
+        "viewer",
+        "SHARED_WITH",
+        {"permission_level": "viewer", "schema_version": SCHEMA_VERSION},
+        schema_version=SCHEMA_VERSION,
+    )
+
+    response = client.post(
+        "/edges",
+        json={
+            "source": event_id,
+            "target": "other_user",
+            "label": "SHARED_WITH",
+            "attrs": {"permission_level": "viewer"},
+        },
+        headers={"Authorization": f"Bearer {token}"},
+        params={"user_id": "viewer"},
+    )
+
+    assert response.status_code == 403
+    assert "Editor permission required" in response.json()["detail"]
+
+
 def test_calendar_event_group_permissions(client_and_graph) -> None:
     client, graph = client_and_graph
     token = _token(client)

--- a/tests/test_decisions_routes.py
+++ b/tests/test_decisions_routes.py
@@ -364,3 +364,44 @@ def test_viewer_cannot_add_action(client_and_graph) -> None:
     ]
     assert proposed_action_nodes == []
     assert all(lbl != "CONSIDERS" for _, _, lbl, _ in g.get_all_edges())
+
+
+def test_viewer_cannot_set_permission_edges_on_decision(
+    client_and_graph,
+) -> None:
+    client, g = client_and_graph
+    token = _token(client)
+
+    res = client.post(
+        "/v1/decisions",
+        json={"query": "Q", "user_id": "owner"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200
+    analysis_id = res.json()["analysis_id"]
+    assert res.json()["schema_version"] == SCHEMA_VERSION
+
+    g.add_node("viewer", {"type": "User"})
+    g.add_node("other_user", {"type": "User"})
+    g.add_edge(
+        analysis_id,
+        "viewer",
+        "SHARED_WITH",
+        {"permission_level": "viewer", "schema_version": EDGE_VERSION},
+        schema_version=EDGE_VERSION,
+    )
+
+    response = client.post(
+        "/edges",
+        json={
+            "source": analysis_id,
+            "target": "other_user",
+            "label": "SHARED_WITH",
+            "attrs": {"permission_level": "viewer"},
+        },
+        headers={"Authorization": f"Bearer {token}"},
+        params={"user_id": "viewer"},
+    )
+
+    assert response.status_code == 403
+    assert "Editor permission required" in response.json()["detail"]

--- a/tests/test_financial_account_routes.py
+++ b/tests/test_financial_account_routes.py
@@ -187,3 +187,51 @@ def test_create_financial_account_rejects_user_not_in_group_members(client_and_g
         headers={"Authorization": f"Bearer {token}"},
     )
     assert res.status_code == 403
+
+
+def test_viewer_cannot_assign_permission_edges_on_account(client_and_graph) -> None:
+    client, graph = client_and_graph
+    token = _token(client)
+
+    graph.add_node("viewer", {})
+    graph.add_node("other_user", {})
+
+    create_res = client.post(
+        "/v1/accounts",
+        json={
+            "account_type": "checking",
+            "institution": "ACME Bank",
+            "balance": 25.0,
+            "currency": "USD",
+            "user_id": "owner",
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert create_res.status_code == 200
+    account_id = create_res.json()["id"]
+    assert create_res.json()["schema_version"] == SCHEMA_VERSION
+
+    graph.add_edge(
+        account_id,
+        "viewer",
+        "SHARED_WITH",
+        {"permission_level": "viewer", "schema_version": EDGE_VERSION},
+        schema_version=EDGE_VERSION,
+    )
+
+    response = client.post(
+        "/edges",
+        json={
+            "source": account_id,
+            "target": "other_user",
+            "label": "OWNED_BY",
+            "attrs": {"permission_level": "editor"},
+        },
+        headers={"Authorization": f"Bearer {token}"},
+        params={"user_id": "viewer"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"].startswith(
+        "OWNED_BY edges must be bootstrapped"
+    )

--- a/tests/test_graph_routes_permissions.py
+++ b/tests/test_graph_routes_permissions.py
@@ -127,6 +127,33 @@ def test_permission_edge_requires_permission_level(
     )
 
 
+def test_invalid_permission_level_value(
+    client_with_graph: tuple[TestClient, MockGraph, dict[str, str]]
+) -> None:
+    client, graph, headers = client_with_graph
+
+    graph.add_node("doc", {"type": "Document"})
+    graph.add_node("owner", {"type": "User"})
+    graph.add_node("target", {"type": "User"})
+    graph.add_edge("doc", "owner", "OWNED_BY", {"permission_level": "editor"})
+
+    params = {"user_id": "owner"}
+    response = client.post(
+        "/edges",
+        json={
+            "source": "doc",
+            "target": "target",
+            "label": "SHARED_WITH",
+            "attrs": {"permission_level": "admin"},
+        },
+        headers=headers,
+        params=params,
+    )
+
+    assert response.status_code == 403
+    assert "Invalid permission_level" in response.json()["detail"]
+
+
 def test_subgraph_filters_view_only_subjects(
     client_with_graph: tuple[TestClient, MockGraph, dict[str, str]]
 ) -> None:


### PR DESCRIPTION
## Summary
- add tests for invalid permission-level attributes when creating graph edges
- cover denied permission edge mutations for decisions, calendar events, and financial accounts
- assert schema_version fields remain present in new permission scenarios

## Testing
- pytest tests/test_graph_routes_permissions.py::test_invalid_permission_level_value tests/test_decisions_routes.py::test_viewer_cannot_set_permission_edges_on_decision tests/test_calendar_decision_api.py::test_viewer_cannot_assign_permission_edges_to_calendar_event tests/test_financial_account_routes.py::test_viewer_cannot_assign_permission_edges_on_account

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d23a2754c8326aa49dd891d7c9521)