### PR TITLE
Clarify policy contract: Rego/OPA evaluates event payload only

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,11 @@ evaluates them using the built-in `RegoPolicyEngine`. Policies should define
 `allow` rules under the `ume` package. Events are rejected when the query
 `data.ume.allow` does not evaluate to `true` for the event input.
 
+`RegoPolicyEngine` passes only the incoming event payload object to OPA/Rego.
+Policies should therefore reference fields under `input` exactly as they appear
+in `event.payload` (for example `input.node_id` or `input.attributes.role`).
+Graph state/snapshots are **not** included in policy input.
+
 ## Quickstart
 
 ![Recall p95](https://img.shields.io/badge/Recall%20p95-0.41ms-brightgreen)

--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -121,7 +121,10 @@ Consent records are stored in a lightweight SQLite ledger located at
 When processing events the privacy agent looks for `user_id` and `scope` fields
 in the event payload. If no matching consent entry is found, the sanitized event
 is published to the quarantine topic instead of the clean events topic. Rego
-policies can reference this status via the `input.consent` value.
+policies can reference this status via the `input.consent` value. UME sends
+only `event.payload` to policy evaluation as Rego/OPA `input`, so policies should
+read fields directly from the payload shape and should not expect graph snapshots
+or graph-context fields unless producers include them in the event payload.
 
 Consent can be granted or revoked programmatically using the
 `ConsentLedger` class from `ume.consent_ledger`.

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -36,6 +36,11 @@ compared to CPU search (see [Vector Store Benchmark](VECTOR_BENCHMARKS.md)).
 The projection engine runs continuously as a consumer of `ume-clean-events`.
 Each event is parsed and applied to the graph through an adapter instance created by `create_graph_adapter()`, keeping the persistent graph and vector store in sync with the event log.
 
+Before `apply_event_to_graph()` mutates graph state, alignment plugins run policy checks.
+For Rego/OPA integration, the policy input contract is **event-only**: UME sends
+`event.payload` as `input`. No serialized graph snapshot or contextual graph data
+is attached to policy evaluation.
+
 ## Component Interactions
 
 The API interfaces with the graph adapter layer and the vector store to answer


### PR DESCRIPTION
### Motivation
- Establish a clear, single intended policy input contract: policy evaluation is `event`-only (no graph snapshot or contextual graph state). 
- Align public documentation with the implemented `RegoPolicyEngine` behavior so policy authors know what input shape to expect.

### Description
- Updated `README.md` to state that `RegoPolicyEngine` passes only `event.payload` as OPA/Rego `input` and to show example field access like `input.node_id` and `input.attributes.role`.
- Updated `docs/ARCHITECTURE_OVERVIEW.md` to clarify alignment plugins run before `apply_event_to_graph()` mutates state and that policy evaluation does not include serialized graph context.
- Updated `docs/ACCESS_CONTROL.md` to note `input.consent` and other policy-accessible fields come from the event payload and that policies should not expect graph snapshots or graph-context fields unless producers include them in the payload.

### Testing
- No automated tests or linters were executed because this change is documentation-only and does not modify runtime code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989e6b01f688326a5d70c2644db1100)