### PR TITLE
Unify plugin registration for graph, integration, and vector backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -1374,7 +1374,8 @@ Install one of these packages to control tokenization behavior.
 Third-party packages can provide additional vector store implementations. These
 plugins are vector backends (not graph adapters) and must implement the
 :class:`ume.vector_store.VectorBackend` interface. Register them using
-:func:`ume.vector_backends.register_backend` or via the
+:func:`ume.vector_backends.register_backend` (which now uses the shared plugin
+registry contract) or via the
 ``ume.vector_backends`` entry point group. The
 ``examples/vector_backend_plugin.py`` example shows a minimal in-memory
 backend and how it is discovered by `create_vector_store()`:
@@ -1423,6 +1424,9 @@ memory = "yourpkg.memory_backend:MemoryBackend"
 
 Setting ``UME_VECTOR_BACKEND=memory`` will then use the plugin when creating a
 vector store.
+
+Use `ume-cli plugins` to inspect registered plugins across capabilities, or
+`ume-cli plugins --capability vector_backend` to filter by one capability.
 ## Running Tests
 
 Install development dependencies before running tests:

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -135,7 +135,8 @@ Third-party packages can provide additional vector store implementations.
 These are vector backends (not graph adapters). A backend must implement the
 `ume.vector_store.VectorBackend` interface and register itself using
 `ume.vector_backends.register_backend` or via the `ume.vector_backends` entry
