### PR TITLE
Respect event schema_version when applying handlers and replaying streams

### DIFF
--- a/src/ume/cli/prompt.py
+++ b/src/ume/cli/prompt.py
@@ -99,7 +99,7 @@ class UMEPrompt(Cmd):
                 "timestamp": self._get_timestamp(),
             }
             evt = parse_event(canonicalize_event(event_data))
-            apply_event_to_graph(evt, self.graph)
+            apply_event_to_graph(evt, self.graph, schema_version=evt.schema_version)
             print(f"Node '{node_id}' created.")
         except (json.JSONDecodeError, EventError, ProcessingError) as e:
             print(f"Error: {e}")
@@ -124,7 +124,7 @@ class UMEPrompt(Cmd):
                 "timestamp": self._get_timestamp(),
             }
             evt = parse_event(canonicalize_event(event_data))
-            apply_event_to_graph(evt, self.graph)
+            apply_event_to_graph(evt, self.graph, schema_version=evt.schema_version)
             print(f"Edge ({source_id})->({target_id}) [{label}] created.")
         except (EventError, ProcessingError) as e:
             print(f"Error: {e}")
@@ -149,7 +149,7 @@ class UMEPrompt(Cmd):
                 "timestamp": self._get_timestamp(),
             }
             evt = parse_event(canonicalize_event(event_data))
-            apply_event_to_graph(evt, self.graph)
+            apply_event_to_graph(evt, self.graph, schema_version=evt.schema_version)
             print(f"Edge ({source_id})->({target_id}) [{label}] deleted.")
         except (EventError, ProcessingError) as e:
             print(f"Error: {e}")

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -6,6 +6,7 @@ import logging
 
 from .events.contract import canonical_timestamp_to_int
 from .events.types import EventType
+from .events.versioning import normalize_schema_version
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,7 @@ class Event:
         subject_entity (Optional[Dict[str, str]]): Entity this event refers to as an object
             with ``id`` and ``type`` keys.
         source_service (Optional[str]): Name of the service emitting the event.
