### PR TITLE
Refactor ingress to typed canonical envelope, protocol adapters, and centralized schema-versioning

### DIFF
--- a/src/ume/events/adapters/__init__.py
+++ b/src/ume/events/adapters/__init__.py
@@ -1,0 +1,7 @@
+"""Transport-specific ingress adapters."""
+
+from .cli import adapt_cli_payload
+from .grpc import adapt_grpc_payload
+from .kafka import adapt_kafka_payload
+
+__all__ = ["adapt_cli_payload", "adapt_grpc_payload", "adapt_kafka_payload"]

--- a/src/ume/events/adapters/cli.py
+++ b/src/ume/events/adapters/cli.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+def adapt_cli_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(deepcopy(payload))
+    if "nodeId" in normalized and "node_id" not in normalized:
+        normalized["node_id"] = normalized["nodeId"]
+    if "targetNodeId" in normalized and "target_node_id" not in normalized:
+        normalized["target_node_id"] = normalized["targetNodeId"]
+    return normalized

--- a/src/ume/events/adapters/grpc.py
+++ b/src/ume/events/adapters/grpc.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+def adapt_grpc_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(deepcopy(payload))
+    if "sourceService" in normalized and "source" not in normalized:
+        normalized["source"] = normalized["sourceService"]
+    if "schemaVersion" in normalized and "schema_version" not in normalized:
+        normalized["schema_version"] = normalized["schemaVersion"]
+    return normalized

--- a/src/ume/events/adapters/kafka.py
+++ b/src/ume/events/adapters/kafka.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+def adapt_kafka_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    normalized = dict(deepcopy(payload))
+    if "nodeId" in normalized and "node_id" not in normalized:
+        normalized["node_id"] = normalized["nodeId"]
+    if "targetNodeId" in normalized and "target_node_id" not in normalized:
+        normalized["target_node_id"] = normalized["targetNodeId"]
+    return normalized

--- a/src/ume/events/contract.py
+++ b/src/ume/events/contract.py
@@ -21,19 +21,76 @@ _SNAKE_TO_CAMEL["source"] = "sourceService"
 
 
 @dataclass(frozen=True)
+class CanonicalMetadata:
+    event_id: str | None
+    event_type: str | None
+    timestamp: int | str | None
+    schema_version: str | None
+    source: str | None
+    correlation_id: str | None
+    subject_entity: Dict[str, str] | None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "timestamp": self.timestamp,
+            "schema_version": self.schema_version,
+            "source": self.source,
+            "correlation_ids": {"correlation_id": self.correlation_id},
+            "subject_entity": self.subject_entity,
+        }
+
+
+@dataclass(frozen=True)
+class CanonicalGraph:
+    node_id: str | None
+    target_node_id: str | None
+    label: str | None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "target_node_id": self.target_node_id,
+            "label": self.label,
+        }
+
+
+@dataclass(frozen=True)
 class CanonicalEnvelope:
     """Canonical in-memory shape used by parsers and transport adapters."""
 
-    metadata: Dict[str, Any]
-    graph: Dict[str, Any]
+    metadata: CanonicalMetadata
+    graph: CanonicalGraph
     payload: Dict[str, Any]
 
     def as_dict(self) -> Dict[str, Any]:
         return {
-            "metadata": dict(self.metadata),
-            "graph": dict(self.graph),
+            "metadata": self.metadata.as_dict(),
+            "graph": self.graph.as_dict(),
             "payload": self.payload if isinstance(self.payload, dict) else self.payload,
         }
+
+
+def _envelope_from_data(data: Mapping[str, Any]) -> CanonicalEnvelope:
+    metadata = CanonicalMetadata(
+        event_id=data.get("event_id"),
+        event_type=data.get("event_type"),
+        timestamp=data.get("timestamp"),
+        schema_version=data.get("schema_version"),
+        source=data.get("source"),
+        correlation_id=data.get("correlation_id"),
+        subject_entity=data.get("subject_entity"),
+    )
+    graph = CanonicalGraph(
+        node_id=data.get("node_id"),
+        target_node_id=data.get("target_node_id"),
+        label=data.get("label"),
+    )
+    payload = data.get("payload", {})
+    if not isinstance(payload, dict):
+        payload = payload
+    return CanonicalEnvelope(metadata=metadata, graph=graph, payload=payload)
 
 
 def _to_snake_keys(data: Mapping[str, Any]) -> Dict[str, Any]:
