### PR TITLE
Clarify LanceDB is planned and point vector backend to existing abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ Producer (canonical JSON) --> ume-raw-events --> Privacy Agent --> ume-clean-eve
 1. `producer_demo.py` publishes raw events conforming to the canonical schema to the `ume-raw-events` Kafka topic.
 2. The **Privacy Agent** validates each event, redacts PII and forwards sanitized messages to `ume-clean-events`.
 3. The projection engine consumes these sanitized events and applies them to the graph via the configured **Graph Adapter**.
-4. The adapter persists nodes and edges to the chosen backend selected by `UME_GRAPH_BACKEND` (`sqlite`, `postgres`, `redis`, `arango`, `neo4j`). Listeners such as `VectorStoreListener` automatically
-   index any `embedding` vectors for similarity search.
+4. The adapter persists nodes and edges to the chosen backend selected by `UME_GRAPH_BACKEND` (`sqlite`, `postgres`, `redis`, `arango`, `neo4j`). Vector indexing is configured separately via
+   `UME_VECTOR_BACKEND` through the vector backend abstraction in `src/ume/vector_store.py`; listeners such as `VectorStoreListener` automatically index any `embedding` vectors for similarity search.
 
 When nodes include textual attributes, the consumer generates vector embeddings using the configured model. These embeddings are stored in the vector store and queried via similarity search to locate relevant nodes before running graph traversals. The same fields are tokenized and the resulting tokens are saved under a `tokens` attribute for search. If the optional [tiktoken](https://github.com/openai/tiktoken) library is installed, it provides OpenAI-compatible tokenization.
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -16,12 +16,24 @@ graph TD
 Events enter the system through the **Ingestion API**, which publishes them to the `ume-raw-events` Kafka topic. The
 Privacy Agent sanitizes sensitive content before forwarding messages to `ume-clean-events`. A dedicated **Projection Engine**
 service consumes these sanitized events, applies them via the configured Graph Adapter, and keeps the graph synchronized with
-the event stream. The adapter persists the knowledge graph to the backend selected by `create_graph_adapter()` from `src/ume/factories.py`. Supported `UME_GRAPH_BACKEND` values are `sqlite`, `postgres`, `redis`, `arango`, and `neo4j`. Embeddings are stored in a vector store.
+the event stream. The adapter persists the knowledge graph to the backend selected by `create_graph_adapter()` from `src/ume/factories.py`. Supported `UME_GRAPH_BACKEND` values are `sqlite`, `postgres`, `redis`, `arango`, and `neo4j`.
 
-The vector store backend is selected with `UME_VECTOR_BACKEND`. In addition to FAISS and Chroma, UME supports Pinecone by
-setting `UME_VECTOR_BACKEND=pinecone` and providing `UME_PINECONE_API_KEY`, `UME_PINECONE_ENVIRONMENT`, and `UME_PINECONE_INDEX`.
+Vector storage is configured separately from graph adapters through `src/ume/vector_store.py` (for example, `create_default_store()` and `VectorStore`). Backend choice is environment-driven via `UME_VECTOR_BACKEND` and resolved through the registered vector backend registry.
+
+The vector store backend is selected with `UME_VECTOR_BACKEND`. In addition to FAISS and Chroma, UME supports Pinecone and Milvus via the vector backend abstraction in `src/ume/vector_store.py` and `src/ume/vector_backends/__init__.py`.
+Set `UME_VECTOR_BACKEND=pinecone` and provide `UME_PINECONE_API_KEY`, `UME_PINECONE_ENVIRONMENT`, and `UME_PINECONE_INDEX`.
 Text fields are tokenized before embeddings are generated using whichever tokenizer library is installed (`unitok`,
 `tatitok`, or `tiktoken`).
+
+## Implementation Status (Current vs Planned)
+
+To keep architecture docs aligned with the codebase, the table below distinguishes what is implemented on `main` versus roadmap/experimental work.
+
+| Area | Implemented on `main` | Planned / Experimental |
+| --- | --- | --- |
+| Graph persistence adapters | `sqlite`, `postgres`, `redis`, `arango`, `neo4j` via `create_graph_adapter()` | New graph adapters are roadmap items until implementation files and factory wiring are merged |
+| Vector storage | Environment-selected vector backend via `src/ume/vector_store.py` (`UME_VECTOR_BACKEND`) | Additional vector providers can be added through the backend registry / plugin entry points |
+| LanceDB usage | Not a shipped graph adapter in the current factory path | Any LanceDB integration should be documented as future/experimental until code is present |
 
 When querying, the API can perform a similarity search against the vector store to retrieve relevant nodes and
 then issue graph queries to traverse relationships.


### PR DESCRIPTION
### Motivation
- Prevent the architecture docs from implying an already-shipped LanceDB graph adapter when the implementation and factory wiring are not present. 
- Ensure the narrative clearly separates graph persistence adapters from vector backends to reduce future documentation drift.

### Description
- Reworded architecture narrative in `docs/ARCHITECTURE_OVERVIEW.md` to highlight that graph persistence is provided by `create_graph_adapter()` and to document vector storage as configured via `src/ume/vector_store.py` and `UME_VECTOR_BACKEND`.
- Added an "Implementation Status (Current vs Planned)" table in `docs/ARCHITECTURE_OVERVIEW.md` that marks `LanceDB` usage as future/experimental until code and factory wiring are present.
- Updated `README.md` event-flow wording to point vector indexing at the vector backend abstraction (`src/ume/vector_store.py`) and environment-driven selection via `UME_VECTOR_BACKEND` instead of implying non-existent graph adapter classes.

### Testing
- No automated tests or linters were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b48749c5083268d22cc26d1059826)