+        schema_version (Optional[str]): Event schema version used to resolve handler/schema behavior.
     """
 
     event_type: str
@@ -50,6 +52,7 @@ class Event:
     correlation_id: Optional[str] = None
     subject_entity: Optional[Dict[str, str]] = None
     source_service: Optional[str] = None
+    schema_version: Optional[str] = None
 
 
 class EventError(ValueError):
@@ -92,6 +95,8 @@ def parse_event(data: Dict[str, Any]) -> Event:
         raise EventError("Invalid timestamp format") from exc
 
     event_id_val = metadata.get("event_id")
+    schema_version_raw = metadata.get("schema_version")
+    schema_version_val = normalize_schema_version(schema_version_raw)
     correlation_ids = metadata.get("correlation_ids")
     correlation_id_val = None
     if isinstance(correlation_ids, Mapping):
@@ -107,6 +112,10 @@ def parse_event(data: Dict[str, Any]) -> Event:
     if event_id_val is not None and not isinstance(event_id_val, str):
         raise EventError(
             f"Invalid type for 'event_id': expected str, got {type(event_id_val).__name__}"
+        )
+    if schema_version_raw is not None and schema_version_val is None:
+        raise EventError(
+            f"Invalid type for 'schema_version': expected non-empty str, got {type(schema_version_raw).__name__}"
         )
     if correlation_id_val is not None and not isinstance(correlation_id_val, str):
         raise EventError(
@@ -176,4 +185,5 @@ def parse_event(data: Dict[str, Any]) -> Event:
         correlation_id=correlation_id_val,
         subject_entity=subject_entity_val,
         source_service=source_service_val,
+        schema_version=schema_version_val,
     )

--- a/src/ume/memory/episodic.py
+++ b/src/ume/memory/episodic.py
@@ -37,7 +37,7 @@ class EpisodicMemory:
 
     def record_event(self, event: Event) -> None:
         """Apply ``event`` to the graph and queue it for flushing."""
-        apply_event_to_graph(event, self.graph)
+        apply_event_to_graph(event, self.graph, schema_version=event.schema_version)
         if self.log_path is not None:
             self._buffer.append(event)
             if not self._thread:
@@ -68,7 +68,7 @@ class EpisodicMemory:
                     continue
                 data = json.loads(line)
                 evt = parse_event(canonicalize_event(data))
-                apply_event_to_graph(evt, self.graph)
+                apply_event_to_graph(evt, self.graph, schema_version=evt.schema_version)
 
     def _replay_logs(self) -> None:
         if not self.log_path:

--- a/src/ume/ontology.py
+++ b/src/ume/ontology.py
@@ -63,7 +63,7 @@ def build_concept_graph(
                     label="RELATES_TO",
                     payload={"similarity": sim},
                 )
-                apply_event_to_graph(event, graph)
+                apply_event_to_graph(event, graph, schema_version=event.schema_version)
                 events.append(event)
     logger.info("Created %s ontology relations", len(events))
     return events
@@ -103,7 +103,7 @@ def update_concept_graph_for_node(
                 label="RELATES_TO",
                 payload={"similarity": sim},
             )
-            apply_event_to_graph(event, graph)
+            apply_event_to_graph(event, graph, schema_version=event.schema_version)
             events.append(event)
     logger.info(
         "Updated ontology for %s with %s relations", node_id, len(events)

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -102,7 +102,7 @@ def run_graph_consumer(
                     raise ValueError("effective_event_missing")
                 if event.event_type not in VALID_EVENT_TYPES:
                     raise ValueError(f"unknown_event_type:{event.event_type}")
-                apply_event_to_graph(event, graph)
+                apply_event_to_graph(event, graph, schema_version=event.schema_version)
                 return {}
 
             envelope = orchestrator.run(

--- a/src/ume/processing.py
+++ b/src/ume/processing.py
@@ -10,7 +10,7 @@ DEFAULT_VERSION = load_default_schema().version
 
 
 def apply_event_to_graph(
-    event: Event, graph: IGraphAdapter, *, schema_version: str = DEFAULT_VERSION
+    event: Event, graph: IGraphAdapter, *, schema_version: str | None = None
 ) -> None:
     """Apply a validated event to the graph via the event handler registry."""
     handler = EVENT_HANDLER_REGISTRY.get(event.event_type)
@@ -20,7 +20,8 @@ def apply_event_to_graph(
             f"Unknown event_type '{event.event_type}' for event: {event.event_id}"
         )
 
-    context = HandlerContext(event=event, graph=graph, schema_version=schema_version)
+    resolved_schema_version = event.schema_version or schema_version or DEFAULT_VERSION
+    context = HandlerContext(event=event, graph=graph, schema_version=resolved_schema_version)
     handler.validate(context)
     handler.apply(context)
     handler.emit_listeners(context)

--- a/src/ume/projection_engine.py
+++ b/src/ume/projection_engine.py
@@ -78,7 +78,7 @@ def run_projection_engine(
                 continue
 
             try:
-                apply_event_to_graph(event, graph)
+                apply_event_to_graph(event, graph, schema_version=event.schema_version)
             except ProcessingError as exc:
                 logger.error("Event processing failed: %s", exc)
     except KeyboardInterrupt:  # pragma: no cover - manual interrupt

--- a/src/ume/replay.py
+++ b/src/ume/replay.py
@@ -32,7 +32,7 @@ def replay_from_ledger(
         if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE} or context.effective_event is None:
             continue
         try:
-            apply_event_to_graph(context.effective_event, graph)
+            apply_event_to_graph(context.effective_event, graph, schema_version=context.effective_event.schema_version)
         except ProcessingError:
             continue
         pipeline.audit_post_apply(context)

--- a/src/ume/replay_mixin.py
+++ b/src/ume/replay_mixin.py
@@ -31,6 +31,6 @@ class ReplayMixin:
             if end_timestamp is not None and data.get("timestamp", 0) > end_timestamp:
                 break
             event = parse_event(canonicalize_event(data))
-            apply_event_to_graph(event, adapter)
+            apply_event_to_graph(event, adapter, schema_version=event.schema_version)
             last = off
         return last

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -8,7 +8,6 @@ from google.protobuf.json_format import MessageToDict
 from ume_client import events_pb2 as _events_pb2
 from google.protobuf import struct_pb2
 from ..event import Event, EventError, EventType
-from ..events.contract import canonical_to_legacy_dict
 from ..events.ingress import ingest_transport_payload
 from ..events.versioning import resolve_schema_version
 from ..processing import DEFAULT_VERSION, apply_event_to_graph
@@ -59,7 +58,7 @@ def apply_event(
     """Apply ``event`` to ``graph`` using :func:`~ume.processing.apply_event_to_graph`."""
 
     if schema_version is None:
-        apply_event_to_graph(event, graph)
+        apply_event_to_graph(event, graph, schema_version=event.schema_version)
     else:
         apply_event_to_graph(event, graph, schema_version=schema_version)
 
@@ -81,8 +80,6 @@ def _build_graph_projector(
         event = context.effective_event
         if canonical is None or event is None:
             raise EventError("missing_canonical_or_event")
-        metadata = canonical["metadata"]
-        unwrapped_event_data = canonical_to_legacy_dict(canonical)
         effective_version = resolve_schema_version(
             canonical,
             explicit_version=schema_version,

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -94,6 +94,27 @@ def test_parse_event_timestamp_iso8601_z():
     event = _parse_event_contract(data)
     assert event.timestamp == int(ts.timestamp())
 
+def test_parse_event_schema_version_is_parsed() -> None:
+    data = {
+        "eventType": "test_event",
+        "timestamp": ISO_TS,
+        "schema_version": " 2.9.9 ",
+    }
+    event = _parse_event_contract(data)
+    assert event.schema_version == "2.9.9"
+
+
+@pytest.mark.parametrize("schema_version", ["", "   ", 123])
+def test_parse_event_invalid_schema_version_rejected(schema_version: object) -> None:
+    data = {
+        "eventType": "test_event",
+        "timestamp": ISO_TS,
+        "schema_version": schema_version,
+    }
+    with pytest.raises(EventError, match="schema_version"):
+        _parse_event_contract(data)
+
+
 
 
 @pytest.mark.parametrize(

--- a/tests/test_event_ledger.py
+++ b/tests/test_event_ledger.py
@@ -1,6 +1,8 @@
 from ume.event_ledger import EventLedger
 from ume.persistent_graph import PersistentGraph
 from ume.replay import replay_from_ledger, build_graph_from_ledger
+from ume.graph_schema import EdgeLabel, GraphSchema
+from ume.schema_manager import DEFAULT_SCHEMA_MANAGER
 import pytest
 
 
@@ -140,3 +142,45 @@ def test_build_graph_from_ledger_roundtrip(tmp_path):
     graph = build_graph_from_ledger(ledger)
     assert set(graph.get_all_node_ids()) == {"a", "b"}
     assert ("a", "b", "TAGGED_AS", {"schema_version": "3.0.0"}) in graph.get_all_edges()
+
+
+def test_replay_mixed_schema_versions_use_event_schema(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+
+    schema_v1 = GraphSchema(version="1.0.0", edge_labels={"TAGGED_AS": EdgeLabel("TAGGED_AS", "1.0.0")})
+    schema_v2 = GraphSchema(version="2.0.0", edge_labels={"TAGGED_AS": EdgeLabel("TAGGED_AS", "2.0.0")})
+
+    monkeypatch.setattr(
+        DEFAULT_SCHEMA_MANAGER,
+        "get_schema",
+        lambda version=None: schema_v2 if version == "2.0.0" else schema_v1,
+    )
+
+    ledger.append(0, {"event_type": "CREATE_NODE", "timestamp": 1, "node_id": "a", "payload": {"node_id": "a"}})
+    ledger.append(1, {"event_type": "CREATE_NODE", "timestamp": 2, "node_id": "b", "payload": {"node_id": "b"}})
+    ledger.append(2, {"event_type": "CREATE_NODE", "timestamp": 3, "node_id": "c", "payload": {"node_id": "c"}})
+    ledger.append(3, {
+        "event_type": "CREATE_EDGE",
+        "timestamp": 4,
+        "node_id": "a",
+        "target_node_id": "b",
+        "label": "TAGGED_AS",
+        "schema_version": "1.0.0",
+        "payload": {},
+    })
+    ledger.append(4, {
+        "event_type": "CREATE_EDGE",
+        "timestamp": 5,
+        "node_id": "a",
+        "target_node_id": "c",
+        "label": "TAGGED_AS",
+        "schema_version": "2.0.0",
+        "payload": {},
+    })
+
+    graph = PersistentGraph(":memory:")
+    replay_from_ledger(graph, ledger, 0)
+
+    attrs_by_target = {target: attrs for _src, target, _label, attrs in graph.get_all_edges()}
+    assert attrs_by_target["b"]["schema_version"] == "1.0.0"
+    assert attrs_by_target["c"]["schema_version"] == "2.0.0"

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -589,3 +589,37 @@ def test_apply_create_node_prefers_top_level_node_id(graph: PersistentGraph) -> 
     )
     apply_event_to_graph(event, graph)
     assert graph.node_exists("node-top")
+
+
+def test_apply_event_uses_event_schema_version_before_default(graph: PersistentGraph, monkeypatch: pytest.MonkeyPatch) -> None:
+    from ume.graph_schema import GraphSchema, EdgeLabel
+    from ume.schema_manager import DEFAULT_SCHEMA_MANAGER
+
+    legacy = GraphSchema(version="1.0.0", edge_labels={"RELATES_TO": EdgeLabel("RELATES_TO", "1.0.0")})
+    modern = GraphSchema(version="2.0.0", edge_labels={"RELATES_TO": EdgeLabel("RELATES_TO", "2.0.0")})
+
+    monkeypatch.setattr(
+        DEFAULT_SCHEMA_MANAGER,
+        "get_schema",
+        lambda version=None: modern if version == "2.0.0" else legacy,
+    )
+
+    graph.add_node("s", {})
+    graph.add_node("t", {})
+
+    event = Event(
+        event_type=EventType.CREATE_EDGE,
+        timestamp=int(time.time()),
+        node_id="s",
+        target_node_id="t",
+        label="RELATES_TO",
+        payload={},
+        schema_version="2.0.0",
+    )
+
+    apply_event_to_graph(event, graph, schema_version="1.0.0")
+
+    edges = graph.get_all_edges()
+    assert len(edges) == 1
+    _src, _tgt, _label, attrs = edges[0]
+    assert attrs["schema_version"] == "2.0.0"


### PR DESCRIPTION
### Motivation
- Make event-local schema version an explicit part of event state and use it to resolve handler/schema behavior so mixed-version streams and replays apply the correct schema per event.

### Description
- Add `schema_version: Optional[str]` to the `Event` dataclass and populate it in `parse_event` from `metadata.schema_version` after normalization and validation using `normalize_schema_version`.
- Change `apply_event_to_graph` to resolve schema as `event.schema_version` first, then the optional `schema_version` argument, then the default schema version.
- Update runtime call sites to pass the event-local schema version explicitly, including `projection_engine`, CLI prompt commands, replay paths, replay mixin, episodic memory, ontology helpers, graph consumer projector, and `services.ingest` helper.
- Add tests to assert schema-version parsing/validation, mixed-version replay behavior, and that an event's schema version takes precedence over a provided fallback.

### Testing
- Ran `ruff check` across modified source and test files and it passed.
- Ran the targeted pytest cases `tests/test_processing.py::test_apply_event_uses_event_schema_version_before_default`, `tests/test_event.py::test_parse_event_schema_version_is_parsed`, `tests/test_event.py::test_parse_event_invalid_schema_version_rejected`, and `tests/test_event_ledger.py::test_replay_mixed_schema_versions_use_event_schema`, and all passed.
- A full test run that includes `tests/test_ingest_schema_version.py` could not be executed in this environment due to a missing `google.protobuf.json_format` dependency; this is an environment limitation and not caused by the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a830a4887c832680fbbfa2a7717401)