### PR TITLE
Fix demo producer/consumer event contract and end-to-end quickstart flow

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -27,14 +27,30 @@ This quickstart shows how to run a simple producer and consumer locally.
    docker run -d -p 9092:9092 -p 9644:9644 --name redpanda docker.redpanda.com/vectorized/redpanda:latest redpanda start
    ```
 
-4. Start a sample producer:
+4. In one terminal, start the demo consumer:
    ```
-   python examples/producer.py --topic test --message "hello world"
-   ```
-
-5. In another terminal, start a sample consumer:
-   ```
-   python examples/consumer.py --topic test
+   python -m ume.consumer_demo
    ```
 
-You should see the message appear in the consumer's output, which verifies the basic data flow.
+5. In another terminal, publish a typed demo event:
+   ```
+   python -m ume.producer_demo
+   ```
+
+### Demo integration path (producer -> consumer)
+
+The demo scripts are wired for direct end-to-end flow with no intermediate
+processor required:
+
+```
+producer_demo.py
+  -> topic: KAFKA_RAW_EVENTS_TOPIC
+  -> consumer_demo.py
+```
+
+Expected behavior:
+
+- `producer_demo.py` publishes a schema-valid `CREATE_NODE` event.
+- `consumer_demo.py` subscribes to the same raw topic and parses each message
+  through `ingest_transport_payload(..., adapter="kafka")` before logging the
+  parsed `Event`.

--- a/src/ume/consumer_demo.py
+++ b/src/ume/consumer_demo.py
@@ -23,7 +23,7 @@ logger = logging.getLogger("consumer_demo")
 # Kafka broker and topic
 # Set KAFKA_CA_CERT, KAFKA_CLIENT_CERT and KAFKA_CLIENT_KEY to enable TLS.
 BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
-TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
+TOPIC = settings.KAFKA_RAW_EVENTS_TOPIC
 GROUP_ID = settings.KAFKA_GROUP_ID
 
 
@@ -80,7 +80,9 @@ def main() -> None:
                     text_values = [v for v in payload.values() if isinstance(v, str)]
                     if text_values:
                         payload["embedding"] = generate_embedding(" ".join(text_values))
-                _, received_event = ingest_transport_payload(event_data_dict, adapter="cli")
+                _, received_event = ingest_transport_payload(
+                    event_data_dict, adapter="kafka"
+                )
                 logger.info(f"Received event object: {received_event}")
             except json.JSONDecodeError as e:
                 logger.error(f"Failed to decode JSON: {data}, error: {e}")

--- a/src/ume/producer_demo.py
+++ b/src/ume/producer_demo.py
@@ -13,7 +13,7 @@ from ume.config import settings
 from ume.logging_utils import configure_logging
 import time
 from confluent_kafka import Producer, KafkaException, Message
-from ume import Event
+from ume import Event, EventType
 from ume.schema_utils import validate_event_dict
 from ume.events.contract import canonicalize_event, canonical_to_camel_dict
 from jsonschema import ValidationError
@@ -51,12 +51,20 @@ def main() -> None:
     producer = Producer(conf)
 
     # Construct an Event instance
-    event_payload_data = {"message": "Hello from producer_demo with Event class!"}
+    demo_node_id = "demo_node_1"
+    event_payload_data = {
+        "node_id": demo_node_id,
+        "attributes": {
+            "message": "Hello from producer_demo with Event class!",
+            "source": "producer_demo",
+        },
+    }
     event_to_send = Event(
-        event_type="demo_event",
+        event_type=EventType.CREATE_NODE.value,
         timestamp=int(time.time()),
         payload=event_payload_data,
         source="producer_demo",  # Add source
+        node_id=demo_node_id,
     )
 
     # Convert Event object to dict for JSON serialization
@@ -68,6 +76,7 @@ def main() -> None:
                 "timestamp": event_to_send.timestamp,
                 "payload": event_to_send.payload,
                 "source": event_to_send.source,
+                "node_id": event_to_send.node_id,
             }
         )
     )

--- a/tests/test_consumer_demo.py
+++ b/tests/test_consumer_demo.py
@@ -57,6 +57,7 @@ def test_consumer_demo_processes_messages(monkeypatch):
     parsed = []
     def _fake_ingress(payload, adapter="default"):
         parsed.append(payload)
+        assert adapter == "kafka"
         return payload, payload
 
     monkeypatch.setattr(consumer_demo, "ingest_transport_payload", _fake_ingress)
@@ -67,4 +68,3 @@ def test_consumer_demo_processes_messages(monkeypatch):
     assert consumer.closed
     assert parsed
     assert parsed[0]["payload"]["embedding"] == [0.0]
-

--- a/tests/test_producer_demo.py
+++ b/tests/test_producer_demo.py
@@ -1,0 +1,49 @@
+# mypy: ignore-errors
+import json
+import importlib.util
+from pathlib import Path
+import sys
+
+module_path = Path(__file__).resolve().parents[1] / "src" / "ume" / "producer_demo.py"
+spec = importlib.util.spec_from_file_location("ume.producer_demo", module_path)
+assert spec and spec.loader
+producer_demo = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = producer_demo
+spec.loader.exec_module(producer_demo)
+
+
+class DummyProducer:
+    def __init__(self, conf):
+        self.conf = conf
+        self.produced = []
+
+    def produce(self, topic, value, callback=None):
+        self.produced.append((topic, value))
+        if callback is not None:
+            callback(None, type("Msg", (), {"topic": lambda self: topic, "partition": lambda self: 0, "offset": lambda self: 1})())
+
+    def flush(self):
+        return None
+
+
+def test_producer_demo_emits_schema_valid_create_node(monkeypatch):
+    holder = {}
+
+    def _producer_factory(conf):
+        p = DummyProducer(conf)
+        holder["producer"] = p
+        return p
+
+    monkeypatch.setattr(producer_demo, "Producer", _producer_factory)
+
+    producer_demo.main()
+
+    produced = holder["producer"].produced
+    assert produced
+    topic, raw = produced[0]
+    assert topic == producer_demo.TOPIC
+
+    event = json.loads(raw.decode("utf-8"))
+    assert event["eventType"] == "CREATE_NODE"
+    assert event["nodeId"] == "demo_node_1"
+    assert event["payload"]["node_id"] == "demo_node_1"


### PR DESCRIPTION
### Motivation
- Make the demo producer emit a schema-supported typed event and ensure the demo consumer can parse it with the same ingress assumptions used in production.
- Remove hidden dependency on a privacy/processor topic by wiring the demo producer and consumer to the same Kafka path so the quickstart works end-to-end.

### Description
- Replace the ad-hoc `demo_event` with a typed `CREATE_NODE` event and shape the payload to include `node_id` and `payload.attributes` so `validate_event_dict()` accepts it (`src/ume/producer_demo.py`).
- Align topics so both demo scripts use the raw ingress path by switching the consumer to `KAFKA_RAW_EVENTS_TOPIC` (`src/ume/consumer_demo.py`).
- Parse incoming messages in the demo consumer using the Kafka ingress assumptions via `ingest_transport_payload(..., adapter="kafka")` to match production normalization (`src/ume/consumer_demo.py`).
- Add an integration section and exact run commands to `QUICKSTART.md` showing `python -m ume.consumer_demo` and `python -m ume.producer_demo` and the expected message path.
- Add/adjust tests: update `tests/test_consumer_demo.py` to assert the Kafka adapter usage and add `tests/test_producer_demo.py` to validate the emitted `CREATE_NODE` event shape.

### Testing
- Ran linter checks with `ruff check src/ume/producer_demo.py src/ume/consumer_demo.py tests/test_consumer_demo.py tests/test_producer_demo.py` and they passed.
- Ran unit tests with `pytest -q tests/test_consumer_demo.py tests/test_producer_demo.py` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a7788a0483268f6ddaacee195e2c)