### PR TITLE
Add schema-validated graph mutation helpers and wire them into creation routes

### DIFF
--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -13,7 +13,7 @@ from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .processing import ProcessingError
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
-from .schema_validation import validate_edge, validate_node_attributes
+from .graph_mutations import add_edge_with_schema_validation, add_node_with_schema_validation
 from .utils import ensure_group_member
 from .models import (
     CalendarEventStatus,
@@ -27,18 +27,49 @@ VALID_GROUP_PERMISSION_LEVELS = {"viewer", "editor"}
 router = APIRouter(prefix="/v1/calendar")
 
 
-def _validate_node_or_http(attrs: dict[str, Any], schema) -> str:
+def _add_node_or_http(
+    graph: IGraphAdapter,
+    node_id: str,
+    attrs: dict[str, Any],
+    schema,
+) -> dict[str, Any]:
     try:
-        return validate_node_attributes(attrs, schema=schema)
+        return add_node_with_schema_validation(graph, node_id, attrs, schema=schema)
     except ProcessingError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid node payload for '{node_id}': {exc}",
+        )
 
 
-def _validate_edge_or_http(label: str, attrs: dict[str, Any] | None, schema) -> str:
+def _add_edge_or_http(
+    graph: IGraphAdapter,
+    source_node_id: str,
+    target_node_id: str,
+    label: str,
+    attrs: dict[str, Any] | None,
+    schema,
+    schema_version: str | None = None,
+) -> str:
     try:
-        return validate_edge(label, attrs, schema_version=None, schema=schema)
+        return add_edge_with_schema_validation(
+            graph,
+            source_node_id,
+            target_node_id,
+            label,
+            attrs,
+            schema=schema,
+            schema_version=schema_version,
+        )
     except ProcessingError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid edge '{label}' from '{source_node_id}' to "
+                f"'{target_node_id}': {exc}"
+            ),
+        )
+
 
 
 def _ensure_user_node(graph: IGraphAdapter, user_id: str, schema) -> None:
@@ -54,8 +85,7 @@ def _ensure_user_node(graph: IGraphAdapter, user_id: str, schema) -> None:
         "created_at": int(user.created_at.timestamp()),
         "schema_version": schema.node_types["User"].version,
     }
-    _validate_node_or_http(attrs, schema)
-    graph.add_node(user.user_id, attrs)
+    _add_node_or_http(graph, user.user_id, attrs, schema)
 
 
 def _user_has_editor_access_to_layer(
@@ -151,8 +181,7 @@ def create_event(
         "visibility": event.visibility.value if event.visibility else None,
         "schema_version": schema.node_types["CalendarEvent"].version,
     }
-    _validate_node_or_http(attrs, schema)
-    graph.add_node(event.event_id, attrs)
+    attrs = _add_node_or_http(graph, event.event_id, attrs, schema)
     invitee_ids = req.invitee_ids or []
     layer_ids = req.layer_ids or []
     _ensure_user_node(graph, req.user_id, schema)
@@ -173,42 +202,41 @@ def create_event(
             if group_permission_level not in VALID_GROUP_PERMISSION_LEVELS:
                 raise HTTPException(status_code=400, detail="Invalid group_permission_level")
         with perm_graph.bootstrap_owner(event.event_id):
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 event.event_id,
                 req.user_id,
                 "OWNED_BY",
                 {"permission_level": "editor"},
-                schema_version=_validate_edge_or_http(
-                    "OWNED_BY", {"permission_level": "editor"}, schema
-                ),
+                schema,
             )
 
         if req.group_id:
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 event.event_id,
                 req.group_id,
                 "SHARED_WITH",
                 {"permission_level": group_permission_level},
-                schema_version=_validate_edge_or_http(
-                    "SHARED_WITH", {"permission_level": group_permission_level}, schema
-                ),
+                schema,
             )
 
         for uid in invitee_ids:
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 event.event_id,
                 uid,
                 "INVITES",
-                schema_version=_validate_edge_or_http("INVITES", {}, schema),
+                {},
+                schema,
             )
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 event.event_id,
                 uid,
                 "SHARED_WITH",
                 {"permission_level": "viewer"},
