### PR TITLE
Add unified ingress boundary for transport payload canonicalization and parsing

### DIFF
--- a/src/ume/async_graph_adapter.py
+++ b/src/ume/async_graph_adapter.py
@@ -9,8 +9,8 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 
 from .persistent_graph import PersistentGraph
 from .processing import ProcessingError, DEFAULT_VERSION
-from .event import Event, EventType, parse_event
-from .events.contract import canonicalize_event
+from .event import Event, EventType
+from .events.ingress import ingest_transport_payload
 from ._internal.listeners import get_registered_listeners
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
 from .graph_adapter import IGraphAdapter, AsyncAdapterMixin
@@ -223,17 +223,17 @@ async def ingest_event_async(
     graph: IAsyncGraphAdapter,
     *,
     schema_version: str | None = None,
+    event: Event | None = None,
 ) -> None:
-    """Validate ``data`` and apply the resulting event to ``graph`` asynchronously."""
-    if "event" in data and isinstance(data["event"], dict):
-        event_dict = cast(Dict[str, Any], data["event"])
-        detected_version = cast(str | None, data.get("schema_version"))
-    else:
-        event_dict = data
-        detected_version = cast(str | None, data.get("schema_version"))
-    event = parse_event(canonicalize_event(event_dict))
+    """Apply a canonical envelope/event pair to ``graph`` asynchronously."""
+    canonical = data
+    parsed_event = event
+    if parsed_event is None:
+        canonical, parsed_event = ingest_transport_payload(data)
+    metadata = canonical.get("metadata", {})
+    detected_version = cast(str | None, metadata.get("schema_version")) if isinstance(metadata, dict) else None
     effective_version = schema_version or detected_version or DEFAULT_VERSION