-point group. The `examples/vector_backend_plugin.py` file demonstrates a
+point group. These registrations now use the same plugin contract as graph and
+integration adapters. The `examples/vector_backend_plugin.py` file demonstrates a
 minimal in-memory backend:
 
 ```python
@@ -182,6 +183,9 @@ memory = "yourpkg.memory_backend:MemoryBackend"
 
 Setting `UME_VECTOR_BACKEND=memory` will then use the plugin when creating a
 vector store through `create_vector_store()`.
+
+To inspect loaded plugins, run `ume-cli plugins` (optionally with
+`--capability vector_backend`, `graph_backend`, or `integration_adapter`).
 
 ## Custom Integration Adapters
 

--- a/src/ume/adapters/registry.py
+++ b/src/ume/adapters/registry.py
@@ -2,32 +2,45 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from importlib import import_module
-from importlib.metadata import entry_points
-from threading import Lock
 
 from ume.graph_adapter import IGraphAdapter
+from ume.plugins.registry import (
+    ConstructorMetadata,
+    PluginRegistrationError,
+    clear_plugins,
+    create_plugin,
+    discover_plugins_from_entry_points,
+    ensure_plugins_discovered,
+    get_plugin_constructor,
+    list_plugins,
+    register_lazy_plugin,
+    register_plugin,
+)
 
 GraphAdapterConstructor = Callable[[str | None], IGraphAdapter]
 LazyConstructorLoader = Callable[[], GraphAdapterConstructor]
 
-_BACKEND_CONSTRUCTORS: dict[str, GraphAdapterConstructor] = {}
-_LAZY_BACKENDS: dict[str, LazyConstructorLoader] = {}
-_DISCOVERY_LOCK = Lock()
-_EXTERNAL_DISCOVERED = False
+GRAPH_BACKEND_CAPABILITY = "graph_backend"
+GRAPH_BACKEND_ENTRYPOINT_GROUP = "ume.graph_adapters"
 
 
-class GraphAdapterRegistrationError(ValueError):
-    """Raised when adapter registration metadata is invalid."""
+class GraphAdapterRegistrationError(PluginRegistrationError):
+    """Raised when graph adapter registration metadata is invalid."""
 
 
 def register_graph_backend(name: str, constructor: GraphAdapterConstructor) -> None:
     """Register a graph backend constructor under ``name``."""
-    _BACKEND_CONSTRUCTORS[name.lower()] = constructor
+    register_plugin(GRAPH_BACKEND_CAPABILITY, name, constructor)
 
 
 def register_lazy_graph_backend(name: str, loader: LazyConstructorLoader) -> None:
     """Register a deferred loader for backend ``name``."""
-    _LAZY_BACKENDS[name.lower()] = loader
+    register_lazy_plugin(
+        GRAPH_BACKEND_CAPABILITY,
+        name,
+        loader,
+        metadata=ConstructorMetadata(lazy=True),
+    )
 
 
 def get_graph_backend_constructor(
@@ -36,16 +49,11 @@ def get_graph_backend_constructor(
     default: str | None = None,
 ) -> GraphAdapterConstructor:
     """Return constructor for ``name``, resolving lazy registrations on demand."""
-    key = name.lower()
-    constructor = _BACKEND_CONSTRUCTORS.get(key)
-    if constructor is None and key in _LAZY_BACKENDS:
-        constructor = _LAZY_BACKENDS.pop(key)()
-        _BACKEND_CONSTRUCTORS[key] = constructor
-    if constructor is not None:
-        return constructor
-    if default is not None and default.lower() != key:
-        return get_graph_backend_constructor(default)
-    raise ValueError(f"Unknown graph backend: {name}")
+    return get_plugin_constructor(
+        GRAPH_BACKEND_CAPABILITY,
+        name,
+        default=default,
+    )
 
 
 def create_registered_graph_adapter(
@@ -55,19 +63,25 @@ def create_registered_graph_adapter(
     default: str | None = None,
 ) -> IGraphAdapter:
     """Instantiate backend ``name`` using the registration table."""
-    constructor = get_graph_backend_constructor(name, default=default)
-    return constructor(db_path)
+    return create_plugin(
+        GRAPH_BACKEND_CAPABILITY,
+        name,
+        db_path,
+        default=default,
+    )
 
 
 def available_graph_backends() -> list[str]:
     """Return all known graph backend keys."""
-    return sorted(set(_BACKEND_CONSTRUCTORS) | set(_LAZY_BACKENDS))
+    return [
+        item["name"]
+        for item in list_plugins(capability=GRAPH_BACKEND_CAPABILITY)
+    ]
 
 
 def clear_graph_backend_registry() -> None:
     """Reset all registered and lazy graph backend constructors."""
-    _BACKEND_CONSTRUCTORS.clear()
-    _LAZY_BACKENDS.clear()
+    clear_plugins(capability=GRAPH_BACKEND_CAPABILITY)
 
 
 def _register_external_loaded_object(name: str, loaded: object) -> None:
@@ -89,11 +103,14 @@ def _register_external_loaded_object(name: str, loaded: object) -> None:
 
 def discover_graph_backends_from_entry_points(
     *,
-    group: str = "ume.graph_adapters",
+    group: str = GRAPH_BACKEND_ENTRYPOINT_GROUP,
 ) -> None:
     """Load external graph backend registrations from Python entry points."""
-    for ep in entry_points(group=group):
-        _register_external_loaded_object(ep.name, ep.load())
+    discover_plugins_from_entry_points(
+        capability=GRAPH_BACKEND_CAPABILITY,
+        group=group,
+        loader=_register_external_loaded_object,
+    )
 
 
 def discover_graph_backends_from_modules(module_paths: Iterable[str]) -> None:
@@ -124,11 +141,8 @@ def discover_external_graph_backends(*, module_paths: Iterable[str] = ()) -> Non
 
 def ensure_external_graph_backends_discovered(*, module_paths: Iterable[str] = ()) -> None:
     """Run external discovery once per process."""
-    global _EXTERNAL_DISCOVERED
-    if _EXTERNAL_DISCOVERED:
-        return
-    with _DISCOVERY_LOCK:
-        if _EXTERNAL_DISCOVERED:
-            return
-        discover_external_graph_backends(module_paths=module_paths)
-        _EXTERNAL_DISCOVERED = True
+    ensure_plugins_discovered(
+        capability=GRAPH_BACKEND_CAPABILITY,
+        group=GRAPH_BACKEND_ENTRYPOINT_GROUP,
+        discover=lambda: discover_external_graph_backends(module_paths=module_paths),
+    )

--- a/src/ume/integrations/registry.py
+++ b/src/ume/integrations/registry.py
@@ -1,26 +1,26 @@
 from __future__ import annotations
 
-from typing import Dict, Iterable
+from typing import Iterable
 
-_ADAPTERS: Dict[str, type] = {}
+from ume.plugins.registry import get_plugin_constructor, list_plugins, register_plugin
+
+
+INTEGRATION_CAPABILITY = "integration_adapter"
 
 
 def register_adapter(name: str, cls: type) -> None:
     """Register an integration adapter class under ``name``."""
-    _ADAPTERS[name.lower()] = cls
+    register_plugin(INTEGRATION_CAPABILITY, name, cls)
 
 
 def get_adapter(name: str) -> type:
     """Return the adapter class registered under ``name``."""
-    key = name.lower()
-    if key not in _ADAPTERS:
-        raise ValueError(f"Unknown integration adapter: {name}")
-    return _ADAPTERS[key]
+    return get_plugin_constructor(INTEGRATION_CAPABILITY, name)
 
 
 def available_adapters() -> Iterable[str]:
     """Return names of all registered adapters."""
-    return list(_ADAPTERS.keys())
+    return [item["name"] for item in list_plugins(capability=INTEGRATION_CAPABILITY)]
 
 
 def register_builtin_adapters() -> None:

--- a/src/ume/plugins/__init__.py
+++ b/src/ume/plugins/__init__.py
@@ -1,0 +1,28 @@
+"""Unified plugin registry helpers."""
+
+from .registry import (
+    ConstructorMetadata,
+    PluginRegistrationError,
+    clear_plugins,
+    create_plugin,
+    discover_plugins_from_entry_points,
+    ensure_plugins_discovered,
+    get_plugin_constructor,
+    list_plugins,
+    register_lazy_plugin,
+    register_plugin,
+)
+
+__all__ = [
+    "ConstructorMetadata",
+    "PluginRegistrationError",
+    "clear_plugins",
+    "create_plugin",
+    "discover_plugins_from_entry_points",
+    "ensure_plugins_discovered",
+    "get_plugin_constructor",
+    "list_plugins",
+    "register_lazy_plugin",
+    "register_plugin",
+]
+

--- a/src/ume/plugins/registry.py
+++ b/src/ume/plugins/registry.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from threading import Lock
+from typing import Any
+
+
+class PluginRegistrationError(ValueError):
+    """Raised when plugin registration metadata is invalid."""
+
+
+@dataclass(frozen=True)
+class ConstructorMetadata:
+    """Metadata describing how a plugin constructor was registered."""
+
+    source: str = "runtime"
+    entry_point_group: str | None = None
+    module_path: str | None = None
+    lazy: bool = False
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class _RegisteredPlugin:
+    capability: str
+    name: str
+    constructor: Callable[..., Any]
+    metadata: ConstructorMetadata
+
+
+_PLUGIN_CONSTRUCTORS: dict[str, dict[str, Callable[..., Any]]] = {}
+_LAZY_PLUGINS: dict[str, dict[str, Callable[[], Callable[..., Any]]]] = {}
+_PLUGIN_METADATA: dict[str, dict[str, ConstructorMetadata]] = {}
+_DISCOVERED_GROUPS: set[tuple[str, str]] = set()
+_DISCOVERY_LOCK = Lock()
+
+
+def register_plugin(
+    capability: str,
+    name: str,
+    constructor: Callable[..., Any],
+    *,
+    metadata: ConstructorMetadata | None = None,
+) -> None:
+    """Register a constructor under ``capability`` and ``name``."""
+    capability_key = capability.lower()
+    name_key = name.lower()
+    _PLUGIN_CONSTRUCTORS.setdefault(capability_key, {})[name_key] = constructor
+    _PLUGIN_METADATA.setdefault(capability_key, {})[name_key] = (
+        metadata or ConstructorMetadata()
+    )
+
+
+def register_lazy_plugin(
+    capability: str,
+    name: str,
+    loader: Callable[[], Callable[..., Any]],
+    *,
+    metadata: ConstructorMetadata | None = None,
+) -> None:
+    """Register a lazy constructor loader under ``capability`` and ``name``."""
+    capability_key = capability.lower()
+    name_key = name.lower()
+    _LAZY_PLUGINS.setdefault(capability_key, {})[name_key] = loader
+    _PLUGIN_METADATA.setdefault(capability_key, {})[name_key] = (
+        metadata or ConstructorMetadata(lazy=True)
+    )
+
+
+def get_plugin_constructor(
+    capability: str,
+    name: str,
+    *,
+    default: str | None = None,
+) -> Callable[..., Any]:
+    """Return a constructor for ``name``, resolving lazy entries on demand."""
+    capability_key = capability.lower()
+    key = name.lower()
+    constructors = _PLUGIN_CONSTRUCTORS.setdefault(capability_key, {})
+    lazy = _LAZY_PLUGINS.setdefault(capability_key, {})
+
+    constructor = constructors.get(key)
+    if constructor is None and key in lazy:
+        constructor = lazy.pop(key)()
+        constructors[key] = constructor
+        current = _PLUGIN_METADATA.setdefault(capability_key, {}).get(key)
+        if current is not None:
+            _PLUGIN_METADATA[capability_key][key] = ConstructorMetadata(
+                source=current.source,
+                entry_point_group=current.entry_point_group,
+                module_path=current.module_path,
+                lazy=False,
+                details=current.details,
+            )
+    if constructor is not None:
+        return constructor
+    if default is not None and default.lower() != key:
+        return get_plugin_constructor(capability, default)
+    raise ValueError(f"Unknown {capability} plugin: {name}")
+
+
+def create_plugin(
+    capability: str,
+    name: str,
+    *args: Any,
+    default: str | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Instantiate a registered plugin using ``*args`` and ``**kwargs``."""
+    constructor = get_plugin_constructor(capability, name, default=default)
+    return constructor(*args, **kwargs)
+
+
+def list_plugins(*, capability: str | None = None) -> list[dict[str, Any]]:
+    """List plugin names and constructor metadata."""
+    capabilities = [capability.lower()] if capability else sorted(_PLUGIN_METADATA)
+    listed: list[dict[str, Any]] = []
+    for capability_key in capabilities:
+        names = set(_PLUGIN_CONSTRUCTORS.get(capability_key, {})) | set(
+            _LAZY_PLUGINS.get(capability_key, {})
+        )
+        for name in sorted(names):
+            metadata = _PLUGIN_METADATA.get(capability_key, {}).get(name)
+            listed.append(
+                {
+                    "capability": capability_key,
+                    "name": name,
+                    "metadata": metadata or ConstructorMetadata(),
+                }
+            )
+    return listed
+
+
+def clear_plugins(*, capability: str | None = None) -> None:
+    """Clear all plugin registrations or only those for one capability."""
+    if capability is None:
+        _PLUGIN_CONSTRUCTORS.clear()
+        _LAZY_PLUGINS.clear()
+        _PLUGIN_METADATA.clear()
+        _DISCOVERED_GROUPS.clear()
+        return
+    capability_key = capability.lower()
+    _PLUGIN_CONSTRUCTORS.pop(capability_key, None)
+    _LAZY_PLUGINS.pop(capability_key, None)
+    _PLUGIN_METADATA.pop(capability_key, None)
+    _DISCOVERED_GROUPS.difference_update(
+        {item for item in _DISCOVERED_GROUPS if item[0] == capability_key}
+    )
+
+
+def discover_plugins_from_entry_points(
+    *,
+    capability: str,
+    group: str,
+    loader: Callable[[str, object], None] | None = None,
+) -> None:
+    """Discover plugins from the Python ``entry_points`` API."""
+    for ep in entry_points(group=group):
+        loaded = ep.load()
+        if loader is None:
+            if not callable(loaded):
+                raise PluginRegistrationError(
+                    f"Entry point '{ep.name}' must load a callable constructor"
+                )
+            register_plugin(
+                capability,
+                ep.name,
+                loaded,
+                metadata=ConstructorMetadata(source="entry_point", entry_point_group=group),
+            )
+            continue
+        loader(ep.name, loaded)
+
+
+def ensure_plugins_discovered(
+    *,
+    capability: str,
+    group: str,
+    discover: Callable[[], None],
+) -> None:
+    """Run discovery once per process for ``(capability, group)``."""
+    key = (capability.lower(), group)
+    if key in _DISCOVERED_GROUPS:
+        return
+    with _DISCOVERY_LOCK:
+        if key in _DISCOVERED_GROUPS:
+            return
+        discover()
+        _DISCOVERED_GROUPS.add(key)
+

--- a/src/ume/vector_backends/__init__.py
+++ b/src/ume/vector_backends/__init__.py
@@ -8,7 +8,6 @@ import os
 import numbers
 import time
 import threading
-from importlib import metadata
 
 import numpy as np
 from numpy.typing import NDArray
@@ -19,6 +18,13 @@ from typing import Any
 
 from ..vector_store import VectorBackend
 from typing import TYPE_CHECKING
+from ..plugins.registry import (
+    ConstructorMetadata,
+    discover_plugins_from_entry_points,
+    get_plugin_constructor,
+    list_plugins,
+    register_plugin,
+)
 
 faiss: Any
 try:  # optional dependency
@@ -52,40 +58,42 @@ else:  # pragma: no cover - optional dependency
 
 logger = logging.getLogger(__name__)
 
-_BACKENDS: Dict[str, type[VectorBackend]] = {}
+VECTOR_BACKEND_CAPABILITY = "vector_backend"
+ENTRYPOINT_GROUP = "ume.vector_backends"
 
 def register_backend(name: str, cls: type[VectorBackend]) -> None:
     """Register a vector backend class under ``name``."""
-    _BACKENDS[name.lower()] = cls
+    register_plugin(VECTOR_BACKEND_CAPABILITY, name, cls)
 
 def get_backend(name: str) -> type[VectorBackend]:
     """Return the backend class registered under ``name``."""
-    key = name.lower()
-    if key not in _BACKENDS:
-        raise ValueError(f"Unknown vector backend: {name}")
-    return _BACKENDS[key]
+    return get_plugin_constructor(VECTOR_BACKEND_CAPABILITY, name)
 
 def available_backends() -> Iterable[str]:
     """Return names of all registered backends."""
-    return list(_BACKENDS.keys())
-
-
-ENTRYPOINT_GROUP = "ume.vector_backends"
+    return [item["name"] for item in list_plugins(capability=VECTOR_BACKEND_CAPABILITY)]
 
 
 def load_entrypoints() -> None:
     """Load and register backends from ``ENTRYPOINT_GROUP`` entry points."""
-    try:
-        eps = metadata.entry_points(group=ENTRYPOINT_GROUP)
-    except Exception:
-        return
-    for ep in eps:
-        try:
-            cls = ep.load()
-        except Exception:  # pragma: no cover - import failures
-            logger.exception("Failed to load vector backend %s", ep.value)
-            continue
-        register_backend(ep.name, cls)
+    def _load(name: str, loaded: object) -> None:
+        if not callable(loaded):
+            raise TypeError(f"Vector backend entry point '{name}' is not callable")
+        register_plugin(
+            VECTOR_BACKEND_CAPABILITY,
+            name,
+            loaded,
+            metadata=ConstructorMetadata(
+                source="entry_point",
+                entry_point_group=ENTRYPOINT_GROUP,
+            ),
+        )
+
+    discover_plugins_from_entry_points(
+        capability=VECTOR_BACKEND_CAPABILITY,
+        group=ENTRYPOINT_GROUP,
+        loader=_load,
+    )
 
 
 class FaissBackend(VectorBackend):

--- a/tests/test_cli_plugins.py
+++ b/tests/test_cli_plugins.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+
+from ume.plugins.registry import clear_plugins, register_plugin
+
+
+class _Dummy:
+    pass
+
+
+def test_plugins_subcommand_outputs_registered_plugins(capsys, monkeypatch) -> None:
+    clear_plugins()
+    register_plugin("integration_adapter", "dummy", _Dummy)
+    monkeypatch.setattr(sys, "argv", ["ume_cli.py", "plugins", "--capability", "integration_adapter"])
+
+    from ume_cli import main
+
+    main()
+    captured = capsys.readouterr()
+    assert '"capability": "integration_adapter"' in captured.out
+    assert '"name": "dummy"' in captured.out

--- a/tests/test_graph_adapter_registry.py
+++ b/tests/test_graph_adapter_registry.py
@@ -13,14 +13,15 @@ from ume.adapters.registry import (
     discover_graph_backends_from_modules,
     register_graph_backend,
 )
+from ume.plugins.registry import clear_plugins
 from ume import factories
 
 
 @pytest.fixture(autouse=True)
 def _reset_registry_state(monkeypatch: pytest.MonkeyPatch) -> None:
     clear_graph_backend_registry()
+    clear_plugins()
     monkeypatch.setattr(bootstrap, "_BUILTINS_REGISTERED", False)
-    monkeypatch.setattr("ume.adapters.registry._EXTERNAL_DISCOVERED", False)
 
 
 class _Adapter:
@@ -83,7 +84,7 @@ def test_discover_graph_backends_from_entry_points(monkeypatch: pytest.MonkeyPat
             return _Adapter
 
     monkeypatch.setattr(
-        "ume.adapters.registry.entry_points",
+        "ume.plugins.registry.entry_points",
         lambda group: [_FakeEntryPoint()] if group == "ume.graph_adapters" else [],
     )
 

--- a/tests/test_integration_registry.py
+++ b/tests/test_integration_registry.py
@@ -1,13 +1,23 @@
+import pytest
+
 from ume.integrations.registry import (
+    INTEGRATION_CAPABILITY,
     register_adapter,
     get_adapter,
     register_builtin_adapters,
 )
 from ume.integrations.langgraph import LangGraph
+from ume.plugins.registry import clear_plugins
 
 
 class DummyAdapter:
     pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> None:
+    clear_plugins(capability=INTEGRATION_CAPABILITY)
+    register_builtin_adapters()
 
 
 def test_register_and_retrieve() -> None:

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from ume.plugins.registry import (
+    ConstructorMetadata,
+    clear_plugins,
+    list_plugins,
+    register_lazy_plugin,
+    register_plugin,
+)
+
+
+def test_list_plugins_filters_by_capability() -> None:
+    clear_plugins()
+    register_plugin("alpha", "one", lambda: 1)
+    register_plugin("beta", "two", lambda: 2)
+
+    alpha = list_plugins(capability="alpha")
+    assert [item["name"] for item in alpha] == ["one"]
+    assert alpha[0]["capability"] == "alpha"
+
+
+def test_list_plugins_includes_lazy_metadata() -> None:
+    clear_plugins()
+    register_lazy_plugin(
+        "graph_backend",
+        "neo4j",
+        lambda: (lambda _db_path: object()),
+        metadata=ConstructorMetadata(source="builtin", lazy=True),
+    )
+
+    plugins = list_plugins(capability="graph_backend")
+    assert plugins[0]["name"] == "neo4j"
+    assert plugins[0]["metadata"].lazy is True

--- a/tests/test_vector_backend_plugins.py
+++ b/tests/test_vector_backend_plugins.py
@@ -1,9 +1,10 @@
 import types
-import importlib.metadata as metadata
 import importlib
+from types import SimpleNamespace
 
 from ume.vector_backends import get_backend, available_backends, load_entrypoints
 from ume.vector_store import VectorBackend
+from ume.plugins.registry import clear_plugins
 
 
 class DummyBackend(VectorBackend):
@@ -37,8 +38,13 @@ def test_entrypoint_registration(monkeypatch):
     module.DummyBackend = DummyBackend
     monkeypatch.setitem(importlib.sys.modules, "dummy_mod", module)
 
-    ep = metadata.EntryPoint(name="dummy", value="dummy_mod:DummyBackend", group="ume.vector_backends")
-    monkeypatch.setattr(metadata, "entry_points", lambda group=None: (ep,) if group == "ume.vector_backends" else ())
+    ep = SimpleNamespace(name="dummy", load=lambda: DummyBackend)
+    monkeypatch.setattr(
+        "ume.plugins.registry.entry_points",
+        lambda group=None: (ep,) if group == "ume.vector_backends" else (),
+    )
+
+    clear_plugins(capability="vector_backend")
 
     load_entrypoints()
 
@@ -51,14 +57,9 @@ def test_backend_loaded_on_import(monkeypatch):
     module.DummyBackend = DummyBackend
     monkeypatch.setitem(importlib.sys.modules, "dummy_mod", module)
 
-    ep = metadata.EntryPoint(
-        name="dummy_imp",
-        value="dummy_mod:DummyBackend",
-        group="ume.vector_backends",
-    )
+    ep = SimpleNamespace(name="dummy_imp", load=lambda: DummyBackend)
     monkeypatch.setattr(
-        metadata,
-        "entry_points",
+        "ume.plugins.registry.entry_points",
         lambda group=None: (ep,) if group == "ume.vector_backends" else (),
     )
 

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -50,6 +50,30 @@ def _replay_graph(db_path: str | None, end_offset: int | None) -> None:
     location = f" at {db_path}" if db_path and db_path != ":memory:" else ""
     print(f"Rebuilt graph{location} with {node_count} nodes and {edge_count} edges")
 
+
+def _list_plugins(capability: str | None = None) -> None:
+    """Print plugin registrations with constructor metadata."""
+    from ume.plugins.registry import list_plugins
+
+    plugins = list_plugins(capability=capability)
+    payload = []
+    for item in plugins:
+        metadata = item["metadata"]
+        payload.append(
+            {
+                "capability": item["capability"],
+                "name": item["name"],
+                "metadata": {
+                    "source": metadata.source,
+                    "entry_point_group": metadata.entry_point_group,
+                    "module_path": metadata.module_path,
+                    "lazy": metadata.lazy,
+                    "details": metadata.details,
+                },
+            }
+        )
+    print(json.dumps(payload, indent=2))
+
 # Detect if a lightweight stub was injected for testing.
 _UME_STUB = not hasattr(ume, "__file__")
 
@@ -472,6 +496,12 @@ def main() -> None:
     replay_graph_parser.add_argument("--db-path", default=":memory:")
     replay_graph_parser.add_argument("--end-offset", type=int)
 
+    plugins_parser = sub.add_parser("plugins", help="List registered plugins")
+    plugins_parser.add_argument(
+        "--capability",
+        help="Filter by capability (graph_backend, integration_adapter, vector_backend)",
+    )
+
     dossier_parser = sub.add_parser("dossier", help="Manage dossiers")
     dossier_sub = dossier_parser.add_subparsers(dest="dossier_cmd")
     view_p = dossier_sub.add_parser("view", help="View a dossier")
@@ -577,6 +607,9 @@ def main() -> None:
             return
         if args.command == "replay-graph":
             _replay_graph(args.db_path, args.end_offset)
+            return
+        if args.command == "plugins":
+            _list_plugins(args.capability)
             return
         if args.command == "dossier":
             if args.dossier_cmd == "view":


### PR DESCRIPTION
### Motivation
- Provide a single, capability-scoped plugin contract with constructor metadata and lazy/eager registration to simplify and standardize how extensions (graph adapters, integration adapters, and vector backends) are discovered and instantiated.
- Preserve existing entry-point and module-based discovery semantics while making it easier to introspect and extend available plugins across the codebase.
- Replace ad-hoc per-backend registries with a unified API so documentation, CLI, and tests can rely on the same behavior and metadata model.

### Description
- Add a unified plugin registry at `src/ume/plugins/registry.py` that exposes `register_plugin`, `register_lazy_plugin`, `get_plugin_constructor`, `create_plugin`, `list_plugins`, `discover_plugins_from_entry_points`, `ensure_plugins_discovered`, `clear_plugins` and metadata type `ConstructorMetadata`.
- Introduce `src/ume/plugins/__init__.py` to re-export registry symbols for consumers.
- Migrate graph backend registration to the unified registry (`src/ume/adapters/registry.py`) while keeping the helper APIs (`register_graph_backend`, `register_lazy_graph_backend`, `get_graph_backend_constructor`, `create_registered_graph_adapter`, `available_graph_backends`, `ensure_external_graph_backends_discovered`) and preserving module/entry-point discovery (`ume.graph_adapters`).
- Migrate integration adapter registration to the registry model (`src/ume/integrations/registry.py`) and expose `INTEGRATION_CAPABILITY` with `register_adapter`, `get_adapter`, and `available_adapters` implemented on top of the unified contract.
- Route vector backend registration and entry-point loading through the same registry (`src/ume/vector_backends/__init__.py`), replacing the ad-hoc backend table and entry-point loader with capability-based registration and discovery (`ume.vector_backends` entry-point group).
- Add a CLI subcommand to inspect plugins: `ume-cli plugins [--capability ...]` (implemented in `ume_cli.py`) which prints unified plugin registrations and their constructor metadata.
- Update docs (`README.md`, `docs/INTEGRATIONS.md`) to mention the unified plugin registry and the `ume-cli plugins` introspection command.
- Add/adjust tests to validate the new registry and CLI integration: `tests/test_plugin_registry.py` and `tests/test_cli_plugins.py` were added, and `tests/test_vector_backend_plugins.py`, `tests/test_graph_adapter_registry.py`, and `tests/test_integration_registry.py` were updated to work with the unified registry and to reset plugin state between tests.

### Testing
- Ran static checks with `ruff check` on modified files and all checks passed.
- Compiled changed modules with `python -m compileall` to ensure syntax correctness and compilation succeeded.
- Ran targeted unit tests: `pytest -q tests/test_graph_adapter_registry.py tests/test_integration_registry.py tests/test_vector_backend_plugins.py tests/test_plugin_registry.py` and all tests passed (`11 passed`).
- Ran the CLI test `pytest -q tests/test_cli_plugins.py` and it passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a195e1a49483269ee3e34535d88773)