### PR TITLE
Unify event ingestion through a shared core orchestrator

### DIFF
--- a/src/ume/pipeline/core.py
+++ b/src/ume/pipeline/core.py
@@ -1,0 +1,217 @@
+"""Core event orchestrator shared by API, Kafka, and stream runtimes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Mapping
+
+from ..classification import classify_event
+from ..event import Event
+from ..events.ingress import ingest_transport_payload, IngressAdapter
+from ..policy.pipeline import (
+    PolicyContext,
+    PolicyDecision,
+    PolicyPipeline,
+    build_default_policy_pipeline,
+)
+from ..processing import ProcessingError
+
+
+class PipelineOutcome(str, Enum):
+    APPLIED = "applied"
+    REJECTED = "rejected"
+    QUARANTINED = "quarantined"
+    REDACTED = "redacted"
+
+
+@dataclass
+class PipelineEnvelope:
+    """Shared orchestration result used for observability and DLQ routing."""
+
+    outcome: PipelineOutcome
+    source: str
+    stage: str
+    reason: str
+    canonical_event: dict[str, Any] | None = None
+    event: Event | None = None
+    policy_decision: PolicyDecision | None = None
+    redacted: bool = False
+    details: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def event_id(self) -> str | None:
+        return self.event.event_id if self.event is not None else None
+
+    @property
+    def event_type(self) -> str | None:
+        return self.event.event_type if self.event is not None else None
+
+
+Projector = Callable[[PolicyContext], dict[str, Any] | None]
+Auditor = Callable[[PipelineEnvelope], None]
+
+
+class EventPipelineOrchestrator:
+    """Decode → normalize → validate → policy → project → audit."""
+
+    def __init__(
+        self,
+        *,
+        policy_pipeline: PolicyPipeline | None = None,
+    ) -> None:
+        self._policy_pipeline = policy_pipeline or build_default_policy_pipeline(
+            redactor=lambda payload: (payload, False)
+        )
+
+    def run(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        source: str,
+        adapter: IngressAdapter = "default",
+        raw_payload: bytes | None = None,
+        projector: Projector | None = None,
+        auditor: Auditor | None = None,
+    ) -> PipelineEnvelope:
+        # decode
+        try:
+            decoded = dict(payload)
+        except Exception as exc:
+            return PipelineEnvelope(
+                outcome=PipelineOutcome.REJECTED,
+                source=source,
+                stage="decode",
+                reason=f"decode_failed:{exc}",
+            )
+
+        # normalize + validate
+        try:
+            canonical, event = ingest_transport_payload(decoded, adapter=adapter)
+        except Exception as exc:
+            return PipelineEnvelope(
+                outcome=PipelineOutcome.QUARANTINED,
+                source=source,
+                stage="validate",
+                reason=f"transport_validation_failed:{exc}",
+                details={"raw_payload_present": raw_payload is not None},
+            )
+
+        # policy
+        context = PolicyContext(
+            source=source,
+            raw_payload=raw_payload,
+            transport_data=decoded,
+            canonical_event=canonical,
+            original_event=event,
+            effective_event=event,
+        )
+        policy_result = self._policy_pipeline.evaluate(context)
+        if policy_result.decision == PolicyDecision.DENY:
+            return PipelineEnvelope(
+                outcome=PipelineOutcome.REJECTED,
+                source=source,
+                stage="policy",
+                reason=policy_result.audit_event.reason,
+                canonical_event=context.canonical_event,
+                event=context.effective_event,
+                policy_decision=policy_result.decision,
+            )
+        if policy_result.decision == PolicyDecision.QUARANTINE:
+            return PipelineEnvelope(
+                outcome=PipelineOutcome.QUARANTINED,
+                source=source,
+                stage="policy",
+                reason=policy_result.audit_event.reason,
+                canonical_event=context.canonical_event,
+                event=context.effective_event,
+                policy_decision=policy_result.decision,
+            )
+
+        provisional_outcome = PipelineOutcome.REDACTED if policy_result.decision == PolicyDecision.REDACTED else PipelineOutcome.APPLIED
+
+        # project
+        if context.effective_event is None:
+            return PipelineEnvelope(
+                outcome=PipelineOutcome.QUARANTINED,
+                source=source,
+                stage="project",
+                reason="effective_event_missing",
+                canonical_event=context.canonical_event,
+                policy_decision=policy_result.decision,
+            )
+
+        details: dict[str, Any] = {}
+        if projector is not None:
+            try:
+                projected = projector(context)
+                if projected:
+                    details.update(projected)
+            except ProcessingError as exc:
+                return PipelineEnvelope(
+                    outcome=PipelineOutcome.REJECTED,
+                    source=source,
+                    stage="project",
+                    reason=f"processing_error:{exc}",
+                    canonical_event=context.canonical_event,
+                    event=context.effective_event,
+                    policy_decision=policy_result.decision,
+                )
+            except Exception as exc:
+                return PipelineEnvelope(
+                    outcome=PipelineOutcome.REJECTED,
+                    source=source,
+                    stage="project",
+                    reason=f"projection_failed:{exc}",
+                    canonical_event=context.canonical_event,
+                    event=context.effective_event,
+                    policy_decision=policy_result.decision,
+                )
+
+        # audit
+        self._policy_pipeline.audit_post_apply(context)
+        envelope = PipelineEnvelope(
+            outcome=provisional_outcome,
+            source=source,
+            stage="audit",
+            reason="mutation_applied",
+            canonical_event=context.canonical_event,
+            event=context.effective_event,
+            policy_decision=policy_result.decision,
+            redacted=provisional_outcome == PipelineOutcome.REDACTED,
+            details=details,
+        )
+        if auditor is not None:
+            auditor(envelope)
+        return envelope
+
+
+def apply_classification(context: PolicyContext) -> dict[str, Any]:
+    """Annotate event payload with classification metadata."""
+
+    event = context.effective_event
+    if event is None:
+        return {}
+    tag_results = classify_event(event)
+    event.payload["classification"] = [
+        {
+            "tag": r.tag,
+            "confidence": r.confidence,
+            "domain": r.domain,
+            "subdomain": r.subdomain,
+            "sensitivity": r.sensitivity,
+        }
+        for r in tag_results
+    ]
+    if tag_results:
+        attributes = event.payload.setdefault("attributes", {})
+        attributes["tags"] = [r.tag for r in tag_results]
+        attributes["tag_confidence"] = [r.confidence for r in tag_results]
+        for r in tag_results:
+            if r.domain and "domain" not in attributes:
+                attributes["domain"] = r.domain
+            if r.subdomain and "subdomain" not in attributes:
+                attributes["subdomain"] = r.subdomain
+            if r.sensitivity and "sensitivity" not in attributes:
+                attributes["sensitivity"] = r.sensitivity
+    return {"classification_count": len(tag_results)}

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -5,23 +5,17 @@ from __future__ import annotations
 import json
 import logging
 
-from jsonschema import ValidationError
 from confluent_kafka import Consumer, KafkaException, KafkaError
 
 from ..config import settings
-from ..utils import ssl_config
-from ..event import EventError, EventType
-from ..events.ingress import ingest_transport_payload
-from ..processing import ProcessingError, apply_event_to_graph
-from ..policy.pipeline import PolicyContext, PolicyDecision, build_default_policy_pipeline
+from ..event import EventType
 from ..event_ledger import event_ledger
-from .invalid_events import (
-    build_rejected_event_ledger_entry,
-    outcome_for_policy_decision,
-    InvalidEventOutcome,
-)
 from ..graph_adapter import IGraphAdapter
 from ..logging_utils import configure_logging
+from ..processing import apply_event_to_graph
+from ..utils import ssl_config
+from .core import EventPipelineOrchestrator, PipelineEnvelope, PipelineOutcome
+from .invalid_events import build_rejected_event_ledger_entry, outcome_for_pipeline_outcome
 
 
 configure_logging()
@@ -31,8 +25,6 @@ BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
 NODE_TOPIC = settings.KAFKA_NODE_TOPIC
 EDGE_TOPIC = settings.KAFKA_EDGE_TOPIC
 DEFAULT_GROUP_ID = settings.KAFKA_GROUP_ID
-# Include newly introduced event types such as RESEARCH_JOB_STARTED and
-# ENTITY_DISCOVERED so the consumer treats them as first-class events.
 VALID_EVENT_TYPES = {e.value for e in EventType}
 
 
@@ -66,24 +58,18 @@ def run_graph_consumer(
             return
         owns_consumer = True
 
-    pipeline = build_default_policy_pipeline(redactor=lambda payload: (payload, False))
+    orchestrator = EventPipelineOrchestrator()
 
-    def _record_invalid_event(
-        *,
-        offset: int,
-        outcome: InvalidEventOutcome,
-        reason: str,
-        context: PolicyContext,
-    ) -> None:
+    def _record_invalid_event(*, offset: int, envelope: PipelineEnvelope) -> None:
         try:
             event_ledger.append(
                 offset,
                 build_rejected_event_ledger_entry(
-                    outcome=outcome,
-                    reason=reason,
-                    source=context.source,
-                    canonical=context.canonical_event,
-                    event=context.original_event,
+                    outcome=outcome_for_pipeline_outcome(envelope.outcome),
+                    reason=envelope.reason,
+                    source=envelope.source,
+                    canonical=envelope.canonical_event,
+                    event=envelope.event,
                 ),
             )
         except ValueError as exc:  # pragma: no cover - unlikely duplicate offset
@@ -110,84 +96,32 @@ def run_graph_consumer(
                 logger.error("Failed to parse Kafka payload: %s", exc)
                 continue
 
-            try:
-                canonical, event = ingest_transport_payload(payload, adapter="kafka")
-            except (EventError, ValidationError, ValueError) as exc:
-                logger.error("Failed to parse Kafka payload: %s", exc)
-                _record_invalid_event(
-                    offset=msg.offset(),
-                    outcome=InvalidEventOutcome.REJECT,
-                    reason=f"transport_parse_error:{exc}",
-                    context=PolicyContext(
-                        source="kafka_graph_consumer",
-                        raw_payload=msg.value(),
-                        transport_data=payload,
-                    ),
-                )
-                try:
-                    event_ledger.update_bookmark(msg.offset())
-                except Exception as bookmark_exc:  # pragma: no cover - unexpected errors
-                    logger.error("Failed to update bookmark: %s", bookmark_exc)
-                continue
-
-            context = PolicyContext(
-                source="kafka_graph_consumer",
-                raw_payload=msg.value(),
-                transport_data=payload,
-                canonical_event=canonical,
-                original_event=event,
-                effective_event=event,
-            )
-            decision = pipeline.evaluate(context)
-            if decision.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
-                logger.warning("Policy blocked event at consumer: %s", decision.audit_event.reason)
-                _record_invalid_event(
-                    offset=msg.offset(),
-                    outcome=outcome_for_policy_decision(decision.decision),
-                    reason=decision.audit_event.reason,
-                    context=context,
-                )
-                try:
-                    event_ledger.update_bookmark(msg.offset())
-                except Exception as exc:  # pragma: no cover - unexpected errors
-                    logger.error("Failed to update bookmark: %s", exc)
-                continue
-
-            event = context.effective_event
-            if event is None or context.canonical_event is None:
-                logger.error("Policy pipeline did not produce a parsed event")
-                continue
-
-            if event.event_type not in VALID_EVENT_TYPES:
-                _record_invalid_event(
-                    offset=msg.offset(),
-                    outcome=InvalidEventOutcome.REJECT,
-                    reason=f"unknown_event_type:{event.event_type}",
-                    context=context,
-                )
-                try:
-                    event_ledger.update_bookmark(msg.offset())
-                except Exception as exc:  # pragma: no cover - unexpected errors
-                    logger.error("Failed to update bookmark: %s", exc)
-                logger.warning("Unknown event type '%s' skipped", event.event_type)
-                continue
-
-            try:
+            def _project(context):
+                event = context.effective_event
+                if event is None:
+                    raise ValueError("effective_event_missing")
+                if event.event_type not in VALID_EVENT_TYPES:
+                    raise ValueError(f"unknown_event_type:{event.event_type}")
                 apply_event_to_graph(event, graph)
-                pipeline.audit_post_apply(context)
-            except ProcessingError as exc:
-                _record_invalid_event(
-                    offset=msg.offset(),
-                    outcome=InvalidEventOutcome.REJECT,
-                    reason=f"processing_error:{exc}",
-                    context=context,
-                )
-                logger.error("Event processing failed: %s", exc)
+                return {}
+
+            envelope = orchestrator.run(
+                payload,
+                source="kafka_graph_consumer",
+                adapter="kafka",
+                raw_payload=msg.value(),
+                projector=_project,
+            )
+
+            if envelope.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
+                _record_invalid_event(offset=msg.offset(), envelope=envelope)
                 try:
                     event_ledger.update_bookmark(msg.offset())
-                except Exception as bookmark_exc:  # pragma: no cover - unexpected errors
-                    logger.error("Failed to update bookmark: %s", bookmark_exc)
+                except Exception as exc:  # pragma: no cover - unexpected errors
+                    logger.error("Failed to update bookmark: %s", exc)
+                logger.warning("Event rejected at %s stage: %s", envelope.stage, envelope.reason)
                 continue
+
             try:
                 event_ledger.update_bookmark(msg.offset())
             except Exception as exc:  # pragma: no cover - unexpected errors

--- a/src/ume/pipeline/invalid_events.py
+++ b/src/ume/pipeline/invalid_events.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 from ..event import Event
 from ..events.contract import canonical_to_camel_dict
 from ..policy.pipeline import PolicyDecision
+from .core import PipelineOutcome
 
 
 class InvalidEventOutcome(str, Enum):
@@ -58,3 +59,13 @@ def build_rejected_event_ledger_entry(
         },
     }
 
+
+
+def outcome_for_pipeline_outcome(outcome: PipelineOutcome) -> InvalidEventOutcome:
+    if outcome == PipelineOutcome.QUARANTINED:
+        return InvalidEventOutcome.QUARANTINE
+    if outcome == PipelineOutcome.REJECTED:
+        return InvalidEventOutcome.REJECT
+    if outcome == PipelineOutcome.REDACTED:
+        return InvalidEventOutcome.REJECT
+    return InvalidEventOutcome.REJECT

--- a/src/ume/pipeline/stream_processor.py
+++ b/src/ume/pipeline/stream_processor.py
@@ -10,10 +10,8 @@ except Exception:  # pragma: no cover - optional dependency missing
     StreamT = object  # type: ignore[assignment]
 import json
 
-from ume import EventError
-
 from ..config import settings
-from ..events.ingress import ingest_transport_payload
+from .core import EventPipelineOrchestrator, PipelineOutcome
 from .router import route_event, router_config_from_settings
 
 IN_TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
@@ -25,6 +23,7 @@ def build_app(broker: str = settings.KAFKA_BOOTSTRAP_SERVERS):
         raise RuntimeError("faust-streaming is not installed")
 
     router_config = router_config_from_settings()
+    orchestrator = EventPipelineOrchestrator()
     app = faust.App("ume_stream_processor", broker=broker)
     app.conf.web_enabled = False
 
@@ -44,11 +43,30 @@ def build_app(broker: str = settings.KAFKA_BOOTSTRAP_SERVERS):
         async for raw in stream:
             try:
                 data = json.loads(raw.decode("utf-8"))
-                canonical, _ = ingest_transport_payload(data, adapter="kafka")
-            except (ValueError, EventError, json.JSONDecodeError):
+            except (ValueError, json.JSONDecodeError):
                 continue
 
-            decision = route_event(canonical, router_config)
+            envelope = orchestrator.run(
+                data,
+                source="faust_stream_processor",
+                adapter="kafka",
+                raw_payload=raw,
+            )
+            if envelope.canonical_event is None:
+                decision = route_event({}, router_config)
+            elif envelope.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
+                decision = route_event(
+                    {
+                        "metadata": {
+                            "policy_result": envelope.outcome.value,
+                            "event_type": envelope.event_type,
+                        },
+                        "graph": {},
+                    },
+                    router_config,
+                )
+            else:
+                decision = route_event(envelope.canonical_event, router_config)
             topic = topic_by_name.get(decision.topic)
             if topic is None:
                 topic = app.topic(decision.topic, value_type=bytes)

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -13,10 +13,13 @@ from ..events.ingress import ingest_transport_payload
 from ..processing import DEFAULT_VERSION, apply_event_to_graph
 from ..graph_adapter import IGraphAdapter
 from ..async_graph_adapter import IAsyncGraphAdapter, ingest_event_async
-from ..classification import classify_event
 from ..anomaly_detection import AnomalyDetector
 from ..schema_manager import DEFAULT_SCHEMA_MANAGER
-from ..policy.pipeline import PolicyContext, PolicyDecision, build_default_policy_pipeline
+from ..pipeline.core import (
+    EventPipelineOrchestrator,
+    PipelineOutcome,
+    apply_classification,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing import for mypy
     from ume_client import events_pb2 as events_pb2_type
@@ -26,7 +29,7 @@ else:
 events_pb2 = cast(Any, _events_pb2)
 
 _anomaly_detector = AnomalyDetector()
-_policy_pipeline = build_default_policy_pipeline(redactor=lambda payload: (payload, False))
+_orchestrator = EventPipelineOrchestrator()
 
 __all__ = [
     "validate_event",
@@ -43,11 +46,10 @@ __all__ = [
 def validate_event(data: Dict[str, Any]) -> Event:
     """Canonicalize and parse incoming transport data into :class:`~ume.event.Event`."""
     canonical, event = ingest_transport_payload(data)
-    context = PolicyContext(source="service_validate", canonical_event=canonical, original_event=event, effective_event=event)
-    result = _policy_pipeline.evaluate(context)
-    if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
-        raise EventError(result.audit_event.reason)
-    return result.context.effective_event or event
+    result = _orchestrator.run(data, source="service_validate")
+    if result.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
+        raise EventError(result.reason)
+    return result.event or event
 
 
 def apply_event(
@@ -76,82 +78,59 @@ def _normalize_schema_version(value: Any) -> str | None:
     return None
 
 
-def _ingest_canonical_event(
-    canonical: Dict[str, Any],
-    event: Event,
+def _build_graph_projector(
     graph: IGraphAdapter,
     *,
     schema_version: str | None = None,
-) -> None:
-    metadata = canonical["metadata"]
-    unwrapped_event_data = canonical_to_legacy_dict(canonical)
-    envelope_version = metadata.get("schema_version")
-    explicit_version = _normalize_schema_version(schema_version)
-    normalized_envelope_version = _normalize_schema_version(envelope_version)
-    normalized_payload_version = _normalize_schema_version(unwrapped_event_data.get("schema_version"))
-    detected_version = normalized_envelope_version or normalized_payload_version
-    effective_version = (
-        explicit_version
-        or detected_version
-        or _normalize_schema_version(_fallback_schema_version())
-        or DEFAULT_VERSION
-    )
-
-    context = PolicyContext(source="service_ingest", canonical_event=canonical, original_event=event, effective_event=event)
-    policy_result = _policy_pipeline.evaluate(context)
-    if policy_result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
-        raise EventError(policy_result.audit_event.reason)
-
-    effective_event = policy_result.context.effective_event
-    if effective_event is None:
-        raise EventError("policy_pipeline_missing_effective_event")
-
-    tag_results = classify_event(effective_event)
-    effective_event.payload["classification"] = [
-        {
-            "tag": r.tag,
-            "confidence": r.confidence,
-            "domain": r.domain,
-            "subdomain": r.subdomain,
-            "sensitivity": r.sensitivity,
-        }
-        for r in tag_results
-    ]
-    if tag_results:
-        attributes = effective_event.payload.setdefault("attributes", {})
-        attributes["tags"] = [r.tag for r in tag_results]
-        attributes["tag_confidence"] = [r.confidence for r in tag_results]
-        for r in tag_results:
-            if r.domain and "domain" not in attributes:
-                attributes["domain"] = r.domain
-            if r.subdomain and "subdomain" not in attributes:
-                attributes["subdomain"] = r.subdomain
-            if r.sensitivity and "sensitivity" not in attributes:
-                attributes["sensitivity"] = r.sensitivity
-
-    apply_event(effective_event, graph, schema_version=effective_version)
-    _policy_pipeline.audit_post_apply(context)
-
-    anomaly_event = _anomaly_detector.process_event(effective_event)
-    if anomaly_event is not None:
-        ingest_event(
-            {
-                "eventType": anomaly_event.event_type,
-                "timestamp": anomaly_event.timestamp,
-                "payload": anomaly_event.payload,
-                "sourceService": anomaly_event.source,
-            },
-            graph,
-            schema_version=effective_version,
+) -> Any:
+    def _project(context: Any) -> dict[str, Any]:
+        canonical = context.canonical_event
+        event = context.effective_event
+        if canonical is None or event is None:
+            raise EventError("missing_canonical_or_event")
+        metadata = canonical["metadata"]
+        unwrapped_event_data = canonical_to_legacy_dict(canonical)
+        envelope_version = metadata.get("schema_version")
+        explicit_version = _normalize_schema_version(schema_version)
+        normalized_envelope_version = _normalize_schema_version(envelope_version)
+        normalized_payload_version = _normalize_schema_version(unwrapped_event_data.get("schema_version"))
+        detected_version = normalized_envelope_version or normalized_payload_version
+        effective_version = (
+            explicit_version
+            or detected_version
+            or _normalize_schema_version(_fallback_schema_version())
+            or DEFAULT_VERSION
         )
+        details = apply_classification(context)
+        apply_event(event, graph, schema_version=effective_version)
+        anomaly_event = _anomaly_detector.process_event(event)
+        if anomaly_event is not None:
+            ingest_event(
+                {
+                    "eventType": anomaly_event.event_type,
+                    "timestamp": anomaly_event.timestamp,
+                    "payload": anomaly_event.payload,
+                    "sourceService": anomaly_event.source,
+                },
+                graph,
+                schema_version=effective_version,
+            )
+        return {**details, "schema_version": effective_version}
+
+    return _project
 
 
 def ingest_event(
     data: Dict[str, Any], graph: IGraphAdapter, *, schema_version: str | None = None
 ) -> None:
     """Validate ``data``, classify it, and apply the resulting event to ``graph``."""
-    canonical, event = ingest_transport_payload(data)
-    _ingest_canonical_event(canonical, event, graph, schema_version=schema_version)
+    result = _orchestrator.run(
+        data,
+        source="service_ingest",
+        projector=_build_graph_projector(graph, schema_version=schema_version),
+    )
+    if result.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
+        raise EventError(result.reason)
 
 
 def ingest_events_batch(
@@ -243,8 +222,14 @@ def ingest_envelope(
 ) -> None:
     """Ingest an :class:`EventEnvelope` into ``graph``."""
     event_dict = envelope_to_event_dict(envelope)
-    canonical, event = ingest_transport_payload(event_dict, adapter="grpc")
-    _ingest_canonical_event(canonical, event, graph, schema_version=schema_version)
+    result = _orchestrator.run(
+        event_dict,
+        source="service_ingest",
+        adapter="grpc",
+        projector=_build_graph_projector(graph, schema_version=schema_version),
+    )
+    if result.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
+        raise EventError(result.reason)
 
 
 async def ingest_envelope_async(

--- a/tests/integration/test_api_kafka_golden_path.py
+++ b/tests/integration/test_api_kafka_golden_path.py
@@ -1,0 +1,100 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume.config import settings
+from ume.event_ledger import EventLedger
+from ume.graph import MockGraph
+from ume.pipeline import graph_consumer
+
+
+class DummyMessage:
+    def __init__(self, value: bytes, offset: int) -> None:
+        self._value = value
+        self._offset = offset
+
+    def value(self) -> bytes:
+        return self._value
+
+    def error(self):
+        return None
+
+    def offset(self) -> int:
+        return self._offset
+
+
+class DummyConsumer:
+    def __init__(self, messages: list[DummyMessage]) -> None:
+        self.messages = messages
+        self.index = 0
+
+    def poll(self, timeout: float = 1.0):
+        if self.index >= len(self.messages):
+            raise KeyboardInterrupt
+        msg = self.messages[self.index]
+        self.index += 1
+        return msg
+
+    def close(self) -> None:
+        return None
+
+
+def _token(client: TestClient) -> str:
+    response = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return response.json()["access_token"]
+
+
+def test_golden_path_api_and_kafka_are_equivalent(tmp_path, monkeypatch):
+    events = [
+        {
+            "eventType": "CREATE_NODE",
+            "eventId": "g-1",
+            "timestamp": 1,
+            "node_id": "n1",
+            "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
+        },
+        {
+            "eventType": "CREATE_NODE",
+            "eventId": "g-2",
+            "timestamp": 2,
+            "node_id": "n2",
+            "payload": {"node_id": "n2", "attributes": {"name": "Bob"}},
+        },
+        {
+            "eventType": "CREATE_EDGE",
+            "eventId": "g-3",
+            "timestamp": 3,
+            "node_id": "n1",
+            "target_node_id": "n2",
+            "label": "KNOWS",
+            "payload": {},
+        },
+    ]
+
+    api_graph = MockGraph()
+    configure_graph(api_graph)
+    client = TestClient(app)
+    response = client.post(
+        "/events/batch",
+        json=events,
+        headers={"Authorization": f"Bearer {_token(client)}"},
+    )
+    assert response.status_code == 200
+
+    kafka_graph = MockGraph()
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    consumer = DummyConsumer(
+        [DummyMessage(json.dumps(event).encode("utf-8"), idx) for idx, event in enumerate(events)]
+    )
+    monkeypatch.setattr(graph_consumer, "event_ledger", ledger)
+
+    graph_consumer.run_graph_consumer(kafka_graph, consumer=consumer)
+
+    assert api_graph.dump() == kafka_graph.dump()
+    assert ledger.last_processed_offset == len(events) - 1
+    rejected = [item for _, item in ledger.range() if item.get("eventType") == "REJECTED_EVENT"]
+    assert rejected == []


### PR DESCRIPTION
### Motivation
- Centralize ingestion semantics into a single orchestrator to ensure API, Kafka, and stream runtimes share decode → normalize → validate → policy → project → audit behavior.
- Keep transport runtimes (Kafka/Faust/API) focused on I/O and routing while moving business semantics (classification, schema resolution, apply-to-graph, anomaly follow-ups) into a projector executed by the core.
- Standardize runtime outcomes and observability with a shared envelope so DLQ/ledger handling and auditing can act on a single contract.
- Provide a golden-path integration test to assert equivalent outcomes across API and Kafka ingestion flows.

### Description
- Added `src/ume/pipeline/core.py` implementing `EventPipelineOrchestrator`, `PipelineOutcome`, `PipelineEnvelope`, `apply_classification`, and the explicit pipeline stages (decode/validate/policy/project/audit).
- Refactored API ingest helpers in `src/ume/services/ingest.py` to run events through the orchestrator and to use a projector callback for classification, schema resolution, graph application, and anomaly follow-ups.
- Refactored Kafka consumer in `src/ume/pipeline/graph_consumer.py` to call the orchestrator and to build invalid-event ledger entries from the returned `PipelineEnvelope` rather than duplicating policy/parse logic.
- Refactored Faust stream processor in `src/ume/pipeline/stream_processor.py` to route messages based on orchestrator outputs so the runtime only performs transport-level routing.
- Extended invalid-event mapping in `src/ume/pipeline/invalid_events.py` to translate `PipelineOutcome` values into ledger outcomes.
- Added a golden-path integration test `tests/integration/test_api_kafka_golden_path.py` that sends the same events through the HTTP ingestion path and the Kafka consumer path and asserts identical graph state and no rejected ledger entries.

### Testing
- Ran linter checks with `ruff` over modified files via `ruff check ...` which completed with no issues.
- Ran unit tests `pytest -q tests/test_graph_consumer.py tests/test_stream_processor.py` which passed (`3 passed`).
- Compiled relevant modules with `python -m compileall ...` which succeeded.
- Attempted broader `pytest` runs that include the new integration golden-path and other ingestion tests but collection failed in this environment due to missing external test dependencies (`fastapi.testclient` and `google.protobuf`), so those integration tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1981a9c7c8326b2df5e77f388d0af)