### PR TITLE
Replace fixed stream topic map with semantic event router

### DIFF
--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -64,6 +64,8 @@ faust:
   input_topic: "ume-clean-events"
   edge_topic: "ume_edges"
   node_topic: "ume_nodes"
+  fallback_topic: "ume-misc-events"
+  dead_letter_topic: "ume-dead-letter-events"
 ```
 
 ## Environment Variables
@@ -118,6 +120,8 @@ is enabled.
 | `KAFKA_QUARANTINE_TOPIC` | `ume-quarantine-events` | Topic for rejected events. |
 | `KAFKA_EDGE_TOPIC` | `ume_edges` | Topic for processed edges. |
 | `KAFKA_NODE_TOPIC` | `ume_nodes` | Topic for processed nodes. |
+| `KAFKA_ROUTING_FALLBACK_TOPIC` | `ume-misc-events` | Fallback topic for unknown/custom events without an explicit schema topic. |
+| `KAFKA_ROUTING_DEAD_LETTER_TOPIC` | `ume-dead-letter-events` | Dead-letter topic for policy-denied events. |
 | `KAFKA_GROUP_ID` | `ume_client_group` | Consumer group for demos and stream processors. |
 | `KAFKA_PRIVACY_AGENT_GROUP_ID` | `ume-privacy-agent-group` | Consumer group for the privacy agent. |
 | `KAFKA_PRODUCER_BATCH_SIZE` | `10` | Number of messages before producer flush. |

--- a/docs/TOPIC_ROUTING.md
+++ b/docs/TOPIC_ROUTING.md
@@ -1,0 +1,49 @@
+# Event Topic Routing Conventions
+
+The stream processor now derives destination topics from canonical envelope metadata
+instead of a fixed event-type lookup. Producer teams should emit canonical fields
+that describe event semantics so routing remains stable as new event types are added.
+
+## Canonical metadata used for routing
+
+Routing decisions are computed from `metadata` and `graph` fields in the canonical
+envelope:
+
+- `metadata.type_family`: optional semantic family (`node`, `edge`, or custom).
+- `metadata.schema_version`: schema version string used for observability and
+  compatibility checks.
+- `metadata.policy_result`: optional policy verdict. Denied/rejected values are
+  routed to dead-letter.
+- `metadata.schema.topic` (or `metadata.destination_topic`): optional explicit topic
+  override from schema metadata.
+- `graph.node_id`, `graph.target_node_id`, `graph.label`: graph semantics used as
+  fallback family detection when `type_family` is not present.
+
+## Routing order
+
+The router applies decisions in this order:
+
+1. **Policy deny path**: denied/rejected events go to dead-letter topic.
+2. **Schema topic override**: if schema metadata specifies a topic, that topic wins.
+3. **Semantic family routing**:
+   - `edge` family -> `KAFKA_EDGE_TOPIC`
+   - `node` family -> `KAFKA_NODE_TOPIC`
+4. **Fallback topic**: unknown/custom events without schema topic ->
+   `KAFKA_ROUTING_FALLBACK_TOPIC`.
+
+## Producer recommendations
+
+- Always provide canonical `metadata.event_type`, `metadata.timestamp`, and
+  `metadata.schema_version` values.
+- Include `metadata.type_family` for custom event names so they route predictably.
+- If a custom event requires a dedicated topic, define it in schema metadata using
+  `metadata.schema.topic` (or `metadata.destination_topic`).
+- Emit `metadata.policy_result` for events already evaluated by policy engines to
+  ensure denied data lands in `KAFKA_ROUTING_DEAD_LETTER_TOPIC`.
+
+## Related settings
+
+- `KAFKA_EDGE_TOPIC`
+- `KAFKA_NODE_TOPIC`
+- `KAFKA_ROUTING_FALLBACK_TOPIC`
+- `KAFKA_ROUTING_DEAD_LETTER_TOPIC`

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -77,6 +77,8 @@ class Settings(BaseSettings):  # type: ignore[misc]
     KAFKA_QUARANTINE_TOPIC: str = "ume-quarantine-events"
     KAFKA_EDGE_TOPIC: str = "ume_edges"
     KAFKA_NODE_TOPIC: str = "ume_nodes"
+    KAFKA_ROUTING_FALLBACK_TOPIC: str = "ume-misc-events"
+    KAFKA_ROUTING_DEAD_LETTER_TOPIC: str = "ume-dead-letter-events"
     KAFKA_GROUP_ID: str = "ume_client_group"
     KAFKA_PRIVACY_AGENT_GROUP_ID: str = "ume-privacy-agent-group"
     # Number of messages to batch before calling `Producer.flush()` in the privacy agent

--- a/src/ume/pipeline/router.py
+++ b/src/ume/pipeline/router.py
@@ -1,0 +1,166 @@
+"""Topic routing utilities for canonical events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from ..config import settings
+
+_POLICY_DENY_RESULTS = {"deny", "denied", "reject", "rejected", "blocked"}
+
+
+@dataclass(frozen=True)
+class RouterConfig:
+    """Destination topics used by the stream processor."""
+
+    node_topic: str
+    edge_topic: str
+    default_topic: str
+    dead_letter_topic: str
+
+
+@dataclass(frozen=True)
+class RoutingDecision:
+    """Result of applying routing semantics to one canonical event."""
+
+    topic: str
+    family: str
+    schema_version: str | None
+    policy_result: str | None
+    reason: str
+
+
+def router_config_from_settings() -> RouterConfig:
+    """Build router configuration from process settings."""
+
+    return RouterConfig(
+        node_topic=settings.KAFKA_NODE_TOPIC,
+        edge_topic=settings.KAFKA_EDGE_TOPIC,
+        default_topic=settings.KAFKA_ROUTING_FALLBACK_TOPIC,
+        dead_letter_topic=settings.KAFKA_ROUTING_DEAD_LETTER_TOPIC,
+    )
+
+
+def route_event(
+    canonical_event: Mapping[str, Any], config: RouterConfig
+) -> RoutingDecision:
+    """Compute destination topic from canonical metadata + schema hints."""
+
+    metadata = canonical_event.get("metadata")
+    graph = canonical_event.get("graph")
+    if not isinstance(metadata, Mapping):
+        metadata = {}
+    if not isinstance(graph, Mapping):
+        graph = {}
+
+    family = _type_family(metadata, graph)
+    schema_version = _string_value(metadata.get("schema_version"))
+    policy_result = _policy_result(metadata)
+
+    if policy_result in _POLICY_DENY_RESULTS:
+        return RoutingDecision(
+            topic=config.dead_letter_topic,
+            family=family,
+            schema_version=schema_version,
+            policy_result=policy_result,
+            reason="policy_denied",
+        )
+
+    schema_topic = _schema_topic(metadata)
+    if schema_topic:
+        return RoutingDecision(
+            topic=schema_topic,
+            family=family,
+            schema_version=schema_version,
+            policy_result=policy_result,
+            reason="schema_topic",
+        )
+
+    if family == "edge":
+        return RoutingDecision(
+            topic=config.edge_topic,
+            family=family,
+            schema_version=schema_version,
+            policy_result=policy_result,
+            reason="edge_family",
+        )
+
+    if family == "node":
+        return RoutingDecision(
+            topic=config.node_topic,
+            family=family,
+            schema_version=schema_version,
+            policy_result=policy_result,
+            reason="node_family",
+        )
+
+    return RoutingDecision(
+        topic=config.default_topic,
+        family=family,
+        schema_version=schema_version,
+        policy_result=policy_result,
+        reason="fallback",
+    )
+
+
+def _schema_topic(metadata: Mapping[str, Any]) -> str | None:
+    direct_topic = _string_value(metadata.get("destination_topic") or metadata.get("topic"))
+    if direct_topic:
+        return direct_topic
+
+    schema_meta = metadata.get("schema")
+    if isinstance(schema_meta, Mapping):
+        return _string_value(schema_meta.get("topic"))
+
+    schema_meta = metadata.get("schema_metadata")
+    if isinstance(schema_meta, Mapping):
+        return _string_value(schema_meta.get("topic"))
+
+    return None
+
+
+def _policy_result(metadata: Mapping[str, Any]) -> str | None:
+    policy_result = _string_value(metadata.get("policy_result"))
+    if policy_result:
+        return policy_result.lower()
+
+    policy_data = metadata.get("policy")
+    if isinstance(policy_data, Mapping):
+        nested = _string_value(policy_data.get("result"))
+        if nested:
+            return nested.lower()
+
+    return None
+
+
+def _type_family(metadata: Mapping[str, Any], graph: Mapping[str, Any]) -> str:
+    metadata_family = _string_value(metadata.get("type_family"))
+    if metadata_family:
+        return metadata_family.lower()
+
+    event_type = _string_value(metadata.get("event_type"))
+    event_type_upper = event_type.upper() if event_type else ""
+
+    has_node_id = _string_value(graph.get("node_id")) is not None
+    has_target_node_id = _string_value(graph.get("target_node_id")) is not None
+    has_label = _string_value(graph.get("label")) is not None
+
+    if has_node_id and has_target_node_id and has_label:
+        return "edge"
+    if has_node_id:
+        return "node"
+
+    if any(keyword in event_type_upper for keyword in ("EDGE", "RELATION", "LINK")):
+        return "edge"
+    if any(keyword in event_type_upper for keyword in ("NODE", "DOCUMENT", "ENTITY", "RESEARCH")):
+        return "node"
+
+    return "unknown"
+
+
+def _string_value(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized if normalized else None

--- a/src/ume/pipeline/stream_processor.py
+++ b/src/ume/pipeline/stream_processor.py
@@ -9,48 +9,52 @@ except Exception:  # pragma: no cover - optional dependency missing
     faust = None  # type: ignore[assignment]
     StreamT = object  # type: ignore[assignment]
 import json
-from typing import Dict
 
-from ume import EventType, parse_event, EventError
-from ..events.contract import canonicalize_event
+from ume import EventError, parse_event
+
 from ..config import settings
+from ..events.contract import canonicalize_event
+from .router import route_event, router_config_from_settings
 
 IN_TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
-EDGE_TOPIC = settings.KAFKA_EDGE_TOPIC
-NODE_TOPIC = settings.KAFKA_NODE_TOPIC
-
-# Map event types to destination topics
-EVENT_TOPIC_MAP: Dict[str, str] = {
-    EventType.CREATE_EDGE.value: EDGE_TOPIC,
-    EventType.CREATE_NODE.value: NODE_TOPIC,
-}
 
 
 def build_app(broker: str = settings.KAFKA_BOOTSTRAP_SERVERS):
     """Create a Faust App instance."""
     if faust is None:  # pragma: no cover - optional dependency missing
         raise RuntimeError("faust-streaming is not installed")
+
+    router_config = router_config_from_settings()
     app = faust.App("ume_stream_processor", broker=broker)
     app.conf.web_enabled = False
 
     source_topic = app.topic(IN_TOPIC, value_type=bytes)
-    edge_topic = app.topic(EDGE_TOPIC, value_type=bytes)
-    node_topic = app.topic(NODE_TOPIC, value_type=bytes)
+    topic_by_name = {
+        topic_name: app.topic(topic_name, value_type=bytes)
+        for topic_name in {
+            router_config.node_topic,
+            router_config.edge_topic,
+            router_config.default_topic,
+            router_config.dead_letter_topic,
+        }
+    }
 
     @app.agent(source_topic)  # type: ignore[misc]
     async def _process(stream: StreamT[bytes]) -> None:
         async for raw in stream:
             try:
                 data = json.loads(raw.decode("utf-8"))
-                event = parse_event(canonicalize_event(data))
+                canonical = canonicalize_event(data)
+                parse_event(canonical)
             except (ValueError, EventError, json.JSONDecodeError):
                 continue
 
-            dest = EVENT_TOPIC_MAP.get(event.event_type)
-            if dest == EDGE_TOPIC:
-                await edge_topic.send(value=raw)
-            elif dest == NODE_TOPIC:
-                await node_topic.send(value=raw)
+            decision = route_event(canonical, router_config)
+            topic = topic_by_name.get(decision.topic)
+            if topic is None:
+                topic = app.topic(decision.topic, value_type=bytes)
+                topic_by_name[decision.topic] = topic
+            await topic.send(value=raw)
 
     return app
 

--- a/src/ume/stream_processor.py
+++ b/src/ume/stream_processor.py
@@ -1,60 +1,7 @@
-"""Backward compatibility wrapper for :mod:`ume.pipeline.stream_processor`."""
+"""Deprecated compatibility wrapper for :mod:`ume.pipeline.stream_processor`."""
 
 from __future__ import annotations
 
-import faust
-import json
-from typing import Dict, Any
+from .pipeline.stream_processor import app, build_app, main
 
-from ume import EventType, parse_event, EventError
-from ume.events.contract import canonicalize_event
-from .config import settings
-
-IN_TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
-EDGE_TOPIC = settings.KAFKA_EDGE_TOPIC
-NODE_TOPIC = settings.KAFKA_NODE_TOPIC
-
-# Map event types to destination topics
-EVENT_TOPIC_MAP: Dict[str, str] = {
-    EventType.CREATE_EDGE.value: EDGE_TOPIC,
-    EventType.CREATE_NODE.value: NODE_TOPIC,
-}
-
-
-def build_app(broker: str = settings.KAFKA_BOOTSTRAP_SERVERS) -> faust.App:
-    """Create a Faust App instance."""
-    app = faust.App("ume_stream_processor", broker=broker)
-    app.conf.web_enabled = False
-
-    source_topic = app.topic(IN_TOPIC, value_type=bytes)
-    edge_topic = app.topic(EDGE_TOPIC, value_type=bytes)
-    node_topic = app.topic(NODE_TOPIC, value_type=bytes)
-
-    @app.agent(source_topic)
-    async def _process(stream: Any) -> None:
-        async for raw in stream:
-            try:
-                data = json.loads(raw.decode("utf-8"))
-                event = parse_event(canonicalize_event(data))
-            except (ValueError, EventError, json.JSONDecodeError):
-                continue
-
-            dest = EVENT_TOPIC_MAP.get(event.event_type)
-            if dest == EDGE_TOPIC:
-                await edge_topic.send(value=raw)
-            elif dest == NODE_TOPIC:
-                await node_topic.send(value=raw)
-
-    return app
-
-
-app = build_app()
-
-
-def main() -> None:
-    app.main()
-
-
-if __name__ == "__main__":
-    main()
-
+__all__ = ["app", "build_app", "main"]

--- a/tests/test_pipeline_router.py
+++ b/tests/test_pipeline_router.py
@@ -1,0 +1,126 @@
+from ume.pipeline.router import RouterConfig, route_event
+
+
+def _canonical_event(
+    *,
+    event_type: str,
+    node_id: str | None = None,
+    target_node_id: str | None = None,
+    label: str | None = None,
+    type_family: str | None = None,
+    schema_version: str = "v1",
+    policy_result: str | None = None,
+    schema_topic: str | None = None,
+) -> dict:
+    metadata: dict = {
+        "event_type": event_type,
+        "timestamp": 1,
+        "schema_version": schema_version,
+    }
+    if type_family is not None:
+        metadata["type_family"] = type_family
+    if policy_result is not None:
+        metadata["policy_result"] = policy_result
+    if schema_topic is not None:
+        metadata["schema"] = {"topic": schema_topic}
+
+    return {
+        "metadata": metadata,
+        "graph": {
+            "node_id": node_id,
+            "target_node_id": target_node_id,
+            "label": label,
+        },
+        "payload": {},
+    }
+
+
+def test_routes_node_family_to_node_topic():
+    config = RouterConfig(
+        node_topic="ume_nodes",
+        edge_topic="ume_edges",
+        default_topic="ume_misc",
+        dead_letter_topic="ume_dlq",
+    )
+
+    decision = route_event(
+        _canonical_event(event_type="CREATE_NODE", node_id="n1"),
+        config,
+    )
+
+    assert decision.topic == "ume_nodes"
+    assert decision.family == "node"
+
+
+def test_routes_edge_family_to_edge_topic():
+    config = RouterConfig(
+        node_topic="ume_nodes",
+        edge_topic="ume_edges",
+        default_topic="ume_misc",
+        dead_letter_topic="ume_dlq",
+    )
+
+    decision = route_event(
+        _canonical_event(
+            event_type="CREATE_EDGE",
+            node_id="a",
+            target_node_id="b",
+            label="LIKES",
+        ),
+        config,
+    )
+
+    assert decision.topic == "ume_edges"
+    assert decision.family == "edge"
+
+
+def test_routes_unknown_family_to_fallback_topic():
+    config = RouterConfig(
+        node_topic="ume_nodes",
+        edge_topic="ume_edges",
+        default_topic="ume_misc",
+        dead_letter_topic="ume_dlq",
+    )
+
+    decision = route_event(_canonical_event(event_type="UNKNOWN_EVENT"), config)
+
+    assert decision.topic == "ume_misc"
+    assert decision.family == "unknown"
+
+
+def test_routes_custom_schema_topic_override():
+    config = RouterConfig(
+        node_topic="ume_nodes",
+        edge_topic="ume_edges",
+        default_topic="ume_misc",
+        dead_letter_topic="ume_dlq",
+    )
+
+    decision = route_event(
+        _canonical_event(event_type="TENANT_AUDIT", schema_topic="tenant-audit-topic"),
+        config,
+    )
+
+    assert decision.topic == "tenant-audit-topic"
+    assert decision.reason == "schema_topic"
+
+
+def test_routes_policy_deny_to_dead_letter():
+    config = RouterConfig(
+        node_topic="ume_nodes",
+        edge_topic="ume_edges",
+        default_topic="ume_misc",
+        dead_letter_topic="ume_dlq",
+    )
+
+    decision = route_event(
+        _canonical_event(
+            event_type="CREATE_NODE",
+            node_id="n1",
+            policy_result="DENIED",
+        ),
+        config,
+    )
+
+    assert decision.topic == "ume_dlq"
+    assert decision.reason == "policy_denied"

--- a/tests/test_stream_processor.py
+++ b/tests/test_stream_processor.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+
 from ume.pipeline.stream_processor import build_app
 
 
@@ -7,13 +8,24 @@ def _encoded(event: dict) -> bytes:
     return json.dumps(event).encode()
 
 
+def _topic_map(agent_fun) -> dict[str, object]:
+    assert agent_fun.__closure__ is not None
+    for cell in agent_fun.__closure__:
+        value = cell.cell_contents
+        if isinstance(value, dict) and value and all(
+            isinstance(k, str) and hasattr(v, "send") for k, v in value.items()
+        ):
+            return value
+    raise AssertionError("topic map closure not found")
+
+
 def test_stream_routing():
     app = build_app("kafka://dummy")
     agent = next(iter(app.agents.values()))
 
-    assert agent.fun.__closure__ is not None
-    edge_topic = agent.fun.__closure__[0].cell_contents
-    node_topic = agent.fun.__closure__[1].cell_contents
+    topic_map = _topic_map(agent.fun)
+    edge_topic = topic_map["ume_edges"]
+    node_topic = topic_map["ume_nodes"]
 
     edge_msgs: list[bytes] = []
     node_msgs: list[bytes] = []


### PR DESCRIPTION
### Motivation
- Move topic routing away from a brittle `EVENT_TOPIC_MAP` keyed by event type toward a semantic router that uses canonical metadata, schema hints, and policy results so new event kinds route predictably.
- Provide a configurable fallback and dead-letter topics for custom/unknown events and policy-denied events to improve operational correctness.

### Description
- Added a new router implementation at `src/ume/pipeline/router.py` exposing `RouterConfig`, `RoutingDecision`, `router_config_from_settings()` and `route_event()` to compute destinations from `metadata` and `graph` in the canonical envelope.
- Refactored the Faust stream processor at `src/ume/pipeline/stream_processor.py` to canonicalize and validate events, call `route_event(...)` for decisions, and publish to dynamically-managed topic objects including fallback and dead-letter topics.
- Replaced the legacy top-level `src/ume/stream_processor.py` with a minimal compatibility re-export that delegates to `ume.pipeline.stream_processor`.
- Added new configuration settings `KAFKA_ROUTING_FALLBACK_TOPIC` and `KAFKA_ROUTING_DEAD_LETTER_TOPIC`, updated docs (`docs/TOPIC_ROUTING.md`, `docs/CONFIG_TEMPLATES.md`), and added tests covering node/edge/unknown/custom-schema and policy-denied routing (`tests/test_pipeline_router.py`, updated `tests/test_stream_processor.py`).

### Testing
- Ran `ruff` on the changed files via `ruff check` and the run completed with all checks passing for the modified files.
- Ran unit tests via `pytest -q tests/test_stream_processor.py tests/test_pipeline_router.py` and all tests passed (`6 passed`).
- Ran `mypy` over the touched modules and it reported failures originating from pre-existing typing issues in `src/ume/events/contract.py`, which are unrelated to the routing changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb629eaa48326bcfac44f91431ed5)