### PR TITLE
Refactor graph adapter creation to registry-based backend resolution

### DIFF
--- a/src/ume/adapters/__init__.py
+++ b/src/ume/adapters/__init__.py
@@ -1,0 +1,27 @@
+"""Graph adapter registration helpers."""
+
+from .registry import (
+    GraphAdapterRegistrationError,
+    available_graph_backends,
+    create_registered_graph_adapter,
+    discover_external_graph_backends,
+    discover_graph_backends_from_entry_points,
+    discover_graph_backends_from_modules,
+    ensure_external_graph_backends_discovered,
+    get_graph_backend_constructor,
+    register_graph_backend,
+    register_lazy_graph_backend,
+)
+
+__all__ = [
+    "GraphAdapterRegistrationError",
+    "available_graph_backends",
+    "create_registered_graph_adapter",
+    "discover_external_graph_backends",
+    "discover_graph_backends_from_entry_points",
+    "discover_graph_backends_from_modules",
+    "ensure_external_graph_backends_discovered",
+    "get_graph_backend_constructor",
+    "register_graph_backend",
+    "register_lazy_graph_backend",
+]

--- a/src/ume/adapters/bootstrap.py
+++ b/src/ume/adapters/bootstrap.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from .registry import register_graph_backend, register_lazy_graph_backend
+
+
+_BUILTINS_REGISTERED = False
+
+
+def register_builtin_graph_backends() -> None:
+    """Register built-in graph backend constructors."""
+    global _BUILTINS_REGISTERED
+    if _BUILTINS_REGISTERED:
+        return
+
+    register_graph_backend("sqlite", _create_persistent_graph)
+    register_graph_backend("persistent", _create_persistent_graph)
+    register_graph_backend("postgres", _create_postgres_graph)
+    register_graph_backend("redis", _create_redis_graph)
+    register_graph_backend("arango", _create_arango_graph)
+    register_lazy_graph_backend("neo4j", _load_neo4j_constructor)
+
+    _BUILTINS_REGISTERED = True
+
+
+def _create_persistent_graph(db_path: str | None):
+    from ume.config import settings
+    from ume.persistent_graph import PersistentGraph
+
+    return PersistentGraph(db_path or settings.UME_DB_PATH)
+
+
+def _create_postgres_graph(db_path: str | None):
+    from ume.config import settings
+    from ume.postgres_graph import PostgresGraph
+
+    return PostgresGraph(db_path or settings.UME_DB_PATH)
+
+
+def _create_redis_graph(db_path: str | None):
+    from ume.config import settings
+    from ume.redis_graph_adapter import RedisGraphAdapter
+
+    return RedisGraphAdapter(db_path or settings.UME_DB_PATH)
+
+
+def _create_arango_graph(_: str | None):
+    from ume.config import settings
+    from ume.arango_graph import ArangoGraph
+
+    return ArangoGraph(
+        settings.ARANGO_URL,
+        settings.ARANGO_USER,
+        settings.ARANGO_PASSWORD,
+        db_name=settings.ARANGO_DB_NAME,
+    )
+
+
+def _load_neo4j_constructor():
+    def _create_neo4j_graph(_: str | None):
+        from ume.config import settings
+
+        try:
+            from ume.neo4j_graph import Neo4jGraph
+        except Exception as exc:
+            raise ImportError("neo4j is required for Neo4jGraph") from exc
+
+        return Neo4jGraph(
+            settings.NEO4J_URI,
+            settings.NEO4J_USER,
+            settings.NEO4J_PASSWORD,
+        )
+
+    return _create_neo4j_graph

