### PR TITLE
Harden projection invalid-event handling and replay determinism

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -81,6 +81,9 @@ response on success.
 
 The standalone ingestion service listens on port `8001` and publishes raw events to Kafka.
 
+Deterministic projection behavior and invalid-event handling rules are documented in
+[`docs/PROJECTION_ENGINE.md`](PROJECTION_ENGINE.md).
+
 ### POST `/events` (ingestion)
 Validate the request body and forward the event to the `ume-raw-events` topic.
 

--- a/docs/PROJECTION_ENGINE.md
+++ b/docs/PROJECTION_ENGINE.md
@@ -2,6 +2,16 @@
 
 `ume.projection_engine` consumes sanitized events from Kafka and applies them to the configured graph adapter. It keeps the local graph in sync with the latest events published by the Privacy Agent.
 
+## Deterministic projection rules
+
+Projection is deterministic when the same ordered event stream is replayed:
+
+1. Events are parsed through the policy pipeline before projection.
+2. Any invalid event is mapped to one explicit outcome: `reject`, `quarantine`, or `dead_letter`.
+3. Invalid events are serialized into the event ledger as `REJECTED_EVENT` records for audit/replay parity.
+4. Graph state changes are performed only by `apply_event_to_graph` handler execution.
+5. Projection/replay skips unknown or otherwise non-applicable events and continues in offset order.
+
 ## Configuration
 
 The engine reads the following settings from `Settings`:

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -9,10 +9,14 @@ from confluent_kafka import Consumer, KafkaException, KafkaError
 from ..config import settings
 from ..utils import ssl_config
 from ..event import EventType
-from ..events.contract import canonical_to_camel_dict, canonicalize_event
 from ..processing import apply_event_to_graph, ProcessingError
 from ..policy.pipeline import PolicyContext, PolicyDecision, build_default_policy_pipeline
 from ..event_ledger import event_ledger
+from .invalid_events import (
+    build_rejected_event_ledger_entry,
+    outcome_for_policy_decision,
+    InvalidEventOutcome,
+)
 from ..graph_adapter import IGraphAdapter
 from ..logging_utils import configure_logging
 