-                schema_version=_validate_edge_or_http(
-                    "SHARED_WITH", {"permission_level": "viewer"}, schema
-                ),
+                schema,
             )
 
 
@@ -218,11 +246,13 @@ def create_event(
                 raise HTTPException(status_code=400, detail=f"Invalid layer_id: {lid}")
             if not _user_has_editor_access_to_layer(graph, req.user_id, lid):
                 raise HTTPException(status_code=400, detail=f"Invalid layer_id: {lid}")
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 event.event_id,
                 lid,
                 "TAGGED_AS",
-                schema_version=_validate_edge_or_http("TAGGED_AS", {}, schema),
+                {},
+                schema,
             )
     except HTTPException:
         with suppress(ProcessingError):

--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -12,8 +12,8 @@ from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .processing import ProcessingError
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
-from .schema_validation import validate_edge, validate_node_attributes
-from .graph_schema import get_default_edge_version
+from .graph_mutations import add_edge_with_schema_validation, add_node_with_schema_validation
+from .schema_validation import validate_node_attributes
 from .utils import ensure_group_member
 from .models import (
     DecisionAnalysis,
@@ -26,9 +26,23 @@ from .models import (
 
 VALID_GROUP_PERMISSION_LEVELS = {"viewer", "editor"}
 
-EDGE_VERSION = get_default_edge_version("OWNED_BY")
 
 router = APIRouter(prefix="/v1/decisions")
+
+
+def _add_node_or_http(
+    graph: IGraphAdapter,
+    node_id: str,
+    attrs: dict[str, Any],
+    schema,
+) -> dict[str, Any]:
+    try:
+        return add_node_with_schema_validation(graph, node_id, attrs, schema=schema)
+    except ProcessingError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid node payload for '{node_id}': {exc}",
+        )
 
 
 def _validate_node_or_http(attrs: dict[str, Any], schema) -> str:
@@ -38,11 +52,34 @@ def _validate_node_or_http(attrs: dict[str, Any], schema) -> str:
         raise HTTPException(status_code=400, detail=str(exc))
 
 
-def _validate_edge_or_http(label: str, attrs: dict[str, Any] | None, schema) -> str:
+def _add_edge_or_http(
+    graph: IGraphAdapter,
+    source_node_id: str,
+    target_node_id: str,
+    label: str,
+    attrs: dict[str, Any] | None,
+    schema,
+    schema_version: str | None = None,
+) -> str:
     try:
-        return validate_edge(label, attrs, schema_version=None, schema=schema)
+        return add_edge_with_schema_validation(
+            graph,
+            source_node_id,
+            target_node_id,
+            label,
+            attrs,
+            schema=schema,
+            schema_version=schema_version,
+        )
     except ProcessingError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid edge '{label}' from '{source_node_id}' to "
+                f"'{target_node_id}': {exc}"
+            ),
+        )
+
 
 
 class DecisionCreateRequest(BaseModel):
@@ -100,8 +137,7 @@ def _ensure_user_node(graph: IGraphAdapter, user_id: str, schema) -> None:
     defaults = _user_node_defaults(user_id, schema)
     attrs = graph.get_node(user_id)
     if attrs is None:
-        _validate_node_or_http(defaults, schema)
-        graph.add_node(user_id, defaults)
+        _add_node_or_http(graph, user_id, defaults, schema)
         return
     update_attrs: dict[str, Any] = {}
     if attrs.get("type") != "User":
@@ -131,8 +167,7 @@ def _ensure_group_node(graph: IGraphAdapter, group_id: str, schema) -> None:
     defaults = _group_node_defaults(group_id, schema)
     attrs = graph.get_node(group_id)
     if attrs is None:
-        _validate_node_or_http(defaults, schema)
-        graph.add_node(group_id, defaults)
+        _add_node_or_http(graph, group_id, defaults, schema)
         return
     update_attrs: dict[str, Any] = {}
     if attrs.get("type") != "UserGroup":