--- a/src/ume/adapters/registry.py
+++ b/src/ume/adapters/registry.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from importlib import import_module
+from importlib.metadata import entry_points
+from threading import Lock
+
+from ume.graph_adapter import IGraphAdapter
+
+GraphAdapterConstructor = Callable[[str | None], IGraphAdapter]
+LazyConstructorLoader = Callable[[], GraphAdapterConstructor]
+
+_BACKEND_CONSTRUCTORS: dict[str, GraphAdapterConstructor] = {}
+_LAZY_BACKENDS: dict[str, LazyConstructorLoader] = {}
+_DISCOVERY_LOCK = Lock()
+_EXTERNAL_DISCOVERED = False
+
+
+class GraphAdapterRegistrationError(ValueError):
+    """Raised when adapter registration metadata is invalid."""
+
+
+def register_graph_backend(name: str, constructor: GraphAdapterConstructor) -> None:
+    """Register a graph backend constructor under ``name``."""
+    _BACKEND_CONSTRUCTORS[name.lower()] = constructor
+
+
+def register_lazy_graph_backend(name: str, loader: LazyConstructorLoader) -> None:
+    """Register a deferred loader for backend ``name``."""
+    _LAZY_BACKENDS[name.lower()] = loader
+
+
+def get_graph_backend_constructor(
+    name: str,
+    *,
+    default: str | None = None,
+) -> GraphAdapterConstructor:
+    """Return constructor for ``name``, resolving lazy registrations on demand."""
+    key = name.lower()
+    constructor = _BACKEND_CONSTRUCTORS.get(key)
+    if constructor is None and key in _LAZY_BACKENDS:
+        constructor = _LAZY_BACKENDS.pop(key)()
+        _BACKEND_CONSTRUCTORS[key] = constructor
+    if constructor is not None:
+        return constructor
+    if default is not None and default.lower() != key:
+        return get_graph_backend_constructor(default)
+    raise ValueError(f"Unknown graph backend: {name}")
+
+
+def create_registered_graph_adapter(
+    name: str,
+    db_path: str | None,
+    *,
+    default: str | None = None,
+) -> IGraphAdapter:
+    """Instantiate backend ``name`` using the registration table."""
+    constructor = get_graph_backend_constructor(name, default=default)
+    return constructor(db_path)
+
+
+def available_graph_backends() -> list[str]:
+    """Return all known graph backend keys."""
+    return sorted(set(_BACKEND_CONSTRUCTORS) | set(_LAZY_BACKENDS))
+
+
+def clear_graph_backend_registry() -> None:
+    """Reset all registered and lazy graph backend constructors."""
+    _BACKEND_CONSTRUCTORS.clear()
+    _LAZY_BACKENDS.clear()
+
+
+def _register_external_loaded_object(name: str, loaded: object) -> None:
+    if callable(loaded):
+        register_graph_backend(name, loaded)
+        return
+    if isinstance(loaded, Mapping):
+        for backend_name, constructor in loaded.items():
+            if not callable(constructor):
+                raise GraphAdapterRegistrationError(
+                    f"Constructor for backend '{backend_name}' is not callable"
+                )
+            register_graph_backend(str(backend_name), constructor)
+        return
+    raise GraphAdapterRegistrationError(
+        f"Entry point '{name}' must load a constructor or backend mapping"
+    )
+
+
+def discover_graph_backends_from_entry_points(
+    *,
+    group: str = "ume.graph_adapters",
+) -> None:
+    """Load external graph backend registrations from Python entry points."""
+    for ep in entry_points(group=group):
+        _register_external_loaded_object(ep.name, ep.load())
+
+
+def discover_graph_backends_from_modules(module_paths: Iterable[str]) -> None:
+    """Load graph backend registrations from importable module paths."""
+    for module_path in module_paths:
+        module_name = module_path.strip()
+        if not module_name:
+            continue
+        module = import_module(module_name)
+        registration_hook = getattr(module, "register_graph_backends", None)
+        if callable(registration_hook):
+            registration_hook(register_graph_backend, register_lazy_graph_backend)
+            continue
+        adapter_map = getattr(module, "GRAPH_ADAPTERS", None)
+        if isinstance(adapter_map, Mapping):
+            _register_external_loaded_object(module_name, adapter_map)
+            continue
+        raise GraphAdapterRegistrationError(
+            f"Module '{module_name}' must define register_graph_backends or GRAPH_ADAPTERS"
+        )
+
+
+def discover_external_graph_backends(*, module_paths: Iterable[str] = ()) -> None:
+    """Discover graph backends via entry points and optional module paths."""
+    discover_graph_backends_from_entry_points()
+    discover_graph_backends_from_modules(module_paths)
+
+
+def ensure_external_graph_backends_discovered(*, module_paths: Iterable[str] = ()) -> None:
+    """Run external discovery once per process."""
+    global _EXTERNAL_DISCOVERED
+    if _EXTERNAL_DISCOVERED:
+        return
+    with _DISCOVERY_LOCK:
+        if _EXTERNAL_DISCOVERED:
+            return
+        discover_external_graph_backends(module_paths=module_paths)
+        _EXTERNAL_DISCOVERED = True

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
     # UME Core
     UME_DB_PATH: str = "ume_graph.db"
     UME_GRAPH_BACKEND: str = "sqlite"  # sqlite, postgres, redis, or neo4j
+    UME_GRAPH_ADAPTER_MODULES: str | None = None
     UME_SNAPSHOT_PATH: str = "ume_snapshot.json"
     UME_SNAPSHOT_DIR: str = "."
     UME_COLD_DB_PATH: str = "ume_cold.db"

