### PR TITLE
docs: align event contract documentation with current parser and projection behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,59 @@ set of common fields and any number of type‑specific attributes.
 | `sourceService` | Name of the service that emitted the event. |
 | `payload` | Event‑specific attributes. |
 
+`parse_event()` accepts both `eventType` (preferred) and legacy `event_type`
+as the event type key. Timestamps are accepted as Unix epoch integers or
+ISO&nbsp;8601 strings (including `Z` suffix) and are normalized internally to an
+epoch integer on the parsed `Event`.
+
 All official event types such as `CREATE_NODE` or `CREATE_EDGE` have
 corresponding JSON Schema definitions under `src/ume/schemas`.  Producers
 should validate events using `ume.validate_event_dict()` before publishing to
 Kafka or any other broker.
 
-`eventType` is the preferred wire-level field name. `parse_event()` currently
-accepts snake_case `event_type` for backward compatibility, but new producers
-should emit `eventType`.
+#### Runtime validation currently enforced
+
+`parse_event()` and `apply_event_to_graph()` currently enforce the following
+event-type-specific checks:
+
+* `CREATE_NODE`, `RESEARCH_JOB_STARTED`
+  * `parse_event`: requires `timestamp`, `node_id` (or matching
+    `payload.node_id`), and `payload` as a `dict`.
+  * `apply_event_to_graph`: requires `event.node_id` as `str`; if
+    `payload.attributes` exists it must be a `dict`.
+* `UPDATE_NODE_ATTRIBUTES`, `DOCUMENT_ARCHIVED`
+  * `parse_event`: requires `node_id`, `payload` as a `dict`, and
+    `payload.attributes` as a `dict`.
+  * `apply_event_to_graph`: requires non-empty `payload.attributes`; for
+    `DOCUMENT_ARCHIVED`, sets `attributes.archived = true` when missing.
+* `CREATE_EDGE`, `DELETE_EDGE`, `CREATE_ONTOLOGY_RELATION`,
+  `DATA_SOURCE_QUERIED`, `ENTITY_DISCOVERED`
+  * `parse_event`: requires `node_id`, `target_node_id`, and `label` as
+    strings; `payload` is optional and defaults to `{}`.
+  * `apply_event_to_graph`: re-checks `node_id`/`target_node_id`/`label` are
+    strings; for `CREATE_EDGE`/`DATA_SOURCE_QUERIED`/`ENTITY_DISCOVERED`,
+    `payload.attributes` must be a `dict` if present.
+  * `apply_event_to_graph`: for `ENTITY_DISCOVERED`, creates `target_node_id`
+    if missing before adding the edge.
+* `ANOMALY_DETECTED`
+  * `parse_event`: no extra required fields beyond base parsing.
+  * `apply_event_to_graph`: informational only (no graph mutation).
+* Unknown event types
+  * `parse_event`: allows unknown `eventType` values (with type checks on known
+    optional fields).
+  * `apply_event_to_graph`: raises `ProcessingError`.
+
+Compatibility note:
+
+* Required for all events: `eventType` (or alias `event_type`) and `timestamp`.
+* Optional for all events: `eventId`, `correlationId`, `subjectEntity`,
+  `sourceService`.
+* Edge-family events (`CREATE_EDGE`, `DELETE_EDGE`, `CREATE_ONTOLOGY_RELATION`,
+  `DATA_SOURCE_QUERIED`, `ENTITY_DISCOVERED`) require `node_id`,
+  `target_node_id`, `label`; `payload` is optional and defaults to `{}`.
+* Node-family update events (`UPDATE_NODE_ATTRIBUTES`, `DOCUMENT_ARCHIVED`)
+  require `payload.attributes`; `DOCUMENT_ARCHIVED` defaults
+  `attributes.archived` to `true` during processing when omitted.
 
 #### CREATE_EDGE Event
 
@@ -156,7 +201,7 @@ Used to create a new directed, labeled edge between two existing nodes.
   "eventType": "RESEARCH_JOB_STARTED",
   "timestamp": "2024-03-15T12:10:00Z",
   "node_id": "job_123",