-    await apply_event_to_async_graph(event, graph, schema_version=effective_version)
+    await apply_event_to_async_graph(parsed_event, graph, schema_version=effective_version)
 
 
 __all__ = [

--- a/src/ume/consumer_demo.py
+++ b/src/ume/consumer_demo.py
@@ -13,8 +13,8 @@ from ume.logging_utils import configure_logging
 from ume.config import settings
 from ume.utils import ssl_config
 from confluent_kafka import Consumer, KafkaException, KafkaError
-from ume import parse_event, EventError  # Import parse_event and EventError
-from ume.events.contract import canonicalize_event
+from ume import EventError
+from ume.events.ingress import ingest_transport_payload
 from ume.embedding import generate_embedding
 
 configure_logging()
@@ -80,7 +80,7 @@ def main() -> None:
                     text_values = [v for v in payload.values() if isinstance(v, str)]
                     if text_values:
                         payload["embedding"] = generate_embedding(" ".join(text_values))
-                received_event = parse_event(canonicalize_event(event_data_dict))
+                _, received_event = ingest_transport_payload(event_data_dict, adapter="cli")
                 logger.info(f"Received event object: {received_event}")
             except json.JSONDecodeError as e:
                 logger.error(f"Failed to decode JSON: {data}, error: {e}")

--- a/src/ume/events/__init__.py
+++ b/src/ume/events/__init__.py
@@ -11,3 +11,4 @@ __all__ = [
     "canonical_to_legacy_dict",
     "canonical_to_camel_dict",
 ]
+

--- a/src/ume/events/ingress.py
+++ b/src/ume/events/ingress.py
@@ -1,0 +1,52 @@
+"""Ingress boundary for transport payload normalization and parsing."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Mapping, Literal
+
+from ..event import Event, parse_event
+from ..schema_utils import validate_canonical_event
+from .contract import canonicalize_event
+
+IngressAdapter = Literal["default", "kafka", "grpc", "cli"]
+
+
+def _legacy_transport_adapter(
+    payload: Mapping[str, Any],
+    *,
+    adapter: IngressAdapter,
+) -> Dict[str, Any]:
+    normalized = dict(payload)
+
+    if adapter in {"kafka", "cli"}:
+        if "nodeId" in normalized and "node_id" not in normalized:
+            normalized["node_id"] = normalized["nodeId"]
+        if "targetNodeId" in normalized and "target_node_id" not in normalized:
+            normalized["target_node_id"] = normalized["targetNodeId"]
+
+    if adapter == "grpc":
+        if "sourceService" in normalized and "source" not in normalized:
+            normalized["source"] = normalized["sourceService"]
+        if "schemaVersion" in normalized and "schema_version" not in normalized:
+            normalized["schema_version"] = normalized["schemaVersion"]
+
+    return normalized
+
+
+def ingest_transport_payload(
+    payload: Mapping[str, Any],
+    *,
+    adapter: IngressAdapter = "default",
+) -> tuple[Dict[str, Any], Event]:
+    """Normalize ``payload`` into canonical shape and parse an :class:`~ume.event.Event`."""
+
+    adapted = _legacy_transport_adapter(deepcopy(payload), adapter=adapter)
+    canonical = canonicalize_event(adapted)
+    validate_canonical_event(canonical)
+    event = parse_event(canonical)
+    return canonical, event
+
+
+__all__ = ["IngressAdapter", "ingest_transport_payload"]
+

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
 from confluent_kafka import Consumer, KafkaException, KafkaError
 
 from ..config import settings
 from ..utils import ssl_config
-from ..event import EventType
-from ..events.contract import canonical_to_camel_dict, canonicalize_event
+from ..event import EventError, EventType
+from ..events.contract import canonical_to_camel_dict
+from ..events.ingress import ingest_transport_payload
 from ..processing import apply_event_to_graph, ProcessingError
 from ..policy.pipeline import PolicyContext, PolicyDecision, build_default_policy_pipeline
 from ..event_ledger import event_ledger
@@ -76,7 +78,20 @@ def run_graph_consumer(
                     logger.error("Kafka error: %s", msg.error())
                 continue
 
-            context = PolicyContext(source="kafka_graph_consumer", raw_payload=msg.value())
+            try:
+                payload = json.loads(msg.value().decode("utf-8"))
+                canonical, event = ingest_transport_payload(payload, adapter="kafka")
+            except (ValueError, EventError, json.JSONDecodeError) as exc:
+                logger.error("Failed to parse Kafka payload: %s", exc)
+                continue
+
+            context = PolicyContext(
+                source="kafka_graph_consumer",
+                raw_payload=msg.value(),
+                transport_data=payload,
+                canonical_event=canonical,
+                event=event,
+            )
             decision = pipeline.evaluate(context)
             if decision.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
                 logger.warning("Policy blocked event at consumer: %s", decision.audit_event.reason)
@@ -86,12 +101,6 @@ def run_graph_consumer(
                     logger.error("Failed to update bookmark: %s", exc)
                 continue
 
-            event = context.event
-            canonical = context.canonical_event
-            if event is None or canonical is None:
-                logger.error("Policy pipeline did not produce a parsed event")
-                continue
-
             if event.event_type not in VALID_EVENT_TYPES:
                 try:
                     event_dict = {
@@ -99,7 +108,7 @@ def run_graph_consumer(
                         "timestamp": event.timestamp,
                         "payload": event.payload,
                     }
-                    event_ledger.append(msg.offset(), canonical_to_camel_dict(canonicalize_event(event_dict)))
+                    event_ledger.append(msg.offset(), canonical_to_camel_dict(ingest_transport_payload(event_dict)[0]))
                 except ValueError as exc:  # pragma: no cover - unlikely duplicate offset
                     logger.error("Ledger append failed: %s", exc)
                 try:

--- a/src/ume/pipeline/stream_processor.py
+++ b/src/ume/pipeline/stream_processor.py
@@ -10,10 +10,10 @@ except Exception:  # pragma: no cover - optional dependency missing
     StreamT = object  # type: ignore[assignment]
 import json
 
-from ume import EventError, parse_event
+from ume import EventError
 
 from ..config import settings
-from ..events.contract import canonicalize_event
+from ..events.ingress import ingest_transport_payload
 from .router import route_event, router_config_from_settings
 
 IN_TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
@@ -44,8 +44,7 @@ def build_app(broker: str = settings.KAFKA_BOOTSTRAP_SERVERS):
         async for raw in stream:
             try:
                 data = json.loads(raw.decode("utf-8"))
-                canonical = canonicalize_event(data)
-                parse_event(canonical)
+                canonical, _ = ingest_transport_payload(data, adapter="kafka")
             except (ValueError, EventError, json.JSONDecodeError):
                 continue
 

--- a/src/ume/policy/pipeline.py
+++ b/src/ume/policy/pipeline.py
@@ -88,6 +88,8 @@ class TransportValidationStage:
 
     def run(self, context: PolicyContext) -> Optional[PolicyResult]:
         try:
+            if context.canonical_event is not None and context.event is not None:
+                return None
             if context.transport_data is None:
                 if context.raw_payload is None:
                     raise ValueError("missing transport payload")

--- a/src/ume/schema_utils.py
+++ b/src/ume/schema_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from importlib import resources
-from typing import Any, Dict
+from typing import Any, Dict, Mapping
 from packaging.version import Version, InvalidVersion
 
 from .events.contract import canonicalize_event, canonical_to_camel_dict
@@ -64,6 +64,11 @@ def _load_schema(event_type: str) -> Dict[str, Any]:
 def validate_event_dict(event_data: Dict[str, Any]) -> None:
     """Validate transport event data after normalizing to canonical contract."""
     canonical = canonicalize_event(event_data)
+    validate_canonical_event(canonical)
+
+
+def validate_canonical_event(canonical: Mapping[str, Any]) -> None:
+    """Validate a canonical event envelope against contract and event-type schemas."""
     normalized = canonical_to_camel_dict(canonical)
 
     schema_version = canonical["metadata"].get("schema_version")

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -7,8 +7,9 @@ from typing import Iterable, Dict, Any, cast, TYPE_CHECKING
 from google.protobuf.json_format import MessageToDict
 from ume_client import events_pb2 as _events_pb2
 from google.protobuf import struct_pb2
-from ..event import Event, EventError, EventType, parse_event
-from ..events.contract import canonicalize_event, canonical_to_legacy_dict
+from ..event import Event, EventError, EventType
+from ..events.contract import canonical_to_legacy_dict
+from ..events.ingress import ingest_transport_payload
 from ..processing import DEFAULT_VERSION, apply_event_to_graph
 from ..graph_adapter import IGraphAdapter
 from ..async_graph_adapter import IAsyncGraphAdapter, ingest_event_async
@@ -41,11 +42,12 @@ __all__ = [
 
 def validate_event(data: Dict[str, Any]) -> Event:
     """Canonicalize and parse incoming transport data into :class:`~ume.event.Event`."""
-    context = PolicyContext(source="service_validate", transport_data=data)
+    canonical, event = ingest_transport_payload(data)
+    context = PolicyContext(source="service_validate", canonical_event=canonical, event=event)
     result = _policy_pipeline.evaluate(context)
-    if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE} or context.event is None:
+    if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
         raise EventError(result.audit_event.reason)
-    return context.event
+    return event
 
 
 def apply_event(
@@ -74,11 +76,13 @@ def _normalize_schema_version(value: Any) -> str | None:
     return None
 
 
-def ingest_event(
-    data: Dict[str, Any], graph: IGraphAdapter, *, schema_version: str | None = None
+def _ingest_canonical_event(
+    canonical: Dict[str, Any],
+    event: Event,
+    graph: IGraphAdapter,
+    *,
+    schema_version: str | None = None,
 ) -> None:
-    """Validate ``data``, classify it, and apply the resulting event to ``graph``."""
-    canonical = canonicalize_event(data)
     metadata = canonical["metadata"]
     unwrapped_event_data = canonical_to_legacy_dict(canonical)
     envelope_version = metadata.get("schema_version")
@@ -93,11 +97,10 @@ def ingest_event(
         or DEFAULT_VERSION
     )
 
-    context = PolicyContext(source="service_ingest", transport_data=data)
+    context = PolicyContext(source="service_ingest", canonical_event=canonical, event=event)
     policy_result = _policy_pipeline.evaluate(context)
-    if policy_result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE} or context.event is None:
+    if policy_result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
         raise EventError(policy_result.audit_event.reason)
-    event = context.event
 
     tag_results = classify_event(event)
     event.payload["classification"] = [
@@ -139,6 +142,14 @@ def ingest_event(
         )
 
 
+def ingest_event(
+    data: Dict[str, Any], graph: IGraphAdapter, *, schema_version: str | None = None
+) -> None:
+    """Validate ``data``, classify it, and apply the resulting event to ``graph``."""
+    canonical, event = ingest_transport_payload(data)
+    _ingest_canonical_event(canonical, event, graph, schema_version=schema_version)
+
+
 def ingest_events_batch(
     events: Iterable[Dict[str, Any]],
     graph: IGraphAdapter,
@@ -152,8 +163,7 @@ def ingest_events_batch(
 
 def dict_to_envelope(data: Dict[str, Any]) -> Any:
     """Convert a raw event dictionary to :class:`~ume_client.events_pb2.EventEnvelope`."""
-    canonical = canonicalize_event(data)
-    evt = parse_event(canonical)
+    canonical, evt = ingest_transport_payload(data, adapter="grpc")
     schema_version = _normalize_schema_version(canonical["metadata"].get("schema_version"))
     if not schema_version:
         schema_version = _fallback_schema_version()
@@ -228,11 +238,9 @@ def ingest_envelope(
     envelope: Any, graph: IGraphAdapter, *, schema_version: str | None = None
 ) -> None:
     """Ingest an :class:`EventEnvelope` into ``graph``."""
-    ingest_event(
-        envelope_to_event_dict(envelope),
-        graph,
-        schema_version=schema_version,
-    )
+    event_dict = envelope_to_event_dict(envelope)
+    canonical, event = ingest_transport_payload(event_dict, adapter="grpc")
+    _ingest_canonical_event(canonical, event, graph, schema_version=schema_version)
 
 
 async def ingest_envelope_async(
@@ -242,8 +250,11 @@ async def ingest_envelope_async(
     schema_version: str | None = None,
 ) -> None:
     """Asynchronously ingest an :class:`EventEnvelope` into ``graph``."""
+    event_dict = envelope_to_event_dict(envelope)
+    canonical, event = ingest_transport_payload(event_dict, adapter="grpc")
     await ingest_event_async(
-        envelope_to_event_dict(envelope),
+        canonical,
         graph,
         schema_version=schema_version,
+        event=event,
     )

--- a/tests/test_consumer_demo.py
+++ b/tests/test_consumer_demo.py
@@ -55,7 +55,11 @@ def test_consumer_demo_processes_messages(monkeypatch):
         consumer_demo, "KafkaError", SimpleNamespace(_PARTITION_EOF=None)
     )
     parsed = []
-    monkeypatch.setattr(consumer_demo, "parse_event", lambda d: parsed.append(d) or d)
+    def _fake_ingress(payload, adapter="default"):
+        parsed.append(payload)
+        return payload, payload
+
+    monkeypatch.setattr(consumer_demo, "ingest_transport_payload", _fake_ingress)
     monkeypatch.setattr(consumer_demo, "generate_embedding", lambda text: [0.0])
 
     consumer_demo.main()

--- a/tests/test_ingress_boundary_contract.py
+++ b/tests/test_ingress_boundary_contract.py
@@ -1,0 +1,44 @@
+from ume.events.ingress import ingest_transport_payload
+
+
+def test_ingress_paths_produce_identical_canonical_output() -> None:
+    kafka_payload = {
+        "eventId": "evt-1",
+        "eventType": "CREATE_EDGE",
+        "timestamp": 1700000000,
+        "nodeId": "n1",
+        "targetNodeId": "n2",
+        "label": "RELATES_TO",
+        "payload": {"weight": 1},
+        "sourceService": "producer",
+        "schemaVersion": "1.0.0",
+    }
+    grpc_payload = {
+        "eventId": "evt-1",
+        "eventType": "CREATE_EDGE",
+        "timestamp": 1700000000,
+        "node_id": "n1",
+        "target_node_id": "n2",
+        "label": "RELATES_TO",
+        "payload": {"weight": 1},
+        "sourceService": "producer",
+        "schemaVersion": "1.0.0",
+    }
+    cli_payload = {
+        "event_id": "evt-1",
+        "event_type": "CREATE_EDGE",
+        "timestamp": 1700000000,
+        "node_id": "n1",
+        "target_node_id": "n2",
+        "label": "RELATES_TO",
+        "payload": {"weight": 1},
+        "source": "producer",
+        "schema_version": "1.0.0",
+    }
+
+    kafka_canonical, kafka_event = ingest_transport_payload(kafka_payload, adapter="kafka")
+    grpc_canonical, grpc_event = ingest_transport_payload(grpc_payload, adapter="grpc")
+    cli_canonical, cli_event = ingest_transport_payload(cli_payload, adapter="cli")
+
+    assert kafka_canonical == grpc_canonical == cli_canonical
+    assert kafka_event == grpc_event == cli_event


### PR DESCRIPTION
### Motivation
- Centralize transport-specific normalization, canonicalization, JSON-schema validation and parsing to avoid duplicated logic across Kafka, gRPC, CLI and HTTP ingress paths.
- Ensure downstream layers only receive a validated canonical envelope and an `Event` object, and keep compatibility adapters at transport edges.

### Description
- Add a new ingress boundary module `src/ume/events/ingress.py` exposing `ingest_transport_payload(payload, adapter=...)` which adapts legacy transport keys, canonicalizes via `canonicalize_event`, validates the canonical envelope, and returns `(canonical_envelope, Event)`.
- Add `validate_canonical_event` in `src/ume/schema_utils.py` so canonical JSON-schema validation can be reused without re-normalizing transport data.
- Refactor ingestion call sites to use the new boundary: `src/ume/services/ingest.py` now consumes canonical/event pairs and consolidates ingestion logic into `_ingest_canonical_event`, `src/ume/pipeline/graph_consumer.py` and `src/ume/pipeline/stream_processor.py` use the ingress boundary at the Kafka edge, and `src/ume/consumer_demo.py` uses the ingress function for CLI/Kafka demo parsing.
- Update `TransportValidationStage` in `src/ume/policy/pipeline.py` to short-circuit when `PolicyContext` already contains `canonical_event` and `event` to avoid double-parsing.
- Make async ingestion helper `ingest_event_async` accept canonical/event inputs while remaining backward-compatible for existing callers in `src/ume/async_graph_adapter.py`.
- Add contract test `tests/test_ingress_boundary_contract.py` that replays equivalent Kafka/gRPC/CLI payloads and asserts identical canonical envelope and `Event` outputs, and update `tests/test_consumer_demo.py` to mock the new ingress boundary.

### Testing
- Ran linter checks with `ruff` on modified modules and tests and all checks passed.
- Ran targeted unit tests: `pytest -q tests/test_ingress_boundary_contract.py tests/test_consumer_demo.py tests/test_graph_consumer.py tests/test_stream_processor.py tests/test_async_graph_adapter.py` which completed with the expected passing/skipped tests (4 passed, 5 skipped) in this environment.
- Ran additional policy/consumer focused suites: `pytest -q tests/test_policy_pipeline_parity.py tests/test_graph_consumer.py tests/test_stream_processor.py tests/test_consumer_demo.py tests/test_ingress_boundary_contract.py` and observed successful runs (7 passed, 1 warning).
- Note: an initial collection error surfaced due to the test environment lacking a `google.protobuf` import path during an earlier run, which was addressed in subsequent changes and test re-runs succeeded as noted above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a18fef70348326960e178168419162)