### PR TITLE
Use event.node_id for async node create/update events

### DIFF
--- a/src/ume/async_graph_adapter.py
+++ b/src/ume/async_graph_adapter.py
@@ -164,7 +164,7 @@ async def apply_event_to_async_graph(
         plugin.validate(event)
 
     if event.event_type == EventType.CREATE_NODE:
-        node_id = event.payload.get("node_id")
+        node_id = event.node_id
         if not node_id or not isinstance(node_id, str):
             raise ProcessingError("Invalid node_id for CREATE_NODE")
         attributes = event.payload.get("attributes", {})
@@ -178,7 +178,7 @@ async def apply_event_to_async_graph(
         for listener in get_registered_listeners():
             listener.on_node_created(node_id, attributes)
     elif event.event_type == EventType.UPDATE_NODE_ATTRIBUTES:
-        node_id = event.payload.get("node_id")
+        node_id = event.node_id
         if not node_id or not isinstance(node_id, str):
             raise ProcessingError("Invalid node_id for UPDATE_NODE_ATTRIBUTES")
         if "attributes" not in event.payload:
@@ -246,4 +246,3 @@ __all__ = [
     "apply_event_to_async_graph",
     "ingest_event_async",
 ]
-

--- a/tests/test_async_graph_adapter.py
+++ b/tests/test_async_graph_adapter.py
@@ -51,3 +51,35 @@ async def test_ingest_event_async_creates_node() -> None:
     assert await graph.get_node("n2") == {"y": 2}
     await graph.close()
 
+
+@pytest.mark.asyncio
+async def test_ingest_event_async_create_node_uses_top_level_node_id() -> None:
+    graph = AsyncGraphAdapterWrapper(MockGraph())
+    data = {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n3",
+        "payload": {"attributes": {"z": 3}},
+    }
+
+    await ingest_event_async(data, graph)
+
+    assert await graph.get_node("n3") == {"z": 3}
+    await graph.close()
+
+
+@pytest.mark.asyncio
+async def test_ingest_event_async_update_node_uses_top_level_node_id() -> None:
+    graph = AsyncGraphAdapterWrapper(MockGraph())
+    await graph.add_node("n4", {"value": 1})
+    data = {
+        "event_type": "UPDATE_NODE_ATTRIBUTES",
+        "timestamp": 2,
+        "node_id": "n4",
+        "payload": {"attributes": {"value": 2}},
+    }
+
+    await ingest_event_async(data, graph)
+
+    assert await graph.get_node("n4") == {"value": 2}
+    await graph.close()


### PR DESCRIPTION
### Motivation
- Align asynchronous event handling with synchronous semantics by reading node identifiers from the event top-level `node_id` rather than `payload.node_id` for node create/update flows. 
- Limit reliance on `payload` to `attributes` and event-specific metadata to avoid duplication and ambiguity between top-level and payload fields.

### Description
- Updated `apply_event_to_async_graph()` so `CREATE_NODE` reads `node_id` from `event.node_id` and validates it before using `payload["attributes"]` for node data. 
- Updated `apply_event_to_async_graph()` so `UPDATE_NODE_ATTRIBUTES` reads `node_id` from `event.node_id` and enforces the presence and shape of `payload["attributes"]`. 
- Added async ingestion tests in `tests/test_async_graph_adapter.py` to verify that events with a top-level `node_id` (and no `payload.node_id`) succeed for both create and update flows (`test_ingest_event_async_create_node_uses_top_level_node_id` and `test_ingest_event_async_update_node_uses_top_level_node_id`).

### Testing
- Ran `pytest -q tests/test_async_graph_adapter.py`, which collected the async tests but they were skipped in this environment because the `pytest-asyncio` plugin is not available. 
- Attempted `pytest -q -p pytest_asyncio`, which failed to import `pytest_asyncio` in the current environment. 
- Ran `ruff check src/ume/async_graph_adapter.py tests/test_async_graph_adapter.py`, which completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b34321a1c83268d2fbb93d6bd72b2)