-  "payload": {"attributes": {"status": "running"}}
+  "payload": {"attributes": {"type": "research_job", "status": "running"}}
 }
 ```
 
@@ -178,7 +223,7 @@ Used to create a new directed, labeled edge between two existing nodes.
   "node_id": "job_123",
   "target_node_id": "entity_789",
   "label": "FOUND",
-  "payload": {"name": "Foo"}
+  "payload": {"attributes": {"name": "Foo", "type": "entity"}}
 }
 ```
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -142,10 +142,28 @@ Each ledger entry preserves the original `eventType` string. The event parser
 maps known constants to the :class:`~ume.event.EventType` enum but allows
 arbitrary values to pass through unchanged. It accepts `timestamp` values as
 either epoch integers or ISO-8601 strings, and normalizes parsed events to an
-epoch integer timestamp. This flexibility lets producers introduce new event
-categories without requiring a code update. Custom types are stored and replayed
-like built-in events. For backward compatibility, snake_case `event_type` is
-currently tolerated but `eventType` remains the preferred wire-level field name.
+epoch integer timestamp. For backward compatibility, snake_case `event_type` is
+currently tolerated but `eventType` remains the preferred wire-level field
+name.
+
+Current event-contract compatibility rules are enforced at two layers:
+
+* `parse_event()`: validates required keys per event family (`node_id` plus
+  payload constraints for node events, and `node_id`/`target_node_id`/`label`
+  for edge events).
+* `apply_event_to_graph()`: applies stricter runtime checks used by projection,
+  such as requiring non-empty `payload.attributes` for
+  `UPDATE_NODE_ATTRIBUTES`/`DOCUMENT_ARCHIVED`, defaulting
+  `DOCUMENT_ARCHIVED.attributes.archived` to `true` when absent, and treating
+  `ENTITY_DISCOVERED` as edge creation with opportunistic target-node creation.
+* Edge-family events (`CREATE_EDGE`, `DELETE_EDGE`,
+  `CREATE_ONTOLOGY_RELATION`, `DATA_SOURCE_QUERIED`, `ENTITY_DISCOVERED`) may
+  omit `payload`; it defaults to `{}` during parsing.
+
+This flexibility lets producers introduce new event categories without requiring
+an immediate parser change, while still keeping projection semantics explicit.
+Custom types are stored and replayed like built-in events but are currently
+rejected by projection unless explicitly handled.
 
 ## Policy DSL Flow
 

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -219,6 +219,9 @@ map this value to the :class:`~ume.event.EventType` enumeration but preserves th
 original text when the value is unknown. This allows custom event categories to
 flow through the pipeline and be stored in the ledger without schema changes.
 
+For compatibility, the parser accepts both `eventType` (preferred) and
+`event_type` as input keys.
+
 During sanitization the Privacy Agent tokenizes common text fields such as
 `name`, `text` and `content`. The resulting list of tokens is attached to the
 event payload under the `tokens` key so that downstream components can create
@@ -236,6 +239,34 @@ vector embeddings consistently.
 | `sourceService` | Originating service name. |
 | `payload` | Additional attributes specific to the event type. |
 