@@ -169,30 +204,27 @@ def create_decision(
     try:
         analysis = create_decision_analysis(req.query)
         attrs = _analysis_to_dict(analysis, schema)
-        _validate_node_or_http(attrs, schema)
-        perm_graph.add_node(analysis.analysis_id, attrs)
+        attrs = _add_node_or_http(perm_graph, analysis.analysis_id, attrs, schema)
         # Ensure subject nodes exist
         _ensure_user_node(graph, req.user_id, schema)
         # Link analysis to the owning user
         with perm_graph.bootstrap_owner(analysis.analysis_id):
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 analysis.analysis_id,
                 req.user_id,
                 "OWNED_BY",
                 {"permission_level": "editor"},
-                schema_version=_validate_edge_or_http(
-                    "OWNED_BY", {"permission_level": "editor"}, schema
-                ),
+                schema,
             )
         if req.group_id:
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 analysis.analysis_id,
                 req.group_id,
                 "SHARED_WITH",
                 {"permission_level": group_permission_level},
-                schema_version=_validate_edge_or_http(
-                    "SHARED_WITH", {"permission_level": group_permission_level}, schema
-                ),
+                schema,
             )
     except AccessDeniedError as exc:
         status = 400 if "bootstrapped" in str(exc) else 403
@@ -230,42 +262,41 @@ def add_action(
             outcome_metrics=req.outcome_metrics or {},
         )
         action_attrs = _action_to_dict(action, schema)
-        _validate_node_or_http(action_attrs, schema)
-        perm_graph.add_node(action.action_id, action_attrs)
+        action_attrs = _add_node_or_http(perm_graph, action.action_id, action_attrs, schema)
         created_action = True
         # Ensure subject nodes exist
         _ensure_user_node(graph, req.user_id, schema)
         # Link action to the owning user
         with perm_graph.bootstrap_owner(action.action_id):
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 action.action_id,
                 req.user_id,
                 "OWNED_BY",
                 {"permission_level": "editor"},
-                schema_version=_validate_edge_or_http(
-                    "OWNED_BY", {"permission_level": "editor"}, schema
-                ),
+                schema,
             )
         perm_graph.rebuild_index()
         if req.group_id:
             try:
-                perm_graph.add_edge(
+                _add_edge_or_http(
+                    perm_graph,
                     action.action_id,
                     req.group_id,
                     "SHARED_WITH",
                     {"permission_level": group_permission_level},
-                    schema_version=_validate_edge_or_http(
-                        "SHARED_WITH", {"permission_level": group_permission_level}, schema
-                    ),
+                    schema,
                 )
             except AccessDeniedError as exc:
                 raise AccessDeniedError("Editor permission required for target group") from exc
         perm_graph.rebuild_index()
-        perm_graph.add_edge(
+        _add_edge_or_http(
+            perm_graph,
             analysis_id,
             action.action_id,
             "CONSIDERS",
-            schema_version=_validate_edge_or_http("CONSIDERS", {}, schema),
+            {},
+            schema,
         )
     except AccessDeniedError as exc:
         if created_action:

--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -10,7 +10,7 @@ from .graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
-from .schema_validation import validate_edge, validate_node_attributes
+from .graph_mutations import add_edge_with_schema_validation, add_node_with_schema_validation
 from .models import create_financial_account, create_user
 from .processing import ProcessingError
 from .utils import ensure_group_member
@@ -18,18 +18,48 @@ from .utils import ensure_group_member
 router = APIRouter(prefix="/v1/accounts")
 
 
-def _validate_node_or_http(attrs: dict[str, Any], schema) -> str:
+def _add_node_or_http(
+    graph: IGraphAdapter,
+    node_id: str,
+    attrs: dict[str, Any],
+    schema,
+) -> dict[str, Any]:
     try:
-        return validate_node_attributes(attrs, schema=schema)
+        return add_node_with_schema_validation(graph, node_id, attrs, schema=schema)
     except ProcessingError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid node payload for '{node_id}': {exc}",
+        )
 
 
-def _validate_edge_or_http(label: str, attrs: dict[str, Any] | None, schema) -> str:
+def _add_edge_or_http(
+    graph: IGraphAdapter,
+    source_node_id: str,
+    target_node_id: str,
+    label: str,
+    attrs: dict[str, Any] | None,
+    schema,
+    schema_version: str | None = None,
+) -> str:
     try:
-        return validate_edge(label, attrs, schema_version=None, schema=schema)
+        return add_edge_with_schema_validation(
+            graph,
+            source_node_id,
+            target_node_id,
+            label,
+            attrs,
+            schema=schema,
+            schema_version=schema_version,
+        )
     except ProcessingError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid edge '{label}' from '{source_node_id}' to "
+                f"'{target_node_id}': {exc}"
+            ),
+        )
 
 
 class FinancialAccountCreateRequest(BaseModel):
