### PR TITLE
Route graph mutation endpoints through canonical event ingestion

### DIFF
--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -17,6 +17,8 @@ class EventType(str, Enum):
     UPDATE_NODE_ATTRIBUTES = "UPDATE_NODE_ATTRIBUTES"
     CREATE_EDGE = "CREATE_EDGE"
     DELETE_EDGE = "DELETE_EDGE"
+    REDACT_NODE = "REDACT_NODE"
+    REDACT_EDGE = "REDACT_EDGE"
     CREATE_ONTOLOGY_RELATION = "CREATE_ONTOLOGY_RELATION"
     RESEARCH_JOB_STARTED = "RESEARCH_JOB_STARTED"
     DATA_SOURCE_QUERIED = "DATA_SOURCE_QUERIED"
@@ -145,6 +147,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
         EventType.UPDATE_NODE_ATTRIBUTES,
         EventType.RESEARCH_JOB_STARTED,
         EventType.DOCUMENT_ARCHIVED,
+        EventType.REDACT_NODE,
     ]:
         payload_node_id = payload_val.get("node_id")
         if node_id_val is None and payload_node_id is not None:
@@ -164,6 +167,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
     elif event_type in [
         EventType.CREATE_EDGE,
         EventType.DELETE_EDGE,
+        EventType.REDACT_EDGE,
         EventType.CREATE_ONTOLOGY_RELATION,
         EventType.DATA_SOURCE_QUERIED,
         EventType.ENTITY_DISCOVERED,

--- a/src/ume/events/handlers/__init__.py
+++ b/src/ume/events/handlers/__init__.py
@@ -6,9 +6,10 @@ from .edge_handlers import (
     CreateEdgeHandler,
     CreateOntologyRelationHandler,
     DeleteEdgeHandler,
+    RedactEdgeHandler,
 )
 from .misc_handlers import NoOpEventHandler
-from .node_handlers import CreateNodeHandler, UpdateNodeAttributesHandler
+from .node_handlers import CreateNodeHandler, RedactNodeHandler, UpdateNodeAttributesHandler
 
 EVENT_HANDLER_REGISTRY: dict[EventType, EventHandler] = {
     EventType.CREATE_NODE: CreateNodeHandler(),
@@ -20,6 +21,8 @@ EVENT_HANDLER_REGISTRY: dict[EventType, EventHandler] = {
     EventType.ENTITY_DISCOVERED: CreateEdgeHandler(create_target_node_if_missing=True),
     EventType.CREATE_ONTOLOGY_RELATION: CreateOntologyRelationHandler(),
     EventType.DELETE_EDGE: DeleteEdgeHandler(),
+    EventType.REDACT_NODE: RedactNodeHandler(),
+    EventType.REDACT_EDGE: RedactEdgeHandler(),
     EventType.ANOMALY_DETECTED: NoOpEventHandler(),
 }
 

--- a/src/ume/events/handlers/edge_handlers.py
+++ b/src/ume/events/handlers/edge_handlers.py
@@ -113,3 +113,17 @@ class DeleteEdgeHandler(BaseEventHandler):
         )
         for listener in get_registered_listeners():
             listener.on_edge_deleted(source_node_id, target_node_id, label)
+
+
+class RedactEdgeHandler(BaseEventHandler):
+    def validate(self, context: HandlerContext) -> None:
+        require_edge_fields(context.event, event_label="REDACT_EDGE")
+
+    def apply(self, context: HandlerContext) -> None:
+        source_node_id, target_node_id, label = require_edge_fields(
+            context.event, event_label="REDACT_EDGE"
+        )
+        context.graph.redact_edge(source_node_id, target_node_id, label)
+
+    def emit_listeners(self, context: HandlerContext) -> None:
+        return None

--- a/src/ume/events/handlers/node_handlers.py
+++ b/src/ume/events/handlers/node_handlers.py
@@ -94,3 +94,27 @@ class UpdateNodeAttributesHandler(BaseEventHandler):
         if isinstance(node_id, str) and isinstance(attributes, dict):
             for listener in get_registered_listeners():
                 listener.on_node_updated(node_id, attributes)
+
+
+class RedactNodeHandler(BaseEventHandler):
+    def validate(self, context: HandlerContext) -> None:
+        event = context.event
+        require_str_field(
+            event.node_id,
+            field_name="node_id",
+            event=event,
+            event_label="REDACT_NODE",
+        )
+
+    def apply(self, context: HandlerContext) -> None:
+        event = context.event
+        node_id = require_str_field(
+            event.node_id,
+            field_name="node_id",
+            event=event,
+            event_label="REDACT_NODE",
+        )
+        context.graph.redact_node(node_id)
+
+    def emit_listeners(self, context: HandlerContext) -> None:
+        return None

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -30,12 +30,79 @@ from .query import Neo4jQueryEngine, build_events_query
 from .event import EventError
 from .processing import ProcessingError
 from .graph_schema import DEFAULT_SCHEMA
+from .rbac_adapter import AccessDeniedError
 from ume.services.ingest import ingest_event, ingest_events_batch
 
 # import shared API dependencies
 from . import api_deps as deps
 
 router = APIRouter()
+
+_ROUTE_SOURCE_SERVICE = "graph_routes"
+
+
+def _command_metadata(perm_graph: PermissionsGraphAdapter) -> Dict[str, Any]:
+    return {
+        "requested_by": {
+            "user_id": perm_graph.user_id,
+            "group_id": perm_graph.group_id,
+        },
+        "route": "graph_routes",
+    }
+
+
+def _canonical_command_event(
+    *,
+    event_type: str,
+    node_id: str | None = None,
+    target_node_id: str | None = None,
+    label: str | None = None,
+    payload: Dict[str, Any] | None = None,
+    metadata: Dict[str, Any] | None = None,
+) -> Dict[str, Any]:
+    command_payload = dict(payload or {})
+    if metadata:
+        command_payload["metadata"] = metadata
+    return {
+        "eventType": event_type,
+        "eventId": str(uuid4()),
+        "timestamp": int(time.time()),
+        "sourceService": _ROUTE_SOURCE_SERVICE,
+        "node_id": node_id,
+        "target_node_id": target_node_id,
+        "label": label,
+        "payload": command_payload,
+    }
+
+
+def _require_edge_permissions(
+    perm_graph: PermissionsGraphAdapter,
+    source: str,
+    target: str,
+    label: str,
+) -> None:
+    perm_graph._require_editor(source)
+    if label not in {"OWNED_BY", "SHARED_WITH", "INVITES"}:
+        perm_graph._require_editor(target)
+
+
+async def _ingest_event_dispatch(event: Dict[str, Any], graph: IGraphAdapter) -> None:
+    if isinstance(graph, IAsyncGraphAdapter) or inspect.iscoroutinefunction(
+        getattr(graph, "add_node", None)
+    ):
+        await ingest_event_async(event, graph)  # type: ignore[arg-type]
+    else:
+        ingest_event(event, graph)
+
+
+async def _ingest_events_batch_dispatch(events: List[Dict[str, Any]], graph: IGraphAdapter) -> None:
+    if isinstance(graph, IAsyncGraphAdapter) or inspect.iscoroutinefunction(
+        getattr(graph, "add_node", None)
+    ):
+        for event in events:
+            await ingest_event_async(event, graph)  # type: ignore[arg-type]
+    else:
+        ingest_events_batch(events, graph)
 
 
 async def _maybe_call(graph: IGraphAdapter, name: str, *args: Any) -> Any:
@@ -264,9 +331,17 @@ async def api_subgraph(
 async def api_redact_node(
     node_id: str,
     perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
+    graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> Dict[str, Any]:
     """Redact (delete) a node by its ID."""
-    await _maybe_call(perm_graph, "redact_node", node_id)
+    perm_graph._require_editor(node_id)
+    event = _canonical_command_event(
+        event_type="REDACT_NODE",
+        node_id=node_id,
+        payload={"node_id": node_id},
+        metadata=_command_metadata(perm_graph),
+    )
+    await _ingest_event_dispatch(event, graph)
     return {"status": "ok"}
 
 
@@ -318,11 +393,19 @@ async def api_store_events_batch(
 async def api_redact_edge(
     req: RedactEdgeRequest,
     perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
+    graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> Dict[str, Any]:
     """Redact an edge between two nodes."""
-    await _maybe_call(
-        perm_graph, "redact_edge", req.source, req.target, req.label
+    _require_edge_permissions(perm_graph, req.source, req.target, req.label)
+    event = _canonical_command_event(
+        event_type="REDACT_EDGE",
+        node_id=req.source,
+        target_node_id=req.target,
+        label=req.label,
+        payload={"source_node_id": req.source, "target_node_id": req.target, "label": req.label},
+        metadata=_command_metadata(perm_graph),
     )
+    await _ingest_event_dispatch(event, graph)
     return {"status": "ok"}
 
 
@@ -330,9 +413,16 @@ async def api_redact_edge(
 async def api_create_node(
     req: NodeCreateRequest,
     perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
+    graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> Dict[str, Any]:
     """Create a node with optional attributes."""
-    await _maybe_call(perm_graph, "add_node", req.id, req.attributes or {})
+    event = _canonical_command_event(
+        event_type="CREATE_NODE",
+        node_id=req.id,
+        payload={"node_id": req.id, "attributes": req.attributes or {}},
+        metadata=_command_metadata(perm_graph),
+    )
+    await _ingest_event_dispatch(event, graph)
     return {"status": "ok"}
 
 
@@ -341,9 +431,17 @@ async def api_update_node(
     node_id: str,
     req: NodeUpdateRequest,
     perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
+    graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> Dict[str, Any]:
     """Update attributes of an existing node."""
-    await _maybe_call(perm_graph, "update_node", node_id, req.attributes)
+    perm_graph._require_editor(node_id)
+    event = _canonical_command_event(
+        event_type="UPDATE_NODE_ATTRIBUTES",
+        node_id=node_id,
+        payload={"node_id": node_id, "attributes": req.attributes},
+        metadata=_command_metadata(perm_graph),
+    )
+    await _ingest_event_dispatch(event, graph)
     return {"status": "ok"}
 
 
@@ -351,9 +449,17 @@ async def api_update_node(
 async def api_delete_node(
     node_id: str,
     perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
+    graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> Dict[str, Any]:
     """Remove a node from the graph."""
-    await _maybe_call(perm_graph, "redact_node", node_id)
+    perm_graph._require_editor(node_id)
+    event = _canonical_command_event(
+        event_type="REDACT_NODE",
+        node_id=node_id,
+        payload={},
+        metadata=_command_metadata(perm_graph),
+    )
+    await _ingest_event_dispatch(event, graph)
     return {"status": "ok"}
 
 
@@ -361,20 +467,30 @@ async def api_delete_node(
 async def api_create_edge(
     req: EdgeCreateRequest,
     perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
+    graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> Dict[str, Any]:
     """Create an edge between two nodes."""
     edge_def = DEFAULT_SCHEMA.edge_labels.get(req.label)
     version = edge_def.version if edge_def else None
     attrs = dict(req.attrs or {})
-    await _maybe_call(
-        perm_graph,
-        "add_edge",
-        req.source,
-        req.target,
-        req.label,
-        attrs,
-        version,
+    is_bootstrap_owner = (
+        req.label == "OWNED_BY" and req.source in perm_graph._bootstrap_owner_nodes
     )
+    if not is_bootstrap_owner and req.label == "OWNED_BY" and not perm_graph._has_permission(
+        req.source, "editor"
+    ):
+        raise AccessDeniedError("OWNED_BY edges must be bootstrapped before an editor exists")
+    if not is_bootstrap_owner:
+        _require_edge_permissions(perm_graph, req.source, req.target, req.label)
+    event = _canonical_command_event(
+        event_type="CREATE_EDGE",
+        node_id=req.source,
+        target_node_id=req.target,
+        label=req.label,
+        payload={"source_node_id": req.source, "target_node_id": req.target, "label": req.label, "attributes": attrs, "schema_version": version},
+        metadata=_command_metadata(perm_graph),
+    )
+    await _ingest_event_dispatch(event, graph)
     return {"status": "ok"}
 
 
@@ -384,9 +500,19 @@ async def api_delete_edge(
     target: str,
     label: str,
     perm_graph: PermissionsGraphAdapter = Depends(deps.get_permissions_graph),
+    graph: IGraphAdapter = Depends(deps.get_graph),
 ) -> Dict[str, Any]:
     """Delete an edge identified by source, target and label."""
-    await _maybe_call(perm_graph, "delete_edge", source, target, label)
+    _require_edge_permissions(perm_graph, source, target, label)
+    event = _canonical_command_event(
+        event_type="DELETE_EDGE",
+        node_id=source,
+        target_node_id=target,
+        label=label,
+        payload={"source_node_id": source, "target_node_id": target, "label": label},
+        metadata=_command_metadata(perm_graph),
+    )
+    await _ingest_event_dispatch(event, graph)
     return {"status": "ok"}
 
 
@@ -499,4 +625,3 @@ async def api_store_event(
         raise HTTPException(status_code=400, detail=str(exc))
 
     return {"status": "ok"}
-

--- a/tests/test_graph_routes_permissions.py
+++ b/tests/test_graph_routes_permissions.py
@@ -178,3 +178,156 @@ def test_subgraph_filters_view_only_subjects(
     payload = response.json()
     assert set(payload["nodes"].keys()) == {"visible"}
     assert payload["edges"] == []
+
+
+def _issue_token(client: TestClient) -> dict[str, str]:
+    token_res = client.post(
+        "/auth/token",
+        data={
+            "username": settings.UME_OAUTH_USERNAME,
+            "password": settings.UME_OAUTH_PASSWORD,
+        },
+    )
+    token_res.raise_for_status()
+    token = token_res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_mutation_endpoints_match_events_graph_results() -> None:
+    conv_graph = MockGraph()
+    evt_graph = MockGraph()
+    conv_client: TestClient | None = None
+    evt_client: TestClient | None = None
+    try:
+        configure_graph(conv_graph)
+        conv_client = TestClient(app)
+        conv_headers = _issue_token(conv_client)
+
+        conv_graph.add_node("doc", {"type": "Document"})
+        conv_graph.add_node("owner", {"type": "User"})
+        conv_graph.add_node("team", {"type": "UserGroup"})
+        conv_graph.add_edge("doc", "owner", "OWNED_BY", {"permission_level": "editor"})
+        params = {"user_id": "owner"}
+
+        assert conv_client.post(
+            "/nodes", json={"id": "draft", "attributes": {"title": "t1"}}, headers=conv_headers, params=params
+        ).status_code == 200
+        assert conv_client.patch(
+            "/nodes/draft", json={"attributes": {"title": "t2"}}, headers=conv_headers, params=params
+        ).status_code == 200
+        assert conv_client.post(
+            "/edges",
+            json={
+                "source": "doc",
+                "target": "team",
+                "label": "SHARED_WITH",
+                "attrs": {"permission_level": "viewer"},
+            },
+            headers=conv_headers,
+            params=params,
+        ).status_code == 200
+        assert conv_client.post(
+            "/redact/edge",
+            json={"source": "doc", "target": "team", "label": "SHARED_WITH"},
+            headers=conv_headers,
+            params=params,
+        ).status_code == 200
+        assert conv_client.post(
+            "/redact/node/draft", headers=conv_headers, params=params
+        ).status_code == 200
+
+        conv_dump = conv_graph.dump()
+
+        configure_graph(evt_graph)
+        evt_client = TestClient(app)
+        evt_headers = _issue_token(evt_client)
+
+        evt_graph.add_node("doc", {"type": "Document"})
+        evt_graph.add_node("owner", {"type": "User"})
+        evt_graph.add_node("team", {"type": "UserGroup"})
+        evt_graph.add_edge("doc", "owner", "OWNED_BY", {"permission_level": "editor"})
+
+        events = [
+            {
+                "eventType": "CREATE_NODE",
+                "timestamp": 1700000000,
+                "node_id": "draft",
+                "payload": {"node_id": "draft", "attributes": {"title": "t1"}},
+            },
+            {
+                "eventType": "UPDATE_NODE_ATTRIBUTES",
+                "timestamp": 1700000001,
+                "node_id": "draft",
+                "payload": {"node_id": "draft", "attributes": {"title": "t2"}},
+            },
+            {
+                "eventType": "CREATE_EDGE",
+                "timestamp": 1700000002,
+                "node_id": "doc",
+                "target_node_id": "team",
+                "label": "SHARED_WITH",
+                "payload": {
+                    "source_node_id": "doc",
+                    "target_node_id": "team",
+                    "label": "SHARED_WITH",
+                    "attributes": {"permission_level": "viewer"},
+                },
+            },
+            {
+                "eventType": "REDACT_EDGE",
+                "timestamp": 1700000003,
+                "node_id": "doc",
+                "target_node_id": "team",
+                "label": "SHARED_WITH",
+                "payload": {
+                    "source_node_id": "doc",
+                    "target_node_id": "team",
+                    "label": "SHARED_WITH",
+                },
+            },
+            {
+                "eventType": "REDACT_NODE",
+                "timestamp": 1700000004,
+                "node_id": "draft",
+                "payload": {"node_id": "draft"},
+            },
+        ]
+        for event in events:
+            assert evt_client.post("/events", json=event, headers=evt_headers).status_code == 200
+
+        evt_dump = evt_graph.dump()
+        assert conv_dump == evt_dump
+    finally:
+        with TOKENS_LOCK:
+            TOKENS.clear()
+        if conv_client is not None:
+            conv_client.close()
+        if evt_client is not None:
+            evt_client.close()
+
+
+def test_mutation_endpoints_match_events_policy_behavior(
+    client_with_graph: tuple[TestClient, MockGraph, dict[str, str]],
+) -> None:
+    client, _, headers = client_with_graph
+
+    convenience = client.post(
+        "/nodes",
+        json={"id": "forbidden", "attributes": {"type": "Document"}},
+        headers=headers,
+        params={"user_id": "owner"},
+    )
+    assert convenience.status_code == 400
+
+    event = client.post(
+        "/events",
+        json={
+            "eventType": "CREATE_NODE",
+            "timestamp": 1700000000,
+            "node_id": "forbidden",
+            "payload": {"node_id": "forbidden", "attributes": {"type": "Document"}},
+        },
+        headers=headers,
+    )
+    assert event.status_code == 400
+    assert convenience.json()["detail"] == event.json()["detail"]


### PR DESCRIPTION
### Motivation

- Unify all graph mutations (node/edge create/update/delete/redact) to flow through the canonical event ingestion pipeline for consistent policy evaluation, auditing, and ledger tracing.  
- Ensure convenience HTTP endpoints remain for UX but act as command translators rather than performing direct graph mutations.  
- Make each translated command carry canonical event fields (`eventType`, `eventId`, `timestamp`, `sourceService`) and request subject metadata for auditability.  
- Add route-level parity tests to guarantee mutation endpoints and `/events` produce identical graph outcomes and identical policy behavior.

### Description

- Refactored mutation routes in `src/ume/graph_routes.py` to build canonical command events via a new helper `_canonical_command_event` and dispatch via ingestion helpers (`_ingest_event_dispatch` / `_ingest_events_batch_dispatch`) instead of calling graph mutator methods directly.  
- Added route-level permission checks and preserved bootstrap-owner logic while moving enforcement to command translation helpers (helpers include `_require_edge_permissions` and `_command_metadata`).  
- Introduced `REDACT_NODE` and `REDACT_EDGE` event types in `src/ume/event.py` and implemented `RedactNodeHandler` and `RedactEdgeHandler` in `src/ume/events/handlers/*` and registered them in the handler registry so redaction commands flow through the same pipeline.  
- Added parity tests in `tests/test_graph_routes_permissions.py` that assert the convenience mutation endpoints and `/events` ingestion produce identical graph dumps and identical policy rejection responses.

### Testing

- Ran `ruff check` on the changed files (`graph_routes.py`, `event.py`, handlers and the new tests`) and it passed.  
- Ran byte-compile (`python -m py_compile`) on the modified files and it succeeded.  
- Ran `pytest -q tests/test_graph_routes_permissions.py` which failed in this environment due to an import error (`ModuleNotFoundError: No module named 'fastapi.testclient'`) caused by the test/runtime environment rather than the code changes.  
- Ran `mypy` which surfaced project-wide baseline type issues unrelated to these changes, so type-check failures are acknowledged as existing in the repository rather than introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5a91495948326a00985103c21913c)