@@ -53,27 +110,11 @@ def canonicalize_event(data: Mapping[str, Any]) -> Dict[str, Any]:
     snake_data = _to_snake_keys(data)
     event_data = snake_data.get("event") if isinstance(snake_data.get("event"), Mapping) else snake_data
 
-    metadata = {
-        "event_id": event_data.get("event_id"),
-        "event_type": event_data.get("event_type"),
-        "timestamp": event_data.get("timestamp"),
+    resolved = {
+        **event_data,
         "schema_version": snake_data.get("schema_version") or event_data.get("schema_version"),
-        "source": event_data.get("source"),
-        "correlation_ids": {
-            "correlation_id": event_data.get("correlation_id"),
-        },
-        "subject_entity": event_data.get("subject_entity"),
     }
-    graph = {
-        "node_id": event_data.get("node_id"),
-        "target_node_id": event_data.get("target_node_id"),
-        "label": event_data.get("label"),
-    }
-    payload = event_data.get("payload", {})
-    if not isinstance(payload, dict):
-        payload = payload
-
-    return CanonicalEnvelope(metadata=metadata, graph=graph, payload=payload).as_dict()
+    return _envelope_from_data(resolved).as_dict()
 
 
 def canonical_to_legacy_dict(canonical: Mapping[str, Any]) -> Dict[str, Any]:

--- a/src/ume/events/ingress.py
+++ b/src/ume/events/ingress.py
@@ -2,36 +2,21 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
-from typing import Any, Dict, Mapping, Literal
+from typing import Any, Dict, Mapping, Literal, Callable
 
 from ..event import Event, parse_event
 from ..schema_utils import validate_canonical_event
+from .adapters import adapt_cli_payload, adapt_grpc_payload, adapt_kafka_payload
 from .contract import canonicalize_event
 
 IngressAdapter = Literal["default", "kafka", "grpc", "cli"]
 
-
-def _legacy_transport_adapter(
-    payload: Mapping[str, Any],
-    *,
-    adapter: IngressAdapter,
-) -> Dict[str, Any]:
-    normalized = dict(payload)
-
-    if adapter in {"kafka", "cli"}:
-        if "nodeId" in normalized and "node_id" not in normalized:
-            normalized["node_id"] = normalized["nodeId"]
-        if "targetNodeId" in normalized and "target_node_id" not in normalized:
-            normalized["target_node_id"] = normalized["targetNodeId"]
-
-    if adapter == "grpc":
-        if "sourceService" in normalized and "source" not in normalized:
-            normalized["source"] = normalized["sourceService"]
-        if "schemaVersion" in normalized and "schema_version" not in normalized:
-            normalized["schema_version"] = normalized["schemaVersion"]
-
-    return normalized
+_ADAPTERS: dict[IngressAdapter, Callable[[Mapping[str, Any]], dict[str, Any]]] = {
+    "default": lambda payload: dict(payload),
+    "kafka": adapt_kafka_payload,
+    "grpc": adapt_grpc_payload,
+    "cli": adapt_cli_payload,
+}
 
 
 def ingest_transport_payload(
@@ -41,7 +26,7 @@ def ingest_transport_payload(
 ) -> tuple[Dict[str, Any], Event]:
     """Normalize ``payload`` into canonical shape and parse an :class:`~ume.event.Event`."""
 
-    adapted = _legacy_transport_adapter(deepcopy(payload), adapter=adapter)
+    adapted = _ADAPTERS[adapter](payload)
     canonical = canonicalize_event(adapted)
     validate_canonical_event(canonical)
     event = parse_event(canonical)
@@ -49,4 +34,3 @@ def ingest_transport_payload(
 
 
 __all__ = ["IngressAdapter", "ingest_transport_payload"]
-

--- a/src/ume/events/versioning.py
+++ b/src/ume/events/versioning.py
@@ -1,0 +1,33 @@
+"""Schema-version resolution for event ingestion."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def normalize_schema_version(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def resolve_schema_version(
+    canonical_event: Mapping[str, Any],
+    *,
+    explicit_version: str | None = None,
+    fallback_version: str | None = None,
+    default_version: str,
+) -> str:
+    metadata = canonical_event.get("metadata") if isinstance(canonical_event, Mapping) else None
+    metadata_schema = None
+    if isinstance(metadata, Mapping):
+        metadata_schema = metadata.get("schema_version")
+
+    return (
+        normalize_schema_version(explicit_version)
+        or normalize_schema_version(metadata_schema)
+        or normalize_schema_version(fallback_version)
+        or default_version
+    )

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -14,7 +14,7 @@ except Exception:  # pragma: no cover - provide stub for tests without limiter
             return None
 
         return _noop
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, Field, AliasChoices, ConfigDict, model_validator
 from pydantic_core import PydanticCustomError
 from sse_starlette.sse import EventSourceResponse
 
@@ -203,14 +203,30 @@ class SnapshotPathRequest(BaseModel):
 class EventRequest(BaseModel):
     """Schema for a single event."""
 
-    eventType: str
+    model_config = ConfigDict(populate_by_name=True)
+
+    event_type: str = Field(validation_alias=AliasChoices("event_type", "eventType"))
     timestamp: int
-    eventId: str | None = None
-    sourceService: str | None = None
+    event_id: str | None = Field(default=None, validation_alias=AliasChoices("event_id", "eventId"))
+    source: str | None = Field(default=None, validation_alias=AliasChoices("source", "sourceService"))
     node_id: str | None = None
-    target_node_id: str | None = None
+    target_node_id: str | None = Field(default=None, validation_alias=AliasChoices("target_node_id", "targetNodeId"))
     label: str | None = None
+    schema_version: str | None = Field(default=None, validation_alias=AliasChoices("schema_version", "schemaVersion"))
     payload: Dict[str, Any] | None = None
+
+    def to_ingress_dict(self) -> Dict[str, Any]:
+        return {
+            "event_type": self.event_type,
+            "event_id": self.event_id,
+            "timestamp": self.timestamp,
+            "source": self.source,
+            "node_id": self.node_id,
+            "target_node_id": self.target_node_id,
+            "label": self.label,
+            "schema_version": self.schema_version,
+            "payload": self.payload,
+        }
     
 
 @router.get("/query")
@@ -353,7 +369,7 @@ async def api_post_events_batch(
 ) -> Dict[str, Any]:
     """Apply multiple events sequentially to the graph."""
     try:
-        payload = [e.model_dump(exclude_none=True) for e in events]
+        payload = [e.to_ingress_dict() for e in events]
         if isinstance(graph, IAsyncGraphAdapter) or inspect.iscoroutinefunction(
             getattr(graph, "add_node", None)
         ):
@@ -375,7 +391,7 @@ async def api_store_events_batch(
 ) -> Dict[str, Any]:
     """Alias for :func:`api_post_events_batch`."""
     try:
-        payload = [e.model_dump(exclude_none=True) for e in events]
+        payload = [e.to_ingress_dict() for e in events]
         if isinstance(graph, IAsyncGraphAdapter) or inspect.iscoroutinefunction(
             getattr(graph, "add_node", None)
         ):
@@ -593,7 +609,7 @@ async def api_post_event(
 ) -> Dict[str, Any]:
     """Validate and apply an event to the graph."""
     try:
-        data = req.model_dump(exclude_none=True)
+        data = req.to_ingress_dict()
         if isinstance(graph, IAsyncGraphAdapter) or inspect.iscoroutinefunction(
             getattr(graph, "add_node", None)
         ):
@@ -614,7 +630,7 @@ async def api_store_event(
 ) -> Dict[str, Any]:
     """Alias for :func:`api_post_event`."""
     try:
-        data = req.model_dump(exclude_none=True)
+        data = req.to_ingress_dict()
         if isinstance(graph, IAsyncGraphAdapter) or inspect.iscoroutinefunction(
             getattr(graph, "add_node", None)
         ):

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -10,6 +10,7 @@ from google.protobuf import struct_pb2
 from ..event import Event, EventError, EventType
 from ..events.contract import canonical_to_legacy_dict
 from ..events.ingress import ingest_transport_payload
+from ..events.versioning import resolve_schema_version
 from ..processing import DEFAULT_VERSION, apply_event_to_graph
 from ..graph_adapter import IGraphAdapter
 from ..async_graph_adapter import IAsyncGraphAdapter, ingest_event_async
@@ -70,14 +71,6 @@ def _fallback_schema_version() -> str:
         return ""
 
 
-def _normalize_schema_version(value: Any) -> str | None:
-    if isinstance(value, str):
-        stripped = value.strip()
-        if stripped:
-            return stripped
-    return None
-
-
 def _build_graph_projector(
     graph: IGraphAdapter,
     *,
@@ -90,16 +83,11 @@ def _build_graph_projector(
             raise EventError("missing_canonical_or_event")
         metadata = canonical["metadata"]
         unwrapped_event_data = canonical_to_legacy_dict(canonical)
-        envelope_version = metadata.get("schema_version")
-        explicit_version = _normalize_schema_version(schema_version)
-        normalized_envelope_version = _normalize_schema_version(envelope_version)
-        normalized_payload_version = _normalize_schema_version(unwrapped_event_data.get("schema_version"))
-        detected_version = normalized_envelope_version or normalized_payload_version
-        effective_version = (
-            explicit_version
-            or detected_version
-            or _normalize_schema_version(_fallback_schema_version())
-            or DEFAULT_VERSION
+        effective_version = resolve_schema_version(
+            canonical,
+            explicit_version=schema_version,
+            fallback_version=_fallback_schema_version(),
+            default_version=DEFAULT_VERSION,
         )
         details = apply_classification(context)
         apply_event(event, graph, schema_version=effective_version)
@@ -147,9 +135,11 @@ def ingest_events_batch(
 def dict_to_envelope(data: Dict[str, Any]) -> Any:
     """Convert a raw event dictionary to :class:`~ume_client.events_pb2.EventEnvelope`."""
     canonical, evt = ingest_transport_payload(data, adapter="grpc")
-    schema_version = _normalize_schema_version(canonical["metadata"].get("schema_version"))
-    if not schema_version:
-        schema_version = _fallback_schema_version()
+    schema_version = resolve_schema_version(
+        canonical,
+        fallback_version=_fallback_schema_version(),
+        default_version=DEFAULT_VERSION,
+    )
     struct_payload = struct_pb2.Struct()
     struct_payload.update(evt.payload)
     meta = events_pb2.BaseEvent(
@@ -162,7 +152,7 @@ def dict_to_envelope(data: Dict[str, Any]) -> Any:
         label=evt.label or "",
         payload=struct_payload,
     )
-    envelope_kwargs = {"schema_version": schema_version or DEFAULT_VERSION}
+    envelope_kwargs = {"schema_version": schema_version}
     envelope = events_pb2.EventEnvelope(**envelope_kwargs)
     if evt.event_type == EventType.CREATE_NODE.value:
         return events_pb2.EventEnvelope(

--- a/tests/test_graph_routes_event_request.py
+++ b/tests/test_graph_routes_event_request.py
@@ -1,0 +1,33 @@
+from ume.graph_routes import EventRequest
+
+
+def test_event_request_accepts_legacy_aliases() -> None:
+    req = EventRequest(
+        eventType="CREATE_NODE",
+        eventId="e-1",
+        timestamp=1700000000,
+        sourceService="api",
+        node_id="n1",
+        payload={"node_id": "n1", "attributes": {}},
+    )
+
+    event = req.to_ingress_dict()
+    assert event["event_type"] == "CREATE_NODE"
+    assert event["event_id"] == "e-1"
+    assert event["source"] == "api"
+
+
+def test_event_request_accepts_canonical_envelope_keys() -> None:
+    req = EventRequest(
+        event_type="CREATE_EDGE",
+        event_id="e-2",
+        timestamp=1700000001,
+        source="api",
+        node_id="n1",
+        target_node_id="n2",
+        label="RELATES_TO",
+        schema_version="3.0.0",
+        payload={"attributes": {}},
+    )
+
+    assert req.to_ingress_dict()["schema_version"] == "3.0.0"

--- a/tests/test_ingress_boundary_contract.py
+++ b/tests/test_ingress_boundary_contract.py
@@ -42,3 +42,23 @@ def test_ingress_paths_produce_identical_canonical_output() -> None:
 
     assert kafka_canonical == grpc_canonical == cli_canonical
     assert kafka_event == grpc_event == cli_event
+
+
+def test_ingress_accepts_legacy_nested_event_shape() -> None:
+    legacy_payload = {
+        "schemaVersion": "2.0.0",
+        "event": {
+            "eventId": "evt-2",
+            "eventType": "CREATE_NODE",
+            "timestamp": 1700000000,
+            "sourceService": "legacy-producer",
+            "nodeId": "n1",
+            "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
+        },
+    }
+
+    canonical, event = ingest_transport_payload(legacy_payload, adapter="kafka")
+
+    assert canonical["metadata"]["schema_version"] == "2.0.0"
+    assert canonical["graph"]["node_id"] == "n1"
+    assert event.event_type == "CREATE_NODE"


### PR DESCRIPTION
### Motivation

- Replace ad-hoc transport rewrites with explicit per-protocol adapters so payload translation is localized and testable.
- Introduce a single internal typed envelope model as the canonical input shape consumed by parsers and downstream services to reduce scattered normalization logic.
- Centralize schema-version resolution into one component so version detection is consistent across ingestion and protobuf conversion.

### Description

- Added transport adapters under `src/ume/events/adapters/` (`kafka.py`, `grpc.py`, `cli.py`) and switched `ingest_transport_payload` in `src/ume/events/ingress.py` to dispatch to these adapters instead of inline rewrites.
- Reworked the contract to use typed dataclasses `CanonicalMetadata`, `CanonicalGraph`, and `CanonicalEnvelope` and a builder `_envelope_from_data`, and updated `canonicalize_event` to produce the typed envelope before emitting the canonical dict (`src/ume/events/contract.py`).
- Introduced `src/ume/events/versioning.py` with `resolve_schema_version` and wired ingestion and protobuf helpers in `src/ume/services/ingest.py` to use it instead of repeating normalization logic.
- Updated `EventRequest` in `src/ume/graph_routes.py` to accept legacy aliases while exposing a `to_ingress_dict()` method that maps into the canonical snake_case envelope shape, and changed event endpoints to use that mapping.
- Added compatibility tests to ensure legacy nested/alias shapes still normalize correctly (`tests/test_ingress_boundary_contract.py`, `tests/test_graph_routes_event_request.py`).

### Testing

- Ran `ruff` checks on modified modules (`src/ume/events/contract.py`, `src/ume/events/ingress.py`, `src/ume/events/adapters`, `src/ume/events/versioning.py`, `src/ume/graph_routes.py`, and new tests) and they passed.
- Executed `pytest -q tests/test_ingress_boundary_contract.py tests/test_event_contract_normalization.py` and both tests passed (`3 passed`).
- Attempted to run a broader test set including `tests/test_ingest_schema_version.py`, but collection failed due to missing optional runtime dependencies (`pydantic` and `google.protobuf`) in the current environment; these are external to the refactor and caused import-time errors during test collection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5b05df78c8326af0eb624eefdfe76)