@@ -61,6 +65,27 @@ def run_graph_consumer(
 
     pipeline = build_default_policy_pipeline(redactor=lambda payload: (payload, False))
 
+    def _record_invalid_event(
+        *,
+        offset: int,
+        outcome: InvalidEventOutcome,
+        reason: str,
+        context: PolicyContext,
+    ) -> None:
+        try:
+            event_ledger.append(
+                offset,
+                build_rejected_event_ledger_entry(
+                    outcome=outcome,
+                    reason=reason,
+                    source=context.source,
+                    canonical=context.canonical_event,
+                    event=context.event,
+                ),
+            )
+        except ValueError as exc:  # pragma: no cover - unlikely duplicate offset
+            logger.error("Ledger append failed: %s", exc)
+
     logger.info("Graph consumer started with group_id %s", gid)
     try:
         while True:
@@ -80,6 +105,12 @@ def run_graph_consumer(
             decision = pipeline.evaluate(context)
             if decision.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
                 logger.warning("Policy blocked event at consumer: %s", decision.audit_event.reason)
+                _record_invalid_event(
+                    offset=msg.offset(),
+                    outcome=outcome_for_policy_decision(decision.decision),
+                    reason=decision.audit_event.reason,
+                    context=context,
+                )
                 try:
                     event_ledger.update_bookmark(msg.offset())
                 except Exception as exc:  # pragma: no cover - unexpected errors
@@ -87,21 +118,17 @@ def run_graph_consumer(
                 continue
 
             event = context.event
-            canonical = context.canonical_event
-            if event is None or canonical is None:
+            if event is None or context.canonical_event is None:
                 logger.error("Policy pipeline did not produce a parsed event")
                 continue
 
             if event.event_type not in VALID_EVENT_TYPES:
-                try:
-                    event_dict = {
-                        "event_type": event.event_type,
-                        "timestamp": event.timestamp,
-                        "payload": event.payload,
-                    }
-                    event_ledger.append(msg.offset(), canonical_to_camel_dict(canonicalize_event(event_dict)))
-                except ValueError as exc:  # pragma: no cover - unlikely duplicate offset
-                    logger.error("Ledger append failed: %s", exc)
+                _record_invalid_event(
+                    offset=msg.offset(),
+                    outcome=InvalidEventOutcome.REJECT,
+                    reason=f"unknown_event_type:{event.event_type}",
+                    context=context,
+                )
                 try:
                     event_ledger.update_bookmark(msg.offset())
                 except Exception as exc:  # pragma: no cover - unexpected errors
@@ -113,18 +140,18 @@ def run_graph_consumer(
                 apply_event_to_graph(event, graph)
                 pipeline.audit_post_apply(context)
             except ProcessingError as exc:
-                if (
-                    event.event_type == EventType.CREATE_EDGE
-                    and "Unknown edge label" in str(exc)
-                    and isinstance(event.node_id, str)
-                    and isinstance(event.target_node_id, str)
-                    and isinstance(event.label, str)
-                ):
-                    graph.add_edge(event.node_id, event.target_node_id, event.label, {})
-                    pipeline.audit_post_apply(context)
-                else:
-                    logger.error("Event processing failed: %s", exc)
-                    continue
+                _record_invalid_event(
+                    offset=msg.offset(),
+                    outcome=InvalidEventOutcome.REJECT,
+                    reason=f"processing_error:{exc}",
+                    context=context,
+                )
+                logger.error("Event processing failed: %s", exc)
+                try:
+                    event_ledger.update_bookmark(msg.offset())
+                except Exception as bookmark_exc:  # pragma: no cover - unexpected errors
+                    logger.error("Failed to update bookmark: %s", bookmark_exc)
+                continue
             try:
                 event_ledger.update_bookmark(msg.offset())
             except Exception as exc:  # pragma: no cover - unexpected errors

--- a/src/ume/pipeline/invalid_events.py
+++ b/src/ume/pipeline/invalid_events.py
@@ -1,0 +1,60 @@
+"""Shared invalid-event outcomes and ledger serialization helpers."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Mapping
+
+from ..event import Event
+from ..events.contract import canonical_to_camel_dict
+from ..policy.pipeline import PolicyDecision
+
+
+class InvalidEventOutcome(str, Enum):
+    REJECT = "reject"
+    QUARANTINE = "quarantine"
+    DEAD_LETTER = "dead_letter"
+
+
+def outcome_for_policy_decision(decision: PolicyDecision) -> InvalidEventOutcome:
+    """Map policy decisions to explicit invalid-event outcomes."""
+
+    if decision == PolicyDecision.QUARANTINE:
+        return InvalidEventOutcome.QUARANTINE
+    if decision == PolicyDecision.DENY:
+        return InvalidEventOutcome.DEAD_LETTER
+    return InvalidEventOutcome.REJECT
+
+
+def build_rejected_event_ledger_entry(
+    *,
+    outcome: InvalidEventOutcome,
+    reason: str,
+    source: str,
+    canonical: Mapping[str, Any] | None,
+    event: Event | None,
+) -> dict[str, Any]:
+    """Build a deterministic rejected-event ledger payload."""
+
+    timestamp = 0
+    if event is not None and isinstance(event.timestamp, int):
+        timestamp = event.timestamp
+    elif isinstance(canonical, Mapping):
+        metadata = canonical.get("metadata")
+        if isinstance(metadata, Mapping) and isinstance(metadata.get("timestamp"), int):
+            timestamp = metadata["timestamp"]
+
+    original = canonical_to_camel_dict(canonical) if canonical is not None else None
+    return {
+        "eventType": "REJECTED_EVENT",
+        "timestamp": timestamp,
+        "payload": {
+            "outcome": outcome.value,
+            "reason": reason,
+            "source": source,
+            "original_event": original,
+            "original_event_id": event.event_id if event is not None else None,
+            "original_event_type": event.event_type if event is not None else None,
+        },
+    }
+

--- a/src/ume/replay.py
+++ b/src/ume/replay.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from .graph_adapter import IGraphAdapter
 from .policy.pipeline import PolicyContext, PolicyDecision, build_default_policy_pipeline
+from .processing_errors import ProcessingError
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .event_ledger import EventLedger
@@ -30,7 +31,10 @@ def replay_from_ledger(
         result = pipeline.evaluate(context)
         if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE} or context.event is None:
             continue
-        apply_event_to_graph(context.event, graph)
+        try:
+            apply_event_to_graph(context.event, graph)
+        except ProcessingError:
+            continue
         pipeline.audit_post_apply(context)
         last = off
     return last

--- a/tests/test_event_ledger.py
+++ b/tests/test_event_ledger.py
@@ -132,11 +132,11 @@ def test_build_graph_from_ledger_roundtrip(tmp_path):
             "timestamp": 3,
             "node_id": "a",
             "target_node_id": "b",
-            "label": "LINKS_TO",
+            "label": "TAGGED_AS",
             "payload": {},
         },
     )
 
     graph = build_graph_from_ledger(ledger)
     assert set(graph.get_all_node_ids()) == {"a", "b"}
-    assert ("a", "b", "LINKS_TO", {}) in graph.get_all_edges()
+    assert ("a", "b", "TAGGED_AS", {"schema_version": "3.0.0"}) in graph.get_all_edges()

--- a/tests/test_graph_consumer.py
+++ b/tests/test_graph_consumer.py
@@ -53,22 +53,25 @@ def test_graph_consumer_applies_events(tmp_path, monkeypatch: pytest.MonkeyPatch
     events = [
         {
             "eventType": "CREATE_NODE",
+            "eventId": "evt-1",
             "timestamp": 1,
             "nodeId": "n1",
             "payload": {"node_id": "n1"},
         },
         {
             "eventType": "CREATE_NODE",
+            "eventId": "evt-2",
             "timestamp": 1,
             "nodeId": "n2",
             "payload": {"node_id": "n2"},
         },
         {
             "eventType": "CREATE_EDGE",
+            "eventId": "evt-3",
             "timestamp": 1,
             "nodeId": "n1",
             "targetNodeId": "n2",
-            "label": "RELATES_TO",
+            "label": "TAGGED_AS",
             "payload": {},
         },
     ]
@@ -81,5 +84,52 @@ def test_graph_consumer_applies_events(tmp_path, monkeypatch: pytest.MonkeyPatch
 
     assert graph.node_exists("n1")
     assert graph.node_exists("n2")
-    assert ("n1", "n2", "RELATES_TO", {}) in graph.get_all_edges()
+    assert ("n1", "n2", "TAGGED_AS", {"schema_version": "3.0.0"}) in graph.get_all_edges()
     assert ledger.last_processed_offset == 2
+
+
+def test_graph_consumer_replay_is_deterministic_for_rejections(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events = [
+        {
+            "eventType": "CREATE_NODE",
+            "eventId": "det-1",
+            "timestamp": 1,
+            "nodeId": "n1",
+            "payload": {"node_id": "n1"},
+        },
+        {
+            "eventType": "CREATE_EDGE",
+            "eventId": "det-2",
+            "timestamp": 1,
+            "nodeId": "n1",
+            "targetNodeId": "n2",
+            "label": "UNKNOWN_LABEL",
+            "payload": {},
+        },
+        {
+            "eventType": "NOT_A_REAL_EVENT",
+            "eventId": "det-3",
+            "timestamp": 1,
+            "payload": {},
+        },
+    ]
+
+    def _run(db_name: str) -> tuple[dict, list[tuple[int, dict]]]:
+        ledger = EventLedger(str(tmp_path / db_name))
+        msgs = [DummyMessage(json.dumps(e).encode("utf-8"), i) for i, e in enumerate(events)]
+        consumer = DummyConsumer(msgs)
+        _patch_modules(monkeypatch, consumer, ledger)
+
+        graph = MockGraph()
+        graph_consumer.run_graph_consumer(graph)
+        rejected = [item for item in ledger.range() if item[1].get("eventType") == "REJECTED_EVENT"]
+        return graph.dump(), rejected
+
+    state_a, rejected_a = _run("ledger_a.db")
+    state_b, rejected_b = _run("ledger_b.db")
+
+    assert state_a == state_b
+    assert rejected_a == rejected_b
+    assert len(rejected_a) == 2


### PR DESCRIPTION
### Motivation

- Prevent ad-hoc schema-bypass mutations and make invalid-event outcomes explicit so projection and replay are deterministic and auditable.
- Centralize invalid-event handling and ensure all graph mutations flow only through the event handler (`apply_event_to_graph`).

### Description

- Removed the `Unknown edge label` schema-bypass fallback in `run_graph_consumer` so the consumer no longer performs direct `graph.add_edge` mutations. 
- Added `src/ume/pipeline/invalid_events.py` which defines `InvalidEventOutcome` (`reject`, `quarantine`, `dead_letter`) and `build_rejected_event_ledger_entry` to serialize rejected events deterministically.
- Updated `src/ume/pipeline/graph_consumer.py` to record policy-denied/quarantined, unknown-type, and processing-failed events into the `event_ledger` as `REJECTED_EVENT` records via the new helpers and to route outcomes via the policy context.
- Made replay resilient by catching `ProcessingError` in `src/ume/replay.py` so non-applicable ledger entries are skipped during replay, preserving deterministic replay semantics.
- Added a deterministic replay test `test_graph_consumer_replay_is_deterministic_for_rejections` and updated related expectations to use schema-valid labels and stable `eventId` values.
- Documented deterministic projection rules in `docs/PROJECTION_ENGINE.md` and added a cross-reference from the ingestion docs (`docs/API_REFERENCE.md`).

### Testing

- Ran `ruff check` on the modified files which passed. 
- Ran `PYTHONPATH=src pytest -q tests/test_graph_consumer.py tests/test_event_ledger.py` and the test suite for those files passed (`9 passed`).
- Attempted `mypy` on the repo which reported failures, but the failures are from pre-existing typing issues outside the changed files (e.g. `src/ume/events/contract.py` and `src/ume/processing.py`), not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19291ecd4832696303555edefa924)