+`timestamp` accepts either a Unix epoch integer or an ISO&nbsp;8601 string. During
+parsing, values are normalized to an epoch integer in the `Event` object.
+
+### Event Contract Compatibility and Validation
+
+Current runtime behavior in `parse_event()` + `apply_event_to_graph()`:
+
+* Required for all events: `eventType` (or `event_type`) and `timestamp`.
+* Optional common fields: `eventId`, `correlationId`, `subjectEntity`,
+  `sourceService`.
+* Node-create family (`CREATE_NODE`, `RESEARCH_JOB_STARTED`):
+  * parse: requires `node_id` (or `payload.node_id`), plus `payload` as `dict`.
+  * processing: uses `payload.attributes` when present; must be `dict`.
+* Node-update family (`UPDATE_NODE_ATTRIBUTES`, `DOCUMENT_ARCHIVED`):
+  * parse: requires `node_id`, `payload.attributes` as `dict`.
+  * processing: requires non-empty `payload.attributes`;
+    `DOCUMENT_ARCHIVED` defaults `attributes.archived = true` if missing.
+* Edge family (`CREATE_EDGE`, `DELETE_EDGE`, `CREATE_ONTOLOGY_RELATION`,
+  `DATA_SOURCE_QUERIED`, `ENTITY_DISCOVERED`):
+  * parse: requires `node_id`, `target_node_id`, `label` (all strings).
+  * parse: `payload` is optional and defaults to `{}` for these event types.
+  * processing (`CREATE_EDGE`, `DATA_SOURCE_QUERIED`, `ENTITY_DISCOVERED`):
+    `payload.attributes` must be a `dict` if provided.
+  * processing (`ENTITY_DISCOVERED`): creates target node when absent, then adds
+    the edge.
+* Unknown event types: parser accepts them, processor currently rejects with
+  `ProcessingError`.
+
 #### Example: RESEARCH_JOB_STARTED
 
 ```json
@@ -243,7 +274,7 @@ vector embeddings consistently.
   "eventType": "RESEARCH_JOB_STARTED",
   "timestamp": "2024-03-15T12:10:00Z",
   "node_id": "job_123",
-  "payload": {"status": "running"}
+  "payload": {"attributes": {"type": "research_job", "status": "running"}}
 }
 ```
 
@@ -269,7 +300,7 @@ vector embeddings consistently.
   "node_id": "job_123",
   "target_node_id": "entity_789",
   "label": "FOUND",
-  "payload": {"name": "Foo"}
+  "payload": {"attributes": {"name": "Foo", "type": "entity"}}
 }
 ```
 
@@ -280,7 +311,7 @@ vector embeddings consistently.
   "eventType": "DOCUMENT_ARCHIVED",
   "timestamp": "2024-03-15T12:13:00Z",
   "node_id": "doc_1",
-  "payload": {"archived_by": "agent_42"}
+  "payload": {"attributes": {"archived_by": "agent_42", "archived": true}}
 }
 ```
 
@@ -317,7 +348,8 @@ schema, ensuring consistent processing across components.
 
 Compatibility note: `eventType` is the preferred wire field. `parse_event()`
 still accepts snake_case `event_type` for backward compatibility, but new
-producers should emit `eventType`.
+producers should emit `eventType`. For edge-family events, omitted `payload`
+defaults to `{}`.
 
 As events move from the ingestion API through the Privacy Agent
 and into the projection engine, they keep this schema. The engine


### PR DESCRIPTION
### Motivation

* Ensure end-user documentation accurately reflects runtime parsing and projection behavior for events so producers know what to emit and what the system enforces.
* Clarify compatibility rules and example payload shapes to reduce integration errors caused by mismatched expectations between producers and UME's `parse_event`/projection logic.

### Description

* Updated `README.md` to document that `parse_event()` accepts both `eventType` and legacy `event_type` keys, and that timestamps may be a Unix epoch `int` or ISO8601 string and are normalized to an epoch integer in the parsed `Event` object. 
* Added an explicit summary of runtime validation enforced by `parse_event()` and `apply_event_to_graph()` grouped by event families (`CREATE_NODE`/`RESEARCH_JOB_STARTED`, `UPDATE_NODE_ATTRIBUTES`/`DOCUMENT_ARCHIVED`, edge-family events, `ANOMALY_DETECTED`, and unknown types). 
* Clarified compatibility/contract notes describing which fields are required, optional, or defaulted (notably that edge-family `payload` defaults to `{}` and `DOCUMENT_ARCHIVED` will default `attributes.archived = true` during processing). 
* Synchronized `docs/GRAPH_MODEL.md` and `docs/ARCHITECTURE_OVERVIEW.md` with the same alias, timestamp, validation, and example changes and updated example events to use `payload.attributes` and matching enum/event strings. 

### Testing

* No automated tests or linters were run because this is a documentation-only change and does not modify runtime code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b4e7ff2bc83268015d8f18a9c0d20)