### PR TITLE
Unify sync/async ingestion orchestration and handler dispatch

### DIFF
--- a/src/ume/async_graph_adapter.py
+++ b/src/ume/async_graph_adapter.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from .persistent_graph import PersistentGraph
-from .processing import ProcessingError, DEFAULT_VERSION
-from .event import Event, EventType
-from .events.ingress import ingest_transport_payload
-from ._internal.listeners import get_registered_listeners
-from .schema_manager import DEFAULT_SCHEMA_MANAGER
+from .processing import DEFAULT_VERSION, apply_event_to_graph
+from .event import Event, EventError
 from .graph_adapter import IGraphAdapter, AsyncAdapterMixin
+from .pipeline.core import EventPipelineOrchestrator, PipelineOutcome
 
 
 class IAsyncGraphAdapter(ABC):
@@ -100,7 +99,6 @@ class AsyncGraphAdapterWrapper(AsyncAdapterMixin, IAsyncGraphAdapter):
         super().__init__(adapter)
 
 
-
 class AsyncGraphAlgorithmsMixin:
     """Asynchronous versions of traversal helpers."""
 
@@ -153,69 +151,157 @@ class AsyncPersistentGraph(AsyncAdapterMixin, AsyncGraphAlgorithmsMixin, IAsyncG
         return await asyncio.to_thread(lambda: self._adapter.node_count)
 
 
+class _AsyncToSyncGraphAdapter(IGraphAdapter):
+    def __init__(self, graph: IAsyncGraphAdapter) -> None:
+        self._graph = graph
+
+    def _await(self, coro: Any) -> Any:
+        return asyncio.run(coro)
+
+    def add_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        self._await(self._graph.add_node(node_id, attributes))
+
+    def update_node(self, node_id: str, attributes: Dict[str, Any]) -> None:
+        self._await(self._graph.update_node(node_id, attributes))
+
+    def get_node(self, node_id: str) -> Optional[Dict[str, Any]]:
+        return self._await(self._graph.get_node(node_id))
+
+    def node_exists(self, node_id: str) -> bool:
+        return cast(bool, self._await(self._graph.node_exists(node_id)))
+
+    def dump(self) -> Dict[str, Any]:
+        return cast(Dict[str, Any], self._await(self._graph.dump()))
+
+    def clear(self) -> None:
+        self._await(self._graph.clear())
+
+    def get_all_node_ids(self) -> list[str]:
+        return cast(list[str], self._await(self._graph.get_all_node_ids()))
+
+    def find_connected_nodes(
+        self, node_id: str, edge_label: Optional[str] = None
+    ) -> list[str]:
+        return cast(list[str], self._await(self._graph.find_connected_nodes(node_id, edge_label)))
+
+    def add_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+        schema_version: str | None = None,
+    ) -> None:
+        self._await(
+            self._graph.add_edge(
+                source_node_id,
+                target_node_id,
+                label,
+                attrs,
+                schema_version,
+            )
+        )
+
+    def get_all_edges(self) -> list[tuple[str, str, str, Dict[str, Any]]]:
+        return cast(list[tuple[str, str, str, Dict[str, Any]]], self._await(self._graph.get_all_edges()))
+
+    def delete_edge(
+        self,
+        source_node_id: str,
+        target_node_id: str,
+        label: str,
+        attrs: Dict[str, Any] | None = None,
+    ) -> None:
+        self._await(self._graph.delete_edge(source_node_id, target_node_id, label, attrs))
+
+    def redact_node(self, node_id: str) -> None:
+        self._await(self._graph.redact_node(node_id))
+
+    def redact_edge(self, source_node_id: str, target_node_id: str, label: str) -> None:
+        self._await(self._graph.redact_edge(source_node_id, target_node_id, label))
+
+    def close(self) -> None:
+        self._await(self._graph.close())
+
+    def shortest_path(self, source_id: str, target_id: str) -> list[str]:
+        return cast(list[str], self._await(cast(Any, self._graph).shortest_path(source_id, target_id)))
+
+    def traverse(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+    ) -> list[str]:
+        return cast(list[str], self._await(cast(Any, self._graph).traverse(start_node_id, depth, edge_label)))
+
+    def extract_subgraph(
+        self,
+        start_node_id: str,
+        depth: int,
+        edge_label: Optional[str] = None,
+        since_timestamp: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        return cast(
+            Dict[str, Any],
+            self._await(
+                cast(Any, self._graph).extract_subgraph(
+                    start_node_id,
+                    depth,
+                    edge_label,
+                    since_timestamp,
+                )
+            ),
+        )
+
+    def constrained_path(
+        self,
+        source_id: str,
+        target_id: str,
+        max_depth: Optional[int] = None,
+        edge_label: Optional[str] = None,
+        since_timestamp: Optional[int] = None,
+    ) -> list[str]:
+        return cast(
+            list[str],
+            self._await(
+                cast(Any, self._graph).constrained_path(
+                    source_id,
+                    target_id,
+                    max_depth,
+                    edge_label,
+                    since_timestamp,
+                )
+            ),
+        )
+
+
+_orchestrator = EventPipelineOrchestrator()
+
+
+async def _apply_event_via_registry(
+    event: Event,
+    graph: IAsyncGraphAdapter,
+    *,
+    schema_version: str,
+) -> None:
+    shim = _AsyncToSyncGraphAdapter(graph)
+    await asyncio.to_thread(apply_event_to_graph, event, shim, schema_version=schema_version)
+
+
 async def apply_event_to_async_graph(
     event: Event,
     graph: IAsyncGraphAdapter,
     *,
     schema_version: str = DEFAULT_VERSION,
 ) -> None:
-    """Asynchronous equivalent of :func:`ume.processing.apply_event_to_graph`."""
-    if event.event_type == EventType.CREATE_NODE:
-        node_id = event.node_id
-        if not node_id or not isinstance(node_id, str):
-            raise ProcessingError("Invalid node_id for CREATE_NODE")
-        attributes = event.payload.get("attributes", {})
-        if not isinstance(attributes, dict):
-            raise ProcessingError("'attributes' must be a dictionary")
-        node_type = attributes.get("type")
-        if node_type is not None:
-            schema = DEFAULT_SCHEMA_MANAGER.get_schema(schema_version)
-            schema.validate_node_type(str(node_type))
-        await graph.add_node(node_id, attributes)
-        for listener in get_registered_listeners():
-            listener.on_node_created(node_id, attributes)
-    elif event.event_type == EventType.UPDATE_NODE_ATTRIBUTES:
-        node_id = event.node_id
-        if not node_id or not isinstance(node_id, str):
-            raise ProcessingError("Invalid node_id for UPDATE_NODE_ATTRIBUTES")
-        if "attributes" not in event.payload:
-            raise ProcessingError("Missing 'attributes' key in payload")
-        attributes = event.payload["attributes"]
-        if not isinstance(attributes, dict) or not attributes:
-            raise ProcessingError("'attributes' must be a non-empty dictionary")
-        await graph.update_node(node_id, attributes)
-        for listener in get_registered_listeners():
-            listener.on_node_updated(node_id, attributes)
-    elif event.event_type in {EventType.CREATE_EDGE, EventType.CREATE_ONTOLOGY_RELATION}:
-        source_node_id = event.node_id
-        target_node_id = event.target_node_id
-        label = event.label
-        if not (
-            isinstance(source_node_id, str)
-            and isinstance(target_node_id, str)
-            and isinstance(label, str)
-        ):
-            raise ProcessingError("Invalid edge fields")
-        schema = DEFAULT_SCHEMA_MANAGER.get_schema(schema_version)
-        schema.validate_edge_label(label)
-        await graph.add_edge(source_node_id, target_node_id, label)
-        for listener in get_registered_listeners():
-            listener.on_edge_created(source_node_id, target_node_id, label)
-    elif event.event_type == EventType.DELETE_EDGE:
-        source_node_id = event.node_id
-        target_node_id = event.target_node_id
-        label = event.label
-        if not (
-            isinstance(source_node_id, str)
-            and isinstance(target_node_id, str)
-            and isinstance(label, str)
-        ):
-            raise ProcessingError("Invalid edge fields")
-        await graph.delete_edge(source_node_id, target_node_id, label)
-        for listener in get_registered_listeners():
-            listener.on_edge_deleted(source_node_id, target_node_id, label)
-    else:
-        raise ProcessingError(f"Unknown event_type '{event.event_type}'")
+    """Deprecated helper retained for backward compatibility."""
+    warnings.warn(
+        "apply_event_to_async_graph() is deprecated as a standalone decision engine; "
+        "use ingest_event_async() and shared pipeline orchestration instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    await _apply_event_via_registry(event, graph, schema_version=schema_version)
 
 
 async def ingest_event_async(
@@ -227,13 +313,30 @@ async def ingest_event_async(
 ) -> None:
     """Apply a canonical envelope/event pair to ``graph`` asynchronously."""
     canonical = data
-    parsed_event = event
-    if parsed_event is None:
-        canonical, parsed_event = ingest_transport_payload(data)
-    metadata = canonical.get("metadata", {})
-    detected_version = cast(str | None, metadata.get("schema_version")) if isinstance(metadata, dict) else None
-    effective_version = schema_version or detected_version or DEFAULT_VERSION
-    await apply_event_to_async_graph(parsed_event, graph, schema_version=effective_version)
+    if event is not None:
+        warnings.warn(
+            "ingest_event_async(event=...) is deprecated; pass transport payload only.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    async def _project(context: Any) -> dict[str, Any]:
+        effective_event = context.effective_event
+        if effective_event is None:
+            raise EventError("effective_event_missing")
+        metadata = context.canonical_event.get("metadata", {}) if context.canonical_event else {}
+        detected_version = metadata.get("schema_version") if isinstance(metadata, dict) else None
+        effective_version = schema_version or detected_version or DEFAULT_VERSION
+        await _apply_event_via_registry(effective_event, graph, schema_version=effective_version)
+        return {"schema_version": effective_version}
+
+    result = await _orchestrator.run_async(
+        canonical,
+        source="async_ingest",
+        projector=_project,
+    )
+    if result.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
+        raise EventError(result.reason)
 
 
 __all__ = [

--- a/src/ume/pipeline/core.py
+++ b/src/ume/pipeline/core.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Callable, Mapping
+from typing import Any, Awaitable, Callable, Mapping
 
 from ..classification import classify_event
 from ..event import Event
@@ -50,6 +50,8 @@ class PipelineEnvelope:
 
 Projector = Callable[[PolicyContext], dict[str, Any] | None]
 Auditor = Callable[[PipelineEnvelope], None]
+AsyncProjector = Callable[[PolicyContext], Awaitable[dict[str, Any] | None]]
+AsyncAuditor = Callable[[PipelineEnvelope], Awaitable[None]]
 
 
 class EventPipelineOrchestrator:
@@ -64,41 +66,16 @@ class EventPipelineOrchestrator:
             redactor=lambda payload: (payload, False)
         )
 
-    def run(
+    def _base_context(
         self,
-        payload: Mapping[str, Any],
         *,
         source: str,
-        adapter: IngressAdapter = "default",
-        raw_payload: bytes | None = None,
-        projector: Projector | None = None,
-        auditor: Auditor | None = None,
-    ) -> PipelineEnvelope:
-        # decode
-        try:
-            decoded = dict(payload)
-        except Exception as exc:
-            return PipelineEnvelope(
-                outcome=PipelineOutcome.REJECTED,
-                source=source,
-                stage="decode",
-                reason=f"decode_failed:{exc}",
-            )
-
-        # normalize + validate
-        try:
-            canonical, event = ingest_transport_payload(decoded, adapter=adapter)
-        except Exception as exc:
-            return PipelineEnvelope(
-                outcome=PipelineOutcome.QUARANTINED,
-                source=source,
-                stage="validate",
-                reason=f"transport_validation_failed:{exc}",
-                details={"raw_payload_present": raw_payload is not None},
-            )
-
-        # policy
-        context = PolicyContext(
+        raw_payload: bytes | None,
+        decoded: dict[str, Any],
+        canonical: dict[str, Any],
+        event: Event,
+    ) -> PolicyContext:
+        return PolicyContext(
             source=source,
             raw_payload=raw_payload,
             transport_data=decoded,
@@ -106,6 +83,44 @@ class EventPipelineOrchestrator:
             original_event=event,
             effective_event=event,
         )
+
+    def _decode(self, payload: Mapping[str, Any], *, source: str) -> tuple[dict[str, Any] | None, PipelineEnvelope | None]:
+        try:
+            return dict(payload), None
+        except Exception as exc:
+            return None, PipelineEnvelope(
+                outcome=PipelineOutcome.REJECTED,
+                source=source,
+                stage="decode",
+                reason=f"decode_failed:{exc}",
+            )
+
+    def _normalize(
+        self,
+        decoded: dict[str, Any],
+        *,
+        source: str,
+        adapter: IngressAdapter,
+        raw_payload: bytes | None,
+    ) -> tuple[dict[str, Any] | None, Event | None, PipelineEnvelope | None]:
+        try:
+            canonical, event = ingest_transport_payload(decoded, adapter=adapter)
+            return canonical, event, None
+        except Exception as exc:
+            return None, None, PipelineEnvelope(
+                outcome=PipelineOutcome.QUARANTINED,
+                source=source,
+                stage="validate",
+                reason=f"transport_validation_failed:{exc}",
+                details={"raw_payload_present": raw_payload is not None},
+            )
+
+    def _policy(
+        self,
+        context: PolicyContext,
+        *,
+        source: str,
+    ) -> tuple[PipelineEnvelope | None, PipelineOutcome, PolicyDecision]:
         policy_result = self._policy_pipeline.evaluate(context)
         if policy_result.decision == PolicyDecision.DENY:
             return PipelineEnvelope(
@@ -116,7 +131,7 @@ class EventPipelineOrchestrator:
                 canonical_event=context.canonical_event,
                 event=context.effective_event,
                 policy_decision=policy_result.decision,
-            )
+            ), PipelineOutcome.REJECTED, PolicyDecision.DENY
         if policy_result.decision == PolicyDecision.QUARANTINE:
             return PipelineEnvelope(
                 outcome=PipelineOutcome.QUARANTINED,
@@ -126,11 +141,46 @@ class EventPipelineOrchestrator:
                 canonical_event=context.canonical_event,
                 event=context.effective_event,
                 policy_decision=policy_result.decision,
-            )
+            ), PipelineOutcome.QUARANTINED, PolicyDecision.QUARANTINE
+        return None, (
+            PipelineOutcome.REDACTED
+            if policy_result.decision == PolicyDecision.REDACTED
+            else PipelineOutcome.APPLIED
+        ), policy_result.decision
 
-        provisional_outcome = PipelineOutcome.REDACTED if policy_result.decision == PolicyDecision.REDACTED else PipelineOutcome.APPLIED
+    def run(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        source: str,
+        adapter: IngressAdapter = "default",
+        raw_payload: bytes | None = None,
+        projector: Projector | None = None,
+        auditor: Auditor | None = None,
+    ) -> PipelineEnvelope:
+        decoded, decode_error = self._decode(payload, source=source)
+        if decode_error is not None:
+            return decode_error
+        assert decoded is not None
 
-        # project
+        canonical, event, normalize_error = self._normalize(
+            decoded, source=source, adapter=adapter, raw_payload=raw_payload
+        )
+        if normalize_error is not None:
+            return normalize_error
+        assert canonical is not None and event is not None
+
+        context = self._base_context(
+            source=source,
+            raw_payload=raw_payload,
+            decoded=decoded,
+            canonical=canonical,
+            event=event,
+        )
+        policy_error, provisional_outcome, policy_decision = self._policy(context, source=source)
+        if policy_error is not None:
+            return policy_error
+
         if context.effective_event is None:
             return PipelineEnvelope(
                 outcome=PipelineOutcome.QUARANTINED,
@@ -138,7 +188,7 @@ class EventPipelineOrchestrator:
                 stage="project",
                 reason="effective_event_missing",
                 canonical_event=context.canonical_event,
-                policy_decision=policy_result.decision,
+                policy_decision=policy_decision,
             )
 
         details: dict[str, Any] = {}
@@ -155,7 +205,7 @@ class EventPipelineOrchestrator:
                     reason=f"processing_error:{exc}",
                     canonical_event=context.canonical_event,
                     event=context.effective_event,
-                    policy_decision=policy_result.decision,
+                    policy_decision=policy_decision,
                 )
             except Exception as exc:
                 return PipelineEnvelope(
@@ -165,10 +215,9 @@ class EventPipelineOrchestrator:
                     reason=f"projection_failed:{exc}",
                     canonical_event=context.canonical_event,
                     event=context.effective_event,
-                    policy_decision=policy_result.decision,
+                    policy_decision=policy_decision,
                 )
 
-        # audit
         self._policy_pipeline.audit_post_apply(context)
         envelope = PipelineEnvelope(
             outcome=provisional_outcome,
@@ -177,12 +226,98 @@ class EventPipelineOrchestrator:
             reason="mutation_applied",
             canonical_event=context.canonical_event,
             event=context.effective_event,
-            policy_decision=policy_result.decision,
+            policy_decision=policy_decision,
             redacted=provisional_outcome == PipelineOutcome.REDACTED,
             details=details,
         )
         if auditor is not None:
             auditor(envelope)
+        return envelope
+
+    async def run_async(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        source: str,
+        adapter: IngressAdapter = "default",
+        raw_payload: bytes | None = None,
+        projector: AsyncProjector | None = None,
+        auditor: AsyncAuditor | None = None,
+    ) -> PipelineEnvelope:
+        decoded, decode_error = self._decode(payload, source=source)
+        if decode_error is not None:
+            return decode_error
+        assert decoded is not None
+
+        canonical, event, normalize_error = self._normalize(
+            decoded, source=source, adapter=adapter, raw_payload=raw_payload
+        )
+        if normalize_error is not None:
+            return normalize_error
+        assert canonical is not None and event is not None
+
+        context = self._base_context(
+            source=source,
+            raw_payload=raw_payload,
+            decoded=decoded,
+            canonical=canonical,
+            event=event,
+        )
+        policy_error, provisional_outcome, policy_decision = self._policy(context, source=source)
+        if policy_error is not None:
+            return policy_error
+
+        if context.effective_event is None:
+            return PipelineEnvelope(
+                outcome=PipelineOutcome.QUARANTINED,
+                source=source,
+                stage="project",
+                reason="effective_event_missing",
+                canonical_event=context.canonical_event,
+                policy_decision=policy_decision,
+            )
+
+        details: dict[str, Any] = {}
+        if projector is not None:
+            try:
+                projected = await projector(context)
+                if projected:
+                    details.update(projected)
+            except ProcessingError as exc:
+                return PipelineEnvelope(
+                    outcome=PipelineOutcome.REJECTED,
+                    source=source,
+                    stage="project",
+                    reason=f"processing_error:{exc}",
+                    canonical_event=context.canonical_event,
+                    event=context.effective_event,
+                    policy_decision=policy_decision,
+                )
+            except Exception as exc:
+                return PipelineEnvelope(
+                    outcome=PipelineOutcome.REJECTED,
+                    source=source,
+                    stage="project",
+                    reason=f"projection_failed:{exc}",
+                    canonical_event=context.canonical_event,
+                    event=context.effective_event,
+                    policy_decision=policy_decision,
+                )
+
+        self._policy_pipeline.audit_post_apply(context)
+        envelope = PipelineEnvelope(
+            outcome=provisional_outcome,
+            source=source,
+            stage="audit",
+            reason="mutation_applied",
+            canonical_event=context.canonical_event,
+            event=context.effective_event,
+            policy_decision=policy_decision,
+            redacted=provisional_outcome == PipelineOutcome.REDACTED,
+            details=details,
+        )
+        if auditor is not None:
+            await auditor(envelope)
         return envelope
 
 

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -240,10 +240,8 @@ async def ingest_envelope_async(
 ) -> None:
     """Asynchronously ingest an :class:`EventEnvelope` into ``graph``."""
     event_dict = envelope_to_event_dict(envelope)
-    canonical, event = ingest_transport_payload(event_dict, adapter="grpc")
     await ingest_event_async(
-        canonical,
+        event_dict,
         graph,
         schema_version=schema_version,
-        event=event,
     )

--- a/tests/test_ingest_sync_async_parity.py
+++ b/tests/test_ingest_sync_async_parity.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("google.protobuf.json_format")
+
+from ume.async_graph_adapter import AsyncGraphAdapterWrapper
+from ume.event import EventError
+from ume.graph import MockGraph
+from ume.pipeline.core import EventPipelineOrchestrator
+from ume.policy.pipeline import build_default_policy_pipeline
+from ume.services import ingest as ingest_service
+import ume.async_graph_adapter as async_adapter
+
+
+def _base_event() -> dict[str, object]:
+    return {
+        "eventType": "CREATE_NODE",
+        "timestamp": 1,
+        "nodeId": "n1",
+        "payload": {"attributes": {"name": "Alice", "email": "a@example.com"}},
+    }
+
+
+def _set_orchestrators(monkeypatch: pytest.MonkeyPatch, *, pipeline) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+    monkeypatch.setattr("ume.policy.pipeline.get_plugins", lambda: [])
+    orchestrator = EventPipelineOrchestrator(policy_pipeline=pipeline)
+    monkeypatch.setattr(ingest_service, "_orchestrator", orchestrator)
+    monkeypatch.setattr(async_adapter, "_orchestrator", orchestrator)
+
+
+@pytest.mark.asyncio
+async def test_ingest_parity_deny(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.consent_ledger.has_consent", lambda *_: False)
+    pipeline = build_default_policy_pipeline(redactor=lambda payload: (payload, False))
+    _set_orchestrators(monkeypatch, pipeline=pipeline)
+
+    event = _base_event()
+    event["payload"] = {
+        "user_id": "u1",
+        "scope": "email",
+        "attributes": {"name": "Alice"},
+    }
+
+    sync_graph = MockGraph()
+    async_graph = AsyncGraphAdapterWrapper(MockGraph())
+
+    with pytest.raises(EventError):
+        ingest_service.ingest_event(event, sync_graph)
+    with pytest.raises(EventError):
+        await async_adapter.ingest_event_async(event, async_graph)
+
+
+@pytest.mark.asyncio
+async def test_ingest_parity_quarantine(monkeypatch: pytest.MonkeyPatch) -> None:
+    pipeline = build_default_policy_pipeline(redactor=lambda payload: (payload, False))
+    _set_orchestrators(monkeypatch, pipeline=pipeline)
+
+    invalid_event = {"eventType": "CREATE_NODE", "payload": {"attributes": {"x": 1}}}
+
+    with pytest.raises(EventError):
+        ingest_service.ingest_event(invalid_event, MockGraph())
+    with pytest.raises(EventError):
+        await async_adapter.ingest_event_async(invalid_event, AsyncGraphAdapterWrapper(MockGraph()))
+
+
+@pytest.mark.asyncio
+async def test_ingest_parity_redacted(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _redactor(payload):
+        attributes = dict(payload.get("attributes", {}))
+        if "email" in attributes:
+            attributes["email"] = "<REDACTED>"
+        return ({**payload, "attributes": attributes}, True)
+
+    pipeline = build_default_policy_pipeline(redactor=_redactor)
+    _set_orchestrators(monkeypatch, pipeline=pipeline)
+
+    event = _base_event()
+    sync_graph = MockGraph()
+    async_graph = AsyncGraphAdapterWrapper(MockGraph())
+
+    ingest_service.ingest_event(event, sync_graph)
+    await async_adapter.ingest_event_async(event, async_graph)
+
+    assert sync_graph.get_node("n1") == {"name": "Alice", "email": "<REDACTED>"}
+    assert await async_graph.get_node("n1") == {"name": "Alice", "email": "<REDACTED>"}


### PR DESCRIPTION
### Motivation
- Make sync and async ingestion follow a single orchestration path (decode → normalize/validate → policy → project → audit) so semantics and policy decisions are identical across runtimes.
- Avoid duplicating event-type dispatch logic between sync and async flows by invoking the canonical handler registry from the async path.
- Provide a clean async projection/orchestration API so ingestion only differs at the graph execution boundary.

### Description
- Added async orchestration support to `EventPipelineOrchestrator` by introducing `run_async`, `AsyncProjector`, and `AsyncAuditor` while factoring decode/normalize/policy logic into helpers (`_decode`, `_normalize`, `_policy`, `_base_context`) so sync `run` and `run_async` share semantics (`src/ume/pipeline/core.py`).
- Refactored async ingestion to use the shared orchestrator in `ingest_event_async` and to perform graph mutations via an async→sync shim (`_AsyncToSyncGraphAdapter`) that calls the canonical registry path (`apply_event_to_graph`), keeping graph execution awaitable while reusing existing handlers (`src/ume/async_graph_adapter.py`).
- Deprecated `apply_event_to_async_graph()` as a standalone decision engine but preserved a backward-compatible wrapper that emits a `DeprecationWarning` and forwards to the new shared path (`src/ume/async_graph_adapter.py`).
- Kept `ingest_envelope_async` aligned with other entrypoints by passing the transport dictionary to `ingest_event_async` so envelope ingestion exercises the same orchestrator (`src/ume/services/ingest.py`).
- Added parity tests `tests/test_ingest_sync_async_parity.py` that assert DENY / QUARANTINE / REDACTED outcomes behave the same for sync (`ingest_event`) and async (`ingest_event_async`) ingestion entry points and that the redaction result is persisted to the graph.

### Testing
- Ran `ruff check` on modified files (`src/ume/pipeline/core.py`, `src/ume/async_graph_adapter.py`, `src/ume/services/ingest.py`, and the new test file`) and it passed.
- Ensured Python files compile via `py_compile` with no syntax errors.
- Ran `pytest -q tests/test_async_graph_adapter.py tests/test_ingest_sync_async_parity.py`; collection and execution completed but the async tests were skipped in this environment because the async pytest plugin is not available (tests marked with `@pytest.mark.asyncio`).
- Ran `pytest -q tests/test_policy_pipeline_parity.py` which passed (`3 passed`).
- Attempted broader test runs which surfaced unrelated environment dependency limits (missing `fastapi.testclient` and `google.protobuf` in this execution environment), so those unrelated tests failed to collect; the changes themselves were validated where environment permits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a4a196948326ac53950ffa286489)