### PR TITLE
Preserve original Event on redaction and add effective_event + audit payload hashes

### DIFF
--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import json
 import logging
 
+from jsonschema import ValidationError
 from confluent_kafka import Consumer, KafkaException, KafkaError
 
 from ..config import settings
 from ..utils import ssl_config
-from ..event import EventType
-from ..processing import apply_event_to_graph, ProcessingError
+from ..event import EventError, EventType
+from ..events.ingress import ingest_transport_payload
+from ..processing import ProcessingError, apply_event_to_graph
 from ..policy.pipeline import PolicyContext, PolicyDecision, build_default_policy_pipeline
 from ..event_ledger import event_ledger
 from .invalid_events import (
@@ -81,7 +83,7 @@ def run_graph_consumer(
                     reason=reason,
                     source=context.source,
                     canonical=context.canonical_event,
-                    event=context.event,
+                    event=context.original_event,
                 ),
             )
         except ValueError as exc:  # pragma: no cover - unlikely duplicate offset
@@ -104,9 +106,28 @@ def run_graph_consumer(
 
             try:
                 payload = json.loads(msg.value().decode("utf-8"))
-                canonical, event = ingest_transport_payload(payload, adapter="kafka")
-            except (ValueError, EventError, json.JSONDecodeError) as exc:
+            except (ValueError, json.JSONDecodeError) as exc:
                 logger.error("Failed to parse Kafka payload: %s", exc)
+                continue
+
+            try:
+                canonical, event = ingest_transport_payload(payload, adapter="kafka")
+            except (EventError, ValidationError, ValueError) as exc:
+                logger.error("Failed to parse Kafka payload: %s", exc)
+                _record_invalid_event(
+                    offset=msg.offset(),
+                    outcome=InvalidEventOutcome.REJECT,
+                    reason=f"transport_parse_error:{exc}",
+                    context=PolicyContext(
+                        source="kafka_graph_consumer",
+                        raw_payload=msg.value(),
+                        transport_data=payload,
+                    ),
+                )
+                try:
+                    event_ledger.update_bookmark(msg.offset())
+                except Exception as bookmark_exc:  # pragma: no cover - unexpected errors
+                    logger.error("Failed to update bookmark: %s", bookmark_exc)
                 continue
 
             context = PolicyContext(
@@ -114,7 +135,8 @@ def run_graph_consumer(
                 raw_payload=msg.value(),
                 transport_data=payload,
                 canonical_event=canonical,
-                event=event,
+                original_event=event,
+                effective_event=event,
             )
             decision = pipeline.evaluate(context)
             if decision.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
@@ -131,7 +153,7 @@ def run_graph_consumer(
                     logger.error("Failed to update bookmark: %s", exc)
                 continue
 
-            event = context.event
+            event = context.effective_event
             if event is None or context.canonical_event is None:
                 logger.error("Policy pipeline did not produce a parsed event")
                 continue

--- a/src/ume/policy/pipeline.py
+++ b/src/ume/policy/pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from hashlib import sha256
 from dataclasses import dataclass, field
 from enum import Enum
 from time import time
@@ -55,7 +56,8 @@ class PolicyContext:
     raw_payload: bytes | None = None
     transport_data: Dict[str, Any] | None = None
     canonical_event: Dict[str, Any] | None = None
-    event: Event | None = None
+    original_event: Event | None = None
+    effective_event: Event | None = None
     redacted: bool = False
     details: Dict[str, Any] = field(default_factory=dict)
 
@@ -67,6 +69,11 @@ class PolicyContext:
         if isinstance(payload, dict):
             return payload
         return {}
+
+    @property
+    def event(self) -> Event | None:
+        """Backward-compatible alias for the effective event."""
+        return self.effective_event
 
 
 @dataclass
@@ -88,7 +95,7 @@ class TransportValidationStage:
 
     def run(self, context: PolicyContext) -> Optional[PolicyResult]:
         try:
-            if context.canonical_event is not None and context.event is not None:
+            if context.canonical_event is not None and context.effective_event is not None:
                 return None
             if context.transport_data is None:
                 if context.raw_payload is None:
@@ -97,7 +104,9 @@ class TransportValidationStage:
 
             context.canonical_event = canonicalize_event(context.transport_data)
             validate_event_dict(canonical_to_camel_dict(context.canonical_event))
-            context.event = parse_event(context.canonical_event)
+            parsed = parse_event(context.canonical_event)
+            context.original_event = parsed
+            context.effective_event = parsed
         except (ValueError, TypeError, json.JSONDecodeError, ValidationError, EventError) as exc:
             return _result(
                 PolicyDecision.QUARANTINE,
@@ -133,7 +142,7 @@ class AlignmentStage:
         self._plugin_provider = plugin_provider
 
     def run(self, context: PolicyContext) -> Optional[PolicyResult]:
-        if context.event is None:
+        if context.effective_event is None:
             return _result(
                 PolicyDecision.QUARANTINE,
                 context,
@@ -142,7 +151,7 @@ class AlignmentStage:
             )
         try:
             for plugin in self._plugin_provider():
-                plugin.validate(context.event)
+                plugin.validate(context.effective_event)
         except PolicyViolationError as exc:
             return _result(
                 PolicyDecision.DENY,
@@ -169,9 +178,9 @@ class PiiRedactionStage:
             )
         payload = context.event_payload
         redacted, was_redacted = self._redactor(dict(payload))
-        context.canonical_event["payload"] = redacted
-        if context.event is not None:
-            object.__setattr__(context.event, "payload", redacted)
+        canonical = {**context.canonical_event, "payload": redacted}
+        context.canonical_event = canonical
+        context.effective_event = parse_event(canonical)
         context.redacted = was_redacted
         if was_redacted:
             return _result(
@@ -187,7 +196,7 @@ class AuditStage:
     name = "post_apply_auditing"
 
     def run(self, context: PolicyContext) -> Optional[PolicyResult]:
-        event = context.event
+        event = context.effective_event
         audit_event = PolicyAuditEvent(
             decision=PolicyDecision.ALLOW,
             stage=self.name,
@@ -195,7 +204,7 @@ class AuditStage:
             reason="mutation_applied",
             event_id=event.event_id if event else None,
             event_type=event.event_type if event else None,
-            details=context.details,
+            details={**_context_audit_details(context), **context.details},
         )
         logger.info("policy_audit_event=%s", json.dumps(audit_event.to_dict(), sort_keys=True))
         return PolicyResult(PolicyDecision.ALLOW, context, audit_event)
@@ -259,7 +268,12 @@ def _result(
     reason: str,
     details: Dict[str, Any] | None = None,
 ) -> PolicyResult:
-    event = context.event
+    event = context.effective_event
+    merged_details = {
+        **_context_audit_details(context),
+        **context.details,
+        **(details or {}),
+    }
     return PolicyResult(
         decision=decision,
         context=context,
@@ -270,9 +284,35 @@ def _result(
             reason=reason,
             event_id=event.event_id if event else None,
             event_type=event.event_type if event else None,
-            details=details or {},
+            details=merged_details,
         ),
     )
+
+
+def _payload_hash(payload: Dict[str, Any] | None) -> str | None:
+    if payload is None:
+        return None
+    stable = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return sha256(stable.encode("utf-8")).hexdigest()
+
+
+def _context_audit_details(context: PolicyContext) -> Dict[str, Any]:
+    original_payload = None
+    effective_payload = None
+    if context.original_event is not None:
+        original_payload = context.original_event.payload
+    if context.canonical_event is not None and isinstance(context.canonical_event.get("payload"), dict):
+        effective_payload = context.canonical_event["payload"]
+
+    return {
+        "original_event_id": context.original_event.event_id if context.original_event else None,
+        "original_event_type": context.original_event.event_type if context.original_event else None,
+        "effective_event_id": context.effective_event.event_id if context.effective_event else None,
+        "effective_event_type": context.effective_event.event_type if context.effective_event else None,
+        "original_payload_hash": _payload_hash(original_payload),
+        "effective_payload_hash": _payload_hash(effective_payload),
+        "redacted": context.redacted,
+    }
 
 
 def build_default_policy_pipeline(

--- a/src/ume/replay.py
+++ b/src/ume/replay.py
@@ -29,10 +29,10 @@ def replay_from_ledger(
             break
         context = PolicyContext(source="cli_replay", transport_data=data)
         result = pipeline.evaluate(context)
-        if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE} or context.event is None:
+        if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE} or context.effective_event is None:
             continue
         try:
-            apply_event_to_graph(context.event, graph)
+            apply_event_to_graph(context.effective_event, graph)
         except ProcessingError:
             continue
         pipeline.audit_post_apply(context)

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -43,11 +43,11 @@ __all__ = [
 def validate_event(data: Dict[str, Any]) -> Event:
     """Canonicalize and parse incoming transport data into :class:`~ume.event.Event`."""
     canonical, event = ingest_transport_payload(data)
-    context = PolicyContext(source="service_validate", canonical_event=canonical, event=event)
+    context = PolicyContext(source="service_validate", canonical_event=canonical, original_event=event, effective_event=event)
     result = _policy_pipeline.evaluate(context)
     if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
         raise EventError(result.audit_event.reason)
-    return event
+    return result.context.effective_event or event
 
 
 def apply_event(
@@ -97,13 +97,17 @@ def _ingest_canonical_event(
         or DEFAULT_VERSION
     )
 
-    context = PolicyContext(source="service_ingest", canonical_event=canonical, event=event)
+    context = PolicyContext(source="service_ingest", canonical_event=canonical, original_event=event, effective_event=event)
     policy_result = _policy_pipeline.evaluate(context)
     if policy_result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
         raise EventError(policy_result.audit_event.reason)
 
-    tag_results = classify_event(event)
-    event.payload["classification"] = [
+    effective_event = policy_result.context.effective_event
+    if effective_event is None:
+        raise EventError("policy_pipeline_missing_effective_event")
+
+    tag_results = classify_event(effective_event)
+    effective_event.payload["classification"] = [
         {
             "tag": r.tag,
             "confidence": r.confidence,
@@ -114,7 +118,7 @@ def _ingest_canonical_event(
         for r in tag_results
     ]
     if tag_results:
-        attributes = event.payload.setdefault("attributes", {})
+        attributes = effective_event.payload.setdefault("attributes", {})
         attributes["tags"] = [r.tag for r in tag_results]
         attributes["tag_confidence"] = [r.confidence for r in tag_results]
         for r in tag_results:
@@ -125,10 +129,10 @@ def _ingest_canonical_event(
             if r.sensitivity and "sensitivity" not in attributes:
                 attributes["sensitivity"] = r.sensitivity
 
-    apply_event(event, graph, schema_version=effective_version)
+    apply_event(effective_event, graph, schema_version=effective_version)
     _policy_pipeline.audit_post_apply(context)
 
-    anomaly_event = _anomaly_detector.process_event(event)
+    anomaly_event = _anomaly_detector.process_event(effective_event)
     if anomaly_event is not None:
         ingest_event(
             {

--- a/tests/test_policy_pipeline_redaction_identity.py
+++ b/tests/test_policy_pipeline_redaction_identity.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from ume.events.ingress import ingest_transport_payload
+from ume.policy.pipeline import PolicyContext, PolicyDecision, build_default_policy_pipeline
+
+
+def test_redaction_builds_new_effective_event_without_mutating_original_event(monkeypatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+    monkeypatch.setattr("ume.policy.pipeline.get_plugins", lambda: [])
+
+    event_data = {
+        "eventType": "CREATE_NODE",
+        "timestamp": 1,
+        "nodeId": "n1",
+        "payload": {"email": "user@example.com", "attributes": {"name": "Alice"}},
+    }
+    canonical, event = ingest_transport_payload(event_data)
+    original_payload_copy = dict(event.payload)
+
+    def _redactor(payload: dict[str, object]) -> tuple[dict[str, object], bool]:
+        return ({**payload, "email": "<REDACTED>"}, True)
+
+    context = PolicyContext(
+        source="service",
+        canonical_event=canonical,
+        original_event=event,
+        effective_event=event,
+    )
+    result = build_default_policy_pipeline(redactor=_redactor).evaluate(context)
+
+    assert result.decision == PolicyDecision.REDACTED
+    assert result.context.original_event is event
+    assert id(result.context.original_event) == id(event)
+    assert event.payload == original_payload_copy
+
+    assert result.context.effective_event is not None
+    assert result.context.effective_event is not event
+    assert result.context.effective_event.payload["email"] == "<REDACTED>"
+
+
+def test_redaction_audit_details_include_hashes_not_raw_payload(monkeypatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+    monkeypatch.setattr("ume.policy.pipeline.get_plugins", lambda: [])
+
+    def _redactor(payload: dict[str, object]) -> tuple[dict[str, object], bool]:
+        return ({**payload, "email": "<REDACTED>"}, True)
+
+    event_data = {
+        "eventType": "CREATE_NODE",
+        "timestamp": 1,
+        "nodeId": "n1",
+        "payload": {"email": "user@example.com", "attributes": {"name": "Alice"}},
+    }
+    result = build_default_policy_pipeline(redactor=_redactor).evaluate(
+        PolicyContext(source="service", transport_data=event_data)
+    )
+
+    details = result.audit_event.details
+    assert details["redacted"] is True
+    assert details["original_payload_hash"]
+    assert details["effective_payload_hash"]
+    assert details["original_payload_hash"] != details["effective_payload_hash"]
+    assert "email" not in details
+    assert "user@example.com" not in str(details)


### PR DESCRIPTION
### Motivation
- Prevent in-place mutation of parsed `Event` objects during PII redaction so callers can rely on original object identity and content. 
- Make policy processing explicit about which `Event` instance is the canonical/original vs the policy-effective (possibly redacted) event. 
- Avoid logging raw sensitive payload values in audit records by storing deterministic payload fingerprints instead. 

### Description
- Refactor `PolicyContext` to carry `original_event` and `effective_event` and add a backward-compatible `event` property alias for callers expecting the old attribute. 
- Update `PiiRedactionStage` to build a new canonical payload and reconstruct a fresh `Event` via `parse_event` instead of mutating the original `Event.payload`. 
- Enrich audit details with event metadata and payload hashes using `sha256` (fields: `original_payload_hash`, `effective_payload_hash`, `original_event_id`, `effective_event_id`, `redacted`) and merge these into stage audit `details`. 
- Propagate `effective_event` through downstream flows by updating `graph_consumer`, ingest service (`src/ume/services/ingest.py`), and replay path to process/apply `effective_event` while ledger/rejected-event helpers continue to reference the `original_event`. 
- Harden `graph_consumer` parsing error handling so transport-parse failures are recorded deterministically in the rejected-event ledger and bookmarks are updated. 
- Add unit tests `tests/test_policy_pipeline_redaction_identity.py` asserting that redaction constructs a new `effective_event`, preserves `original_event` identity/content, and that audit details include hashes rather than raw sensitive payloads. 

### Testing
- Ran `ruff` checks against the modified files which passed. 
- Ran targeted pytest suites `tests/test_policy_pipeline_parity.py`, `tests/test_policy_pipeline_redaction_identity.py`, and `tests/test_graph_consumer.py` and they passed (all tests in those runs succeeded). 
- Attempted broader test runs for ingestion-related suites but collection errored in this environment due to missing optional test dependencies (`google.protobuf`, `fastapi`), which are unrelated to the changes and prevented running those suites here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a19455e6908326a92bcef982e8e2c4)