### PR TITLE
Canonicalize node_id handling for node events and align parser + projector

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Used to create a new directed, labeled edge between two existing nodes.
   "eventType": "RESEARCH_JOB_STARTED",
   "timestamp": "2024-03-15T12:10:00Z",
   "node_id": "job_123",
-  "payload": {"status": "running"}
+  "payload": {"attributes": {"status": "running"}}
 }
 ```
 
@@ -182,7 +182,7 @@ Used to create a new directed, labeled edge between two existing nodes.
   "eventType": "DOCUMENT_ARCHIVED",
   "timestamp": "2024-03-15T12:13:00Z",
   "node_id": "doc_1",
-  "payload": {"archived_by": "agent_42"}
+  "payload": {"attributes": {"archived_by": "agent_42", "archived": true}}
 }
 ```
 
@@ -657,7 +657,7 @@ body must follow the schema expected by `ume.parse_event`.
 curl -X POST http://localhost:8000/events \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -d '{"event_type": "CREATE_NODE", "timestamp": "2024-01-01T00:00:00Z", "node_id": "n1", "payload": {"node_id": "n1", "attributes": {"name": "demo"}}}'
+  -d '{"event_type": "CREATE_NODE", "timestamp": "2024-01-01T00:00:00Z", "node_id": "n1", "payload": {"attributes": {"name": "demo"}}}'
 ```
 
 The event is validated and immediately applied to the configured graph adapter.

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -199,7 +199,20 @@ def parse_event(data: Dict[str, Any]) -> Event:
         EventType.RESEARCH_JOB_STARTED,
         EventType.DOCUMENT_ARCHIVED,
     ]:
-        if "node_id" not in data:  # Must be present in data
+        if "payload" not in data:  # Must be present in data for these types
+            msg = f"Missing required field 'payload' for {event_type_str} event."
+            logger.error(msg)
+            raise EventError(msg)
+        if not isinstance(payload_val, dict):
+            msg = f"Invalid type for 'payload' in {event_type_str} event: expected dict, got {type(payload_val).__name__}"
+            logger.error(msg)
+            raise EventError(msg)
+
+        payload_node_id = payload_val.get("node_id")
+        if node_id_val is None and payload_node_id is not None:
+            node_id_val = payload_node_id
+
+        if node_id_val is None:
             msg = f"Missing required field 'node_id' for {event_type_str} event."
             logger.error(msg)
             raise EventError(msg)
@@ -207,17 +220,34 @@ def parse_event(data: Dict[str, Any]) -> Event:
             msg = f"Invalid type for 'node_id' in {event_type_str} event: expected str, got {type(node_id_val).__name__}"
             logger.error(msg)
             raise EventError(msg)
+        if payload_node_id is not None and not isinstance(payload_node_id, str):
+            msg = f"Invalid type for 'payload.node_id' in {event_type_str} event: expected str, got {type(payload_node_id).__name__}"
+            logger.error(msg)
+            raise EventError(msg)
+        if payload_node_id is not None and payload_node_id != node_id_val:
+            msg = (
+                f"Conflicting node_id values for {event_type_str} event: "
+                "'node_id' and 'payload.node_id' must match"
+            )
+            logger.error(msg)
+            raise EventError(msg)
 
-        if "payload" not in data:  # Must be present in data for these types
-            msg = f"Missing required field 'payload' for {event_type_str} event."
-            logger.error(msg)
-            raise EventError(msg)
-        # Ensure payload_val (which could be the default {} if "payload" key was missing,
-        # or the actual value if present) is a dict for these event types.
-        if not isinstance(payload_val, dict):
-            msg = f"Invalid type for 'payload' in {event_type_str} event: expected dict, got {type(payload_val).__name__}"
-            logger.error(msg)
-            raise EventError(msg)
+        if event_type in [EventType.UPDATE_NODE_ATTRIBUTES, EventType.DOCUMENT_ARCHIVED]:
+            if "attributes" not in payload_val:
+                msg = (
+                    "Missing required field 'payload.attributes' "
+                    f"for {event_type_str} event."
+                )
+                logger.error(msg)
+                raise EventError(msg)
+            if not isinstance(payload_val["attributes"], dict):
+                msg = (
+                    "Invalid type for 'payload.attributes' in "
+                    f"{event_type_str} event: expected dict, got "
+                    f"{type(payload_val['attributes']).__name__}"
+                )
+                logger.error(msg)
+                raise EventError(msg)
 
     elif event_type in [
         EventType.CREATE_EDGE,

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -68,10 +68,10 @@ def apply_event_to_graph(
     for plugin in get_plugins():
         plugin.validate(event)
     if event.event_type in (EventType.CREATE_NODE, EventType.RESEARCH_JOB_STARTED):
-        node_id = event.payload.get("node_id")
+        node_id = event.node_id
         if not node_id:
             raise ProcessingError(
-                f"Missing 'node_id' in payload for CREATE_NODE event: {event.event_id}"
+                f"Missing 'node_id' in event for CREATE_NODE event: {event.event_id}"
             )
         if not isinstance(node_id, str):
             raise ProcessingError(
@@ -100,10 +100,10 @@ def apply_event_to_graph(
             listener.on_node_created(node_id, attributes)
 
     elif event.event_type in (EventType.UPDATE_NODE_ATTRIBUTES, EventType.DOCUMENT_ARCHIVED):
-        node_id = event.payload.get("node_id")
+        node_id = event.node_id
         if not node_id:
             raise ProcessingError(
-                f"Missing 'node_id' in payload for UPDATE_NODE_ATTRIBUTES event: {event.event_id}"
+                f"Missing 'node_id' in event for UPDATE_NODE_ATTRIBUTES event: {event.event_id}"
             )
         if not isinstance(node_id, str):
             raise ProcessingError(

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -181,6 +181,54 @@ def test_parse_event_document_archived() -> None:
     assert event.payload == {"node_id": "doc1", "attributes": {"archived": True}}
 
 
+@pytest.mark.parametrize("event_type", [
+    EventType.CREATE_NODE,
+    EventType.UPDATE_NODE_ATTRIBUTES,
+    EventType.RESEARCH_JOB_STARTED,
+    EventType.DOCUMENT_ARCHIVED,
+])
+def test_parse_event_node_id_top_level_canonical_shape(event_type: EventType) -> None:
+    ts = datetime.now(timezone.utc)
+    payload = {"attributes": {"name": "n"}}
+    data = {
+        "eventType": event_type.value,
+        "timestamp": ts.isoformat(),
+        "node_id": "n1",
+        "payload": payload,
+    }
+    event = parse_event(data)
+    assert event.node_id == "n1"
+
+
+@pytest.mark.parametrize("event_type", [
+    EventType.CREATE_NODE,
+    EventType.UPDATE_NODE_ATTRIBUTES,
+    EventType.RESEARCH_JOB_STARTED,
+    EventType.DOCUMENT_ARCHIVED,
+])
+def test_parse_event_node_id_payload_backward_compat(event_type: EventType) -> None:
+    ts = datetime.now(timezone.utc)
+    data = {
+        "eventType": event_type.value,
+        "timestamp": ts.isoformat(),
+        "payload": {"node_id": "legacy1", "attributes": {"name": "legacy"}},
+    }
+    event = parse_event(data)
+    assert event.node_id == "legacy1"
+
+
+def test_parse_event_node_id_conflict_rejected() -> None:
+    ts = datetime.now(timezone.utc)
+    data = {
+        "eventType": EventType.CREATE_NODE.value,
+        "timestamp": ts.isoformat(),
+        "node_id": "n1",
+        "payload": {"node_id": "n2", "attributes": {}},
+    }
+    with pytest.raises(EventError, match="Conflicting node_id values"):
+        parse_event(data)
+
+
 # The following tests are now covered by test_parse_event_invalid_inputs:
 # - test_parse_event_missing_required_field
 # - test_parse_event_missing_multiple_required_fields
@@ -205,6 +253,15 @@ def test_parse_event_document_archived() -> None:
         (
             {"eventType": "CREATE_NODE", "timestamp": ISO_TS, "node_id": "n1"},
             "Missing required field 'payload' for CREATE_NODE event.",
+        ),
+        # Case 4b: Missing node_id for node event
+        (
+            {
+                "eventType": "RESEARCH_JOB_STARTED",
+                "timestamp": ISO_TS,
+                "payload": {"attributes": {}},
+            },
+            "Missing required field 'node_id' for RESEARCH_JOB_STARTED event.",
         ),
         # Case 5: Invalid type for 'eventType' (int instead of str)
         (
@@ -394,6 +451,24 @@ def test_parse_event_document_archived() -> None:
                 "node_id": "n1",
             },
             "Missing required field 'payload' for UPDATE_NODE_ATTRIBUTES event",
+        ),
+        (
+            {
+                "eventType": "UPDATE_NODE_ATTRIBUTES",
+                "timestamp": ISO_TS,
+                "node_id": "n1",
+                "payload": {},
+            },
+            "Missing required field 'payload.attributes' for UPDATE_NODE_ATTRIBUTES event",
+        ),
+        (
+            {
+                "eventType": "DOCUMENT_ARCHIVED",
+                "timestamp": ISO_TS,
+                "node_id": "doc1",
+                "payload": {},
+            },
+            "Missing required field 'payload.attributes' for DOCUMENT_ARCHIVED event",
         ),
         # event_id present but wrong type
         (

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -9,6 +9,7 @@ from ume import (
     PersistentGraph,
     apply_event_to_graph,
     ProcessingError,
+    parse_event,
 )
 
 
@@ -27,6 +28,7 @@ def test_apply_create_node_event_success(graph: PersistentGraph):
         event_id=event_id,
         event_type=EventType.CREATE_NODE,
         timestamp=int(time.time()),
+        node_id=node_id,
         payload={"node_id": node_id, "attributes": attributes},
     )
     apply_event_to_graph(event, graph)
@@ -42,6 +44,7 @@ def test_create_node_adds_tokens_from_text(graph: PersistentGraph) -> None:
     event = Event(
         event_type=EventType.CREATE_NODE,
         timestamp=int(time.time()),
+        node_id=node_id,
         payload={"node_id": node_id, "attributes": {"text": "Alpha Beta"}},
     )
     apply_event_to_graph(event, graph)
@@ -57,6 +60,7 @@ def test_apply_create_node_event_no_attributes(graph: PersistentGraph):
     event = Event(
         event_type=EventType.CREATE_NODE,
         timestamp=int(time.time()),
+        node_id=node_id,
         payload={"node_id": node_id},  # Attributes are optional in payload for create
     )
     apply_event_to_graph(event, graph)
@@ -71,6 +75,7 @@ def test_apply_create_node_event_already_exists(graph: PersistentGraph):
     event = Event(
         event_type=EventType.CREATE_NODE,
         timestamp=int(time.time()),
+        node_id=node_id,
         payload={
             "node_id": node_id,
             "attributes": {"name": "New Node", "type": "User"},
@@ -88,7 +93,7 @@ def test_apply_create_node_missing_node_id(graph: PersistentGraph):
         payload={"attributes": {"name": "Test Node"}},
     )
     with pytest.raises(
-        ProcessingError, match="Missing 'node_id' in payload for CREATE_NODE event"
+        ProcessingError, match="Missing 'node_id' in event for CREATE_NODE event"
     ):
         apply_event_to_graph(event, graph)
 
@@ -98,6 +103,7 @@ def test_apply_create_node_invalid_node_id_type(graph: PersistentGraph):
     event = Event(
         event_type=EventType.CREATE_NODE,
         timestamp=int(time.time()),
+        node_id=123,  # type: ignore[arg-type]
         payload={"node_id": 123, "attributes": {"name": "Test Node"}},  # node_id is int
     )
     with pytest.raises(
@@ -117,6 +123,7 @@ def test_apply_update_node_attributes_success(graph: PersistentGraph):
     event = Event(
         event_type=EventType.UPDATE_NODE_ATTRIBUTES,
         timestamp=int(time.time()),
+        node_id=node_id,
         payload={"node_id": node_id, "attributes": updated_attrs},
     )
     apply_event_to_graph(event, graph)
@@ -130,6 +137,7 @@ def test_update_node_adds_tokens(graph: PersistentGraph) -> None:
     event = Event(
         event_type=EventType.UPDATE_NODE_ATTRIBUTES,
         timestamp=int(time.time()),
+        node_id=node_id,
         payload={"node_id": node_id, "attributes": {"content": "Hello world"}},
     )
     apply_event_to_graph(event, graph)
@@ -142,6 +150,7 @@ def test_apply_update_node_attributes_node_not_exists(graph: PersistentGraph):
     event = Event(
         event_type=EventType.UPDATE_NODE_ATTRIBUTES,
         timestamp=int(time.time()),
+        node_id=node_id,
         payload={"node_id": node_id, "attributes": {"name": "Updated Name"}},
     )
     with pytest.raises(
@@ -159,7 +168,7 @@ def test_apply_update_node_attributes_missing_node_id(graph: PersistentGraph):
     )
     with pytest.raises(
         ProcessingError,
-        match="Missing 'node_id' in payload for UPDATE_NODE_ATTRIBUTES event",
+        match="Missing 'node_id' in event for UPDATE_NODE_ATTRIBUTES event",
     ):
         apply_event_to_graph(event, graph)
 
@@ -227,6 +236,7 @@ def test_apply_update_node_attributes_invalid_attributes_payload(
     event = Event(
         event_type=EventType.UPDATE_NODE_ATTRIBUTES,
         timestamp=int(time.time()),
+        node_id=event_payload.get("node_id"),
         payload=event_payload,
     )
 
@@ -489,6 +499,7 @@ def test_apply_research_job_started_creates_node(graph: PersistentGraph) -> None
     event = Event(
         event_type=EventType.RESEARCH_JOB_STARTED,
         timestamp=int(time.time()),
+        node_id="job1",
         payload={"node_id": "job1", "attributes": {"status": "started"}},
     )
     apply_event_to_graph(event, graph)
@@ -548,7 +559,33 @@ def test_apply_document_archived_updates_node(graph: PersistentGraph) -> None:
     event = Event(
         event_type=EventType.DOCUMENT_ARCHIVED,
         timestamp=int(time.time()),
+        node_id="doc1",
         payload={"node_id": "doc1", "attributes": {}},
     )
     apply_event_to_graph(event, graph)
     assert graph.get_node("doc1") == {"title": "D", "archived": True}
+
+
+def test_apply_create_node_parsed_backward_compat_payload_node_id(graph: PersistentGraph) -> None:
+    event = parse_event(
+        {
+            "eventType": EventType.CREATE_NODE.value,
+            "timestamp": int(time.time()),
+            "payload": {"node_id": "legacy-node", "attributes": {"name": "Legacy"}},
+        }
+    )
+    apply_event_to_graph(event, graph)
+    assert graph.node_exists("legacy-node")
+
+
+def test_apply_create_node_prefers_top_level_node_id(graph: PersistentGraph) -> None:
+    event = parse_event(
+        {
+            "eventType": EventType.CREATE_NODE.value,
+            "timestamp": int(time.time()),
+            "node_id": "node-top",
+            "payload": {"node_id": "node-top", "attributes": {"name": "Top"}},
+        }
+    )
+    apply_event_to_graph(event, graph)
+    assert graph.node_exists("node-top")


### PR DESCRIPTION
### Motivation

- Ensure a single canonical location for node identifiers in node events (top-level `node_id`) so parsing, validation, and graph projection behave consistently.
- Preserve backward compatibility for older producers that send `payload.node_id` while rejecting ambiguous/conflicting messages.
- Tighten validation so node-related events have exactly the fields the projection expects (avoiding runtime surprises).

### Description

- Updated `parse_event()` to require `payload` be a `dict` for node events, to prefer a top-level `node_id`, accept `payload.node_id` when the top-level key is absent, and to reject conflicting `node_id` vs `payload.node_id` values; added explicit checks that `payload.attributes` exists and is a `dict` for `UPDATE_NODE_ATTRIBUTES` and `DOCUMENT_ARCHIVED` events.
- Modified `apply_event_to_graph()` to consume `event.node_id` for `CREATE_NODE`, `UPDATE_NODE_ATTRIBUTES`, `RESEARCH_JOB_STARTED`, and `DOCUMENT_ARCHIVED` so runtime projection uses the same canonical field normalized by the parser and updated error messages accordingly.
- Added and adjusted tests in `tests/test_event.py` and `tests/test_processing.py` to cover: canonical top‑level `node_id` shape, legacy `payload.node_id` backward compatibility, missing `node_id` validation, and conflict rejection; updated several existing processing tests to construct `Event(...)` with `node_id` to reflect the canonical shape.
- Updated producer-facing examples in `README.md` so examples place node attributes under `payload.attributes` and demonstrate the canonical top-level `node_id` usage.

### Testing

- Ran unit tests with `pytest -q tests/test_event.py tests/test_processing.py` which completed successfully with all tests passing (`84 passed`).
- Ran the linter with `ruff` on modified files (`src/ume/event.py src/ume/processing.py tests/test_event.py tests/test_processing.py`) and received no issues (`All checks passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e42111c08326b8b6243ce51f1aa4)