@@ -67,8 +97,7 @@ def create_account(
             "created_at": int(user.created_at.timestamp()),
             "schema_version": schema.node_types["User"].version,
         }
-        _validate_node_or_http(user_attrs, schema)
-        graph.add_node(user.user_id, user_attrs)
+        _add_node_or_http(graph, user.user_id, user_attrs, schema)
     if req.group_id:
         group_attrs = graph.get_node(req.group_id)
         if group_attrs is None or group_attrs.get("type") != "UserGroup":
@@ -89,29 +118,26 @@ def create_account(
         "currency": account.currency,
         "schema_version": schema.node_types["FinancialAccount"].version,
     }
-    _validate_node_or_http(attrs, schema)
-    graph.add_node(account.account_id, attrs)
+    attrs = _add_node_or_http(graph, account.account_id, attrs, schema)
     perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
     try:
         with perm_graph.bootstrap_owner(account.account_id):
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 account.account_id,
                 req.user_id,
                 "OWNED_BY",
                 {"permission_level": "editor"},
-                schema_version=_validate_edge_or_http(
-                    "OWNED_BY", {"permission_level": "editor"}, schema
-                ),
+                schema,
             )
         if req.group_id:
-            perm_graph.add_edge(
+            _add_edge_or_http(
+                perm_graph,
                 account.account_id,
                 req.group_id,
                 "SHARED_WITH",
                 {"permission_level": "viewer"},
-                schema_version=_validate_edge_or_http(
-                    "SHARED_WITH", {"permission_level": "viewer"}, schema
-                ),
+                schema,
             )
     except AccessDeniedError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/src/ume/graph_mutations.py
+++ b/src/ume/graph_mutations.py
@@ -1,0 +1,64 @@
+"""Schema-aware helpers for graph creation operations."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .graph_adapter import IGraphAdapter
+from .graph_schema import DEFAULT_SCHEMA, GraphSchema
+from .processing import ProcessingError
+from .schema_validation import validate_edge, validate_node_attributes
+
+
+def add_node_with_schema_validation(
+    graph: IGraphAdapter,
+    node_id: str,
+    attrs: Mapping[str, Any],
+    *,
+    schema: GraphSchema | None = None,
+) -> dict[str, Any]:
+    """Validate a node payload and add it with the matching schema version."""
+
+    node_attrs = dict(attrs)
+    expected_version = validate_node_attributes(node_attrs, schema=schema or DEFAULT_SCHEMA)
+    node_attrs["schema_version"] = expected_version
+    graph.add_node(node_id, node_attrs)
+    return node_attrs
+
+
+def add_edge_with_schema_validation(
+    graph: IGraphAdapter,
+    source_node_id: str,
+    target_node_id: str,
+    label: str,
+    attrs: Mapping[str, Any] | None = None,
+    *,
+    schema: GraphSchema | None = None,
+    schema_version: str | None = None,
+) -> str:
+    """Validate an edge payload and add it with the matching schema version."""
+
+    edge_attrs = dict(attrs) if attrs is not None else None
+    expected_version = validate_edge(
+        label,
+        edge_attrs,
+        schema_version=schema_version,
+        schema=schema or DEFAULT_SCHEMA,
+    )
+    if schema_version is not None and schema_version != expected_version:
+        raise ProcessingError(
+            "schema_version does not match the active schema for edge label "
+            f"'{label}' (expected '{expected_version}')"
+        )
+    graph.add_edge(
+        source_node_id,
+        target_node_id,
+        label,
+        edge_attrs,
+        schema_version=expected_version,
+    )
+    return expected_version
+
+
+__all__ = ["add_edge_with_schema_validation", "add_node_with_schema_validation"]
+

--- a/src/ume/users_routes.py
+++ b/src/ume/users_routes.py
@@ -12,23 +12,54 @@ from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .processing import ProcessingError
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
-from .schema_validation import validate_edge, validate_node_attributes
+from .graph_mutations import add_edge_with_schema_validation, add_node_with_schema_validation
 from .utils import ensure_group_member
 
 router = APIRouter(prefix="/v1")
 
-def _validate_node_or_http(attrs: dict[str, Any], schema) -> str:
+
+def _add_node_or_http(
+    graph: IGraphAdapter,
+    node_id: str,
+    attrs: dict[str, Any],
+    schema,
+) -> dict[str, Any]:
     try:
-        return validate_node_attributes(attrs, schema=schema)
+        return add_node_with_schema_validation(graph, node_id, attrs, schema=schema)
     except ProcessingError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid node payload for '{node_id}': {exc}",
+        )
 
 
-def _validate_edge_or_http(label: str, attrs: dict[str, Any] | None, schema) -> str:
+def _add_edge_or_http(
+    graph: IGraphAdapter,
+    source_node_id: str,
+    target_node_id: str,
+    label: str,
+    attrs: dict[str, Any] | None,
+    schema,
+    schema_version: str | None = None,
+) -> str:
     try:
-        return validate_edge(label, attrs, schema_version=None, schema=schema)
+        return add_edge_with_schema_validation(
+            graph,
+            source_node_id,
+            target_node_id,
+            label,
+            attrs,
+            schema=schema,
+            schema_version=schema_version,
+        )
     except ProcessingError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid edge '{label}' from '{source_node_id}' to "
+                f"'{target_node_id}': {exc}"
+            ),
+        )
 
 
 class UserCreateRequest(BaseModel):
@@ -82,8 +113,7 @@ def create_user_node(
         "created_at": int(user.created_at.timestamp()),
         "schema_version": schema.node_types["User"].version,
     }
-    _validate_node_or_http(attrs, schema)
-    graph.add_node(user.user_id, attrs)
+    attrs = _add_node_or_http(graph, user.user_id, attrs, schema)
     return UserResponse(
         id=user.user_id,
         name=user.name,
@@ -107,20 +137,18 @@ def create_user_group_node(
         "members": group.members,
         "schema_version": schema.node_types["UserGroup"].version,
     }
-    _validate_node_or_http(attrs, schema)
-    graph.add_node(group.group_id, attrs)
+    attrs = _add_node_or_http(graph, group.group_id, attrs, schema)
     if req.user_id:
         perm_graph = PermissionsGraphAdapter(graph, user_id=req.user_id)
         try:
             with perm_graph.bootstrap_owner(group.group_id):
-                perm_graph.add_edge(
+                _add_edge_or_http(
+                    perm_graph,
                     group.group_id,
                     req.user_id,
                     "OWNED_BY",
                     {"permission_level": "editor"},
-                    schema_version=_validate_edge_or_http(
-                        "OWNED_BY", {"permission_level": "editor"}, schema
-                    ),
+                    schema,
                 )
         except AccessDeniedError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -144,14 +172,13 @@ def create_owned_by_edge(
         perm_graph = PermissionsGraphAdapter(graph, group_id=req.owner_id)
     else:
         perm_graph = PermissionsGraphAdapter(graph, user_id=req.owner_id)
-    perm_graph.add_edge(
+    _add_edge_or_http(
+        perm_graph,
         req.node_id,
         req.owner_id,
         "OWNED_BY",
         {"permission_level": req.permission_level},
-        schema_version=_validate_edge_or_http(
-            "OWNED_BY", {"permission_level": req.permission_level}, schema
-        ),
+        schema,
     )
     return {"status": "ok"}
 

--- a/tests/test_graph_mutations.py
+++ b/tests/test_graph_mutations.py
@@ -1,0 +1,80 @@
+from ume.graph_mutations import add_edge_with_schema_validation, add_node_with_schema_validation
+from ume.graph_schema import EdgeLabel, GraphSchema, NodeType, Property
+from ume.processing import ProcessingError
+
+
+class StubGraph:
+    def __init__(self) -> None:
+        self.nodes = {}
+        self.edges = []
+
+    def add_node(self, node_id, attrs):
+        self.nodes[node_id] = attrs
+
+    def add_edge(self, src, tgt, label, attrs=None, schema_version=None):
+        self.edges.append((src, tgt, label, attrs, schema_version))
+
+
+def _schema() -> GraphSchema:
+    return GraphSchema(
+        version="9.0.0",
+        node_types={
+            "User": NodeType(
+                name="User",
+                version="9.1.0",
+                properties={
+                    "type": Property(name="type", version="9.1.0"),
+                    "user_id": Property(name="user_id", version="9.1.0"),
+                },
+            )
+        },
+        edge_labels={
+            "OWNED_BY": EdgeLabel(label="OWNED_BY", version="9.2.0")
+        },
+    )
+
+
+def test_add_node_with_schema_validation_applies_expected_version():
+    graph = StubGraph()
+    attrs = add_node_with_schema_validation(
+        graph,
+        "u1",
+        {"type": "User", "user_id": "u1"},
+        schema=_schema(),
+    )
+
+    assert attrs["schema_version"] == "9.1.0"
+    assert graph.nodes["u1"]["schema_version"] == "9.1.0"
+
+
+def test_add_edge_with_schema_validation_applies_expected_version():
+    graph = StubGraph()
+    version = add_edge_with_schema_validation(
+        graph,
+        "n1",
+        "n2",
+        "OWNED_BY",
+        {"permission_level": "editor"},
+        schema=_schema(),
+    )
+
+    assert version == "9.2.0"
+    assert graph.edges[0][4] == "9.2.0"
+
+
+def test_add_edge_with_schema_validation_rejects_wrong_version():
+    graph = StubGraph()
+    try:
+        add_edge_with_schema_validation(
+            graph,
+            "n1",
+            "n2",
+            "OWNED_BY",
+            None,
+            schema=_schema(),
+            schema_version="1.0.0",
+        )
+    except ProcessingError as exc:
+        assert "schema_version does not match" in str(exc)
+    else:
+        raise AssertionError("Expected ProcessingError")


### PR DESCRIPTION
### Motivation
- Centralize schema preflight validation for node and edge creation to ensure routes attach the correct `schema_version` and return meaningful HTTP 400 errors when payloads do not match the active graph schema.
- Make migrations safer by enforcing label/version and required-property checks at creation time so downstream adapters and migrations can rely on explicit schema metadata.

### Description
- Added a new utility `src/ume/graph_mutations.py` providing `add_node_with_schema_validation` and `add_edge_with_schema_validation` which validate payloads via `validate_node_attributes` / `validate_edge` and then call the adapter with the canonical `schema_version`.
- Updated route creation flows to use HTTP-friendly wrappers that surface validation failures as `HTTP 400` responses and return or attach the authoritative `schema_version`; modified files: `src/ume/users_routes.py`, `src/ume/financial_account_routes.py`, `src/ume/decisions_routes.py`, and `src/ume/calendar_routes.py`.
- Replaced ad-hoc validation usages in the above routes with `_add_node_or_http` / `_add_edge_or_http` helpers that call the new mutation utilities and format contextual error messages including node id / edge endpoints / label.
- Added focused unit tests `tests/test_graph_mutations.py` to assert schema version propagation and rejection of mismatched edge schema versions.

### Testing
- Ran linter checks with `ruff` on the changed files which completed successfully.
- Ran the new unit tests with `pytest -q tests/test_graph_mutations.py` which passed (`3 passed`).
- Attempted to run route-focused tests (`tests/test_users_routes.py`, `tests/test_financial_account_routes.py`, `tests/test_decisions_routes.py`, `tests/test_calendar_event_validation.py`, `tests/test_calendar_invites.py`), but test collection failed in this runtime due to missing `fastapi.testclient` (environment dependency issue); collection did not proceed to route assertions.
- Observed existing schema-related test suites (`tests/test_schema_manager.py`, `tests/test_graph_schema.py`) failing in this runtime, which appears unrelated to the mutation helpers and likely due to the baseline test environment or dependency constraints; these failures were not caused by the new mutation utilities as the focused mutation tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986320441ec83269ccb30ed58b2359c)