--- a/src/ume/factories.py
+++ b/src/ume/factories.py
@@ -1,27 +1,21 @@
 from __future__ import annotations
 
+from .adapters.bootstrap import register_builtin_graph_backends
+from .adapters.registry import create_registered_graph_adapter, ensure_external_graph_backends_discovered
 from .config import settings
-from .persistent_graph import PersistentGraph
-from .postgres_graph import PostgresGraph
-from .redis_graph_adapter import RedisGraphAdapter
-from .arango_graph import ArangoGraph
 from .rbac_adapter import RoleBasedGraphAdapter
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover - for optional dependency hints
-    from .neo4j_graph import Neo4jGraph
-else:  # pragma: no cover - optional dependency
-    try:
-        from .neo4j_graph import Neo4jGraph
-    except Exception:
-        class Neo4jGraph:
-            def __init__(self, *_: object, **__: object) -> None:
-                raise ImportError("neo4j is required for Neo4jGraph")
 from .vector_store import VectorBackend, create_vector_store as _create_vector_store
 from .memory import EpisodicMemory, SemanticMemory
 
 from .graph_adapter import IGraphAdapter
 from .tracing import TracingGraphAdapter, is_tracing_enabled
+
+
+def _configured_adapter_modules() -> list[str]:
+    raw = settings.UME_GRAPH_ADAPTER_MODULES
+    if not raw:
+        return []
+    return [item.strip() for item in raw.split(",") if item.strip()]
 
 
 def create_graph_adapter(
@@ -30,27 +24,10 @@ def create_graph_adapter(
     role: str | None = None,
 ) -> IGraphAdapter:
     """Create the default :class:`IGraphAdapter` using configuration settings."""
+    register_builtin_graph_backends()
+    ensure_external_graph_backends_discovered(module_paths=_configured_adapter_modules())
     backend = settings.UME_GRAPH_BACKEND.lower()
-    base: IGraphAdapter
-    if backend == "postgres":
-        base = PostgresGraph(db_path or settings.UME_DB_PATH)
-    elif backend == "redis":
-        base = RedisGraphAdapter(db_path or settings.UME_DB_PATH)
-    elif backend == "arango":
-        base = ArangoGraph(
-            settings.ARANGO_URL,
-            settings.ARANGO_USER,
-            settings.ARANGO_PASSWORD,
-            db_name=settings.ARANGO_DB_NAME,
-        )
-    elif backend == "neo4j":
-        base = Neo4jGraph(
-            settings.NEO4J_URI,
-            settings.NEO4J_USER,
-            settings.NEO4J_PASSWORD,
-        )
-    else:
-        base = PersistentGraph(db_path or settings.UME_DB_PATH)
+    base = create_registered_graph_adapter(backend, db_path, default="persistent")
     if is_tracing_enabled():
         base = TracingGraphAdapter(base)
     role = role if role is not None else settings.UME_ROLE

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -82,11 +82,21 @@ class DummyTracing:
 def test_create_graph_adapter_with_role_and_tracing(monkeypatch: pytest.MonkeyPatch) -> None:
     created: dict[str, object] = {}
 
-    def dummy_persistent(path: str) -> DummyGraph:
+    def dummy_constructor(path: str | None) -> DummyGraph:
         created["path"] = path
         return DummyGraph()
 
-    monkeypatch.setattr(factories, "PersistentGraph", dummy_persistent)
+    monkeypatch.setattr(factories, "register_builtin_graph_backends", lambda: None)
+    monkeypatch.setattr(
+        factories,
+        "ensure_external_graph_backends_discovered",
+        lambda module_paths=(): None,
+    )
+    monkeypatch.setattr(
+        factories,
+        "create_registered_graph_adapter",
+        lambda backend, db_path, default=None: dummy_constructor(db_path),
+    )
     monkeypatch.setattr(factories, "TracingGraphAdapter", DummyTracing)
     monkeypatch.setattr(factories, "is_tracing_enabled", lambda: True)
 

--- a/tests/test_graph_adapter_registry.py
+++ b/tests/test_graph_adapter_registry.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import types
+import sys
+
+import pytest
+
+from ume.adapters import bootstrap
+from ume.adapters.registry import (
+    clear_graph_backend_registry,
+    create_registered_graph_adapter,
+    discover_graph_backends_from_entry_points,
+    discover_graph_backends_from_modules,
+    register_graph_backend,
+)
+from ume import factories
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    clear_graph_backend_registry()
+    monkeypatch.setattr(bootstrap, "_BUILTINS_REGISTERED", False)
+    monkeypatch.setattr("ume.adapters.registry._EXTERNAL_DISCOVERED", False)
+
+
+class _Adapter:
+    def __init__(self, db_path: str | None) -> None:
+        self.db_path = db_path
+
+
+def test_registry_default_backend_lookup() -> None:
+    register_graph_backend("persistent", _Adapter)
+
+    adapter = create_registered_graph_adapter("unknown", "graph.db", default="persistent")
+
+    assert isinstance(adapter, _Adapter)
+    assert adapter.db_path == "graph.db"
+
+
+def test_factory_can_use_runtime_registered_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    register_graph_backend("custom", _Adapter)
+    monkeypatch.setattr(factories, "register_builtin_graph_backends", lambda: None)
+    monkeypatch.setattr(
+        factories,
+        "ensure_external_graph_backends_discovered",
+        lambda module_paths=(): None,
+    )
+    monkeypatch.setattr(factories.settings, "UME_GRAPH_BACKEND", "custom", raising=False)
+    monkeypatch.setattr(factories.settings, "UME_ROLE", None, raising=False)
+    monkeypatch.setattr(factories, "is_tracing_enabled", lambda: False)
+
+    adapter = factories.create_graph_adapter("custom.db")
+
+    assert isinstance(adapter, _Adapter)
+    assert adapter.db_path == "custom.db"
+
+
+def test_discover_graph_backends_from_modules() -> None:
+    module = types.ModuleType("tmp_custom_graph_module")
+
+    def _register(register, register_lazy) -> None:  # noqa: ANN001
+        del register_lazy
+        register("module_custom", _Adapter)
+
+    module.register_graph_backends = _register  # type: ignore[attr-defined]
+    sys.modules[module.__name__] = module
+    try:
+        discover_graph_backends_from_modules([module.__name__])
+        adapter = create_registered_graph_adapter("module_custom", "from-module.db")
+    finally:
+        sys.modules.pop(module.__name__, None)
+
+    assert isinstance(adapter, _Adapter)
+    assert adapter.db_path == "from-module.db"
+
+
+def test_discover_graph_backends_from_entry_points(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _FakeEntryPoint:
+        name = "ep_custom"
+
+        @staticmethod
+        def load():
+            return _Adapter
+
+    monkeypatch.setattr(
+        "ume.adapters.registry.entry_points",
+        lambda group: [_FakeEntryPoint()] if group == "ume.graph_adapters" else [],
+    )
+
+    discover_graph_backends_from_entry_points()
+    adapter = create_registered_graph_adapter("ep_custom", "from-ep.db")
+
+    assert isinstance(adapter, _Adapter)
+    assert adapter.db_path == "from-ep.db"


### PR DESCRIPTION
### Motivation
- Decouple backend selection from branching logic in `create_graph_adapter` and enable pluggable backends via a registry.
- Allow lazy imports for heavy optional backends and enable external discovery so third-party adapters can be provided without editing core factory code.
- Preserve existing role and tracing wrappers as composable decorators applied after backend instantiation.

### Description
- Added a registry package `src/ume/adapters` with `registry.py` implementing backend constructor registration, lazy constructor hooks, runtime lookup with optional default fallback, entry-point discovery, and module-path discovery APIs using `entry_points` and `import_module`.
- Added `src/ume/adapters/bootstrap.py` to register built-in backends (`sqlite`/`persistent`, `postgres`, `redis`, `arango`) and a lazy loader for `neo4j` so built-ins are registered via a central bootstrap hook.
- Exported registry/discovery helpers from `src/ume/adapters/__init__.py` for use by factories and extensions.
- Refactored `create_graph_adapter` in `src/ume/factories.py` to call `register_builtin_graph_backends()` and `ensure_external_graph_backends_discovered()` and to instantiate backends using `create_registered_graph_adapter(...)` instead of `if/elif` branching, while retaining tracing (`TracingGraphAdapter`) and role (`RoleBasedGraphAdapter`) wrappers.
- Added `UME_GRAPH_ADAPTER_MODULES` configuration (`src/ume/config/__init__.py`) to support comma-separated module paths for adapter discovery.
- Tests updated: `tests/test_factories.py` adjusted to the registry flow; new `tests/test_graph_adapter_registry.py` verifies registry fallback, runtime registration usage by the factory, module-based discovery, and entry-point discovery.

### Testing
- Ran unit tests: `pytest -q tests/test_factories.py tests/test_graph_adapter_registry.py`; all tests passed (`7 passed`).
- Ran linter checks: `ruff check` over modified files; no issues reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb34661a8832684c3e580ea70cb96)