### PR TITLE
Publish canonical outbound envelopes with routing metadata

### DIFF
--- a/docs/TOPIC_ROUTING.md
+++ b/docs/TOPIC_ROUTING.md
@@ -1,29 +1,26 @@
 # Event Topic Routing Conventions
 
-The stream processor now derives destination topics from canonical envelope metadata
-instead of a fixed event-type lookup. Producer teams should emit canonical fields
-that describe event semantics so routing remains stable as new event types are added.
+The stream processor derives destination topics from canonical metadata and publishes
+canonical outbound envelopes with routing metadata attached. This keeps downstream
+services from recomputing policy/routing context.
 
 ## Canonical metadata used for routing
 
-Routing decisions are computed from `metadata` and `graph` fields in the canonical
-envelope:
+Routing decisions are computed from `metadata` and `graph` fields:
 
 - `metadata.type_family`: optional semantic family (`node`, `edge`, or custom).
-- `metadata.schema_version`: schema version string used for observability and
-  compatibility checks.
-- `metadata.policy_result`: optional policy verdict. Denied/rejected values are
-  routed to dead-letter.
+- `metadata.schema_version`: schema version used for compatibility and observability.
+- `metadata.policy_result`: policy verdict (`applied`, `rejected`, `quarantined`, etc.).
 - `metadata.schema.topic` (or `metadata.destination_topic`): optional explicit topic
   override from schema metadata.
 - `graph.node_id`, `graph.target_node_id`, `graph.label`: graph semantics used as
-  fallback family detection when `type_family` is not present.
+  fallback family detection when `type_family` is missing.
 
 ## Routing order
 
 The router applies decisions in this order:
 
-1. **Policy deny path**: denied/rejected events go to dead-letter topic.
+1. **Policy DLQ path**: deny/reject/quarantine-style outcomes route to dead-letter.
 2. **Schema topic override**: if schema metadata specifies a topic, that topic wins.
 3. **Semantic family routing**:
    - `edge` family -> `KAFKA_EDGE_TOPIC`
@@ -31,15 +28,71 @@ The router applies decisions in this order:
 4. **Fallback topic**: unknown/custom events without schema topic ->
    `KAFKA_ROUTING_FALLBACK_TOPIC`.
 
-## Producer recommendations
+## Outbound event contract
 
-- Always provide canonical `metadata.event_type`, `metadata.timestamp`, and
-  `metadata.schema_version` values.
-- Include `metadata.type_family` for custom event names so they route predictably.
-- If a custom event requires a dedicated topic, define it in schema metadata using
-  `metadata.schema.topic` (or `metadata.destination_topic`).
-- Emit `metadata.policy_result` for events already evaluated by policy engines to
-  ensure denied data lands in `KAFKA_ROUTING_DEAD_LETTER_TOPIC`.
+All published events (success, reject, quarantine, malformed input) use a consistent
+envelope with canonical fields and routing metadata:
+
+```json
+{
+  "metadata": {
+    "event_type": "CREATE_NODE",
+    "timestamp": 1736000000,
+    "policy_result": "applied",
+    "schema_version": "v1",
+    "type_family": "node",
+    "routing": {
+      "topic": "ume_nodes",
+      "reason": "node_family",
+      "family": "node",
+      "schema_version": "v1",
+      "policy_result": "applied"
+    }
+  },
+  "graph": {
+    "node_id": "n1"
+  },
+  "payload": {}
+}
+```
+
+### DLQ envelope fields
+
+When canonical data is unavailable (for example malformed JSON or transport validation
+failure), the stream processor publishes a DLQ envelope with:
+
+- `metadata.policy_result`, `metadata.schema_version`, and `metadata.type_family`
+- `metadata.routing` object with final topic + reason
+- `dlq.stage`, `dlq.reason`, and optional `dlq.details`
+
+Example malformed input payload:
+
+```json
+{
+  "metadata": {
+    "event_type": "UNKNOWN_EVENT",
+    "timestamp": null,
+    "policy_result": "rejected",
+    "schema_version": "unknown",
+    "type_family": "unknown",
+    "routing": {
+      "topic": "ume-dead-letter-events",
+      "reason": "policy_denied",
+      "family": "unknown",
+      "schema_version": null,
+      "policy_result": "rejected"
+    }
+  },
+  "graph": {},
+  "dlq": {
+    "stage": "decode",
+    "reason": "malformed_json",
+    "details": {
+      "raw_payload_present": true
+    }
+  }
+}
+```
 
 ## Related settings
 

--- a/src/ume/pipeline/router.py
+++ b/src/ume/pipeline/router.py
@@ -7,7 +7,15 @@ from typing import Any, Mapping
 
 from ..config import settings
 
-_POLICY_DENY_RESULTS = {"deny", "denied", "reject", "rejected", "blocked"}
+_POLICY_DENY_RESULTS = {
+    "deny",
+    "denied",
+    "reject",
+    "rejected",
+    "blocked",
+    "quarantine",
+    "quarantined",
+}
 
 
 @dataclass(frozen=True)
@@ -105,7 +113,9 @@ def route_event(
 
 
 def _schema_topic(metadata: Mapping[str, Any]) -> str | None:
-    direct_topic = _string_value(metadata.get("destination_topic") or metadata.get("topic"))
+    direct_topic = _string_value(
+        metadata.get("destination_topic") or metadata.get("topic")
+    )
     if direct_topic:
         return direct_topic
 
@@ -153,7 +163,10 @@ def _type_family(metadata: Mapping[str, Any], graph: Mapping[str, Any]) -> str:
 
     if any(keyword in event_type_upper for keyword in ("EDGE", "RELATION", "LINK")):
         return "edge"
-    if any(keyword in event_type_upper for keyword in ("NODE", "DOCUMENT", "ENTITY", "RESEARCH")):
+    if any(
+        keyword in event_type_upper
+        for keyword in ("NODE", "DOCUMENT", "ENTITY", "RESEARCH")
+    ):
         return "node"
 
     return "unknown"

--- a/src/ume/pipeline/stream_processor.py
+++ b/src/ume/pipeline/stream_processor.py
@@ -9,12 +9,60 @@ except Exception:  # pragma: no cover - optional dependency missing
     faust = None  # type: ignore[assignment]
     StreamT = object  # type: ignore[assignment]
 import json
+from typing import Any, Mapping
 
 from ..config import settings
 from .core import EventPipelineOrchestrator, PipelineOutcome
 from .router import route_event, router_config_from_settings
 
 IN_TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
+
+
+def _outbound_payload(
+    envelope,
+    *,
+    family: str,
+    schema_version: str | None,
+    policy_result: str | None,
+    topic: str,
+    reason: str,
+) -> dict[str, Any]:
+    canonical = envelope.canonical_event
+    if isinstance(canonical, Mapping):
+        payload: dict[str, Any] = dict(canonical)
+    else:
+        payload = {
+            "metadata": {
+                "event_type": envelope.event_type or "UNKNOWN_EVENT",
+                "timestamp": None,
+            },
+            "graph": {},
+            "dlq": {
+                "stage": envelope.stage,
+                "reason": envelope.reason,
+                "details": envelope.details,
+            },
+        }
+
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        payload["metadata"] = metadata
+
+    metadata["policy_result"] = policy_result or envelope.outcome.value
+    metadata["schema_version"] = (
+        schema_version or metadata.get("schema_version") or "unknown"
+    )
+    metadata["type_family"] = family or metadata.get("type_family") or "unknown"
+    metadata["routing"] = {
+        "topic": topic,
+        "reason": reason,
+        "family": family,
+        "schema_version": schema_version,
+        "policy_result": policy_result or envelope.outcome.value,
+    }
+
+    return payload
 
 
 def build_app(broker: str = settings.KAFKA_BOOTSTRAP_SERVERS):
@@ -44,6 +92,40 @@ def build_app(broker: str = settings.KAFKA_BOOTSTRAP_SERVERS):
             try:
                 data = json.loads(raw.decode("utf-8"))
             except (ValueError, json.JSONDecodeError):
+                decision = route_event(
+                    {
+                        "metadata": {"policy_result": PipelineOutcome.REJECTED.value},
+                        "graph": {},
+                    },
+                    router_config,
+                )
+                envelope_payload = {
+                    "metadata": {
+                        "event_type": "UNKNOWN_EVENT",
+                        "timestamp": None,
+                        "policy_result": PipelineOutcome.REJECTED.value,
+                        "schema_version": "unknown",
+                        "type_family": decision.family,
+                        "routing": {
+                            "topic": decision.topic,
+                            "reason": decision.reason,
+                            "family": decision.family,
+                            "schema_version": decision.schema_version,
+                            "policy_result": decision.policy_result,
+                        },
+                    },
+                    "graph": {},
+                    "dlq": {
+                        "stage": "decode",
+                        "reason": "malformed_json",
+                        "details": {"raw_payload_present": True},
+                    },
+                }
+                topic = topic_by_name.get(decision.topic)
+                if topic is None:
+                    topic = app.topic(decision.topic, value_type=bytes)
+                    topic_by_name[decision.topic] = topic
+                await topic.send(value=json.dumps(envelope_payload).encode("utf-8"))
                 continue
 
             envelope = orchestrator.run(
@@ -52,26 +134,36 @@ def build_app(broker: str = settings.KAFKA_BOOTSTRAP_SERVERS):
                 adapter="kafka",
                 raw_payload=raw,
             )
-            if envelope.canonical_event is None:
-                decision = route_event({}, router_config)
-            elif envelope.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
-                decision = route_event(
-                    {
-                        "metadata": {
-                            "policy_result": envelope.outcome.value,
-                            "event_type": envelope.event_type,
-                        },
-                        "graph": {},
-                    },
-                    router_config,
-                )
+            canonical = envelope.canonical_event
+            if isinstance(canonical, Mapping):
+                routing_input = dict(canonical)
+                metadata = routing_input.get("metadata")
+                if not isinstance(metadata, dict):
+                    metadata = {}
+                    routing_input["metadata"] = metadata
+                metadata["policy_result"] = envelope.outcome.value
             else:
-                decision = route_event(envelope.canonical_event, router_config)
+                routing_input = {
+                    "metadata": {
+                        "policy_result": envelope.outcome.value,
+                        "event_type": envelope.event_type,
+                    },
+                    "graph": {},
+                }
+            decision = route_event(routing_input, router_config)
+            outbound_payload = _outbound_payload(
+                envelope,
+                family=decision.family,
+                schema_version=decision.schema_version,
+                policy_result=decision.policy_result,
+                topic=decision.topic,
+                reason=decision.reason,
+            )
             topic = topic_by_name.get(decision.topic)
             if topic is None:
                 topic = app.topic(decision.topic, value_type=bytes)
                 topic_by_name[decision.topic] = topic
-            await topic.send(value=raw)
+            await topic.send(value=json.dumps(outbound_payload).encode("utf-8"))
 
     return app
 

--- a/tests/test_stream_processor.py
+++ b/tests/test_stream_processor.py
@@ -12,59 +12,124 @@ def _topic_map(agent_fun) -> dict[str, object]:
     assert agent_fun.__closure__ is not None
     for cell in agent_fun.__closure__:
         value = cell.cell_contents
-        if isinstance(value, dict) and value and all(
-            isinstance(k, str) and hasattr(v, "send") for k, v in value.items()
+        if (
+            isinstance(value, dict)
+            and value
+            and all(isinstance(k, str) and hasattr(v, "send") for k, v in value.items())
         ):
             return value
     raise AssertionError("topic map closure not found")
 
 
-def test_stream_routing():
+def _run_stream_once(raw_payload: bytes) -> tuple[str, dict]:
     app = build_app("kafka://dummy")
     agent = next(iter(app.agents.values()))
-
     topic_map = _topic_map(agent.fun)
-    edge_topic = topic_map["ume_edges"]
-    node_topic = topic_map["ume_nodes"]
 
-    edge_msgs: list[bytes] = []
-    node_msgs: list[bytes] = []
+    published: dict[str, list[dict]] = {name: [] for name in topic_map}
 
-    async def fake_edge_send(*, value: bytes) -> None:
-        edge_msgs.append(value)
+    for topic_name, topic in topic_map.items():
 
-    async def fake_node_send(*, value: bytes) -> None:
-        node_msgs.append(value)
+        async def fake_send(*, value: bytes, _topic_name: str = topic_name) -> None:
+            published[_topic_name].append(json.loads(value.decode("utf-8")))
 
-    edge_topic.send = fake_edge_send
-    node_topic.send = fake_node_send
-
-    edge_event = _encoded(
-        {
-            "event_type": "CREATE_EDGE",
-            "timestamp": 1,
-            "node_id": "a",
-            "target_node_id": "b",
-            "label": "L",
-        }
-    )
-    node_event = _encoded(
-        {
-            "event_type": "CREATE_NODE",
-            "timestamp": 1,
-            "node_id": "n1",
-            "payload": {"attributes": {"type": "UserMemory"}, "node_id": "n1"},
-        }
-    )
+        topic.send = fake_send
 
     async def run() -> None:
         async def agen():
-            for data in [edge_event, node_event]:
-                yield data
+            yield raw_payload
 
         await agent.fun(agen())
 
     asyncio.run(run())
 
-    assert edge_msgs == [edge_event]
-    assert node_msgs == [node_event]
+    sent = [
+        (topic_name, messages[0])
+        for topic_name, messages in published.items()
+        if messages
+    ]
+    assert len(sent) == 1
+    return sent[0]
+
+
+def test_stream_routing_valid_event_payload_and_metadata():
+    topic, payload = _run_stream_once(
+        _encoded(
+            {
+                "event_type": "CREATE_EDGE",
+                "timestamp": 1,
+                "node_id": "a",
+                "target_node_id": "b",
+                "label": "L",
+            }
+        )
+    )
+
+    assert topic == "ume_edges"
+    assert payload["metadata"]["policy_result"] == "applied"
+    assert payload["metadata"]["schema_version"] == "unknown"
+    assert payload["metadata"]["type_family"] == "edge"
+    assert payload["metadata"]["routing"] == {
+        "topic": "ume_edges",
+        "reason": "edge_family",
+        "family": "edge",
+        "schema_version": None,
+        "policy_result": "applied",
+    }
+
+
+def test_stream_routing_policy_reject_to_dead_letter_with_envelope():
+    topic, payload = _run_stream_once(
+        _encoded(
+            {
+                "event_type": "CREATE_NODE",
+                "timestamp": 1,
+                "node_id": "n1",
+                "payload": {
+                    "attributes": {"type": "UserMemory"},
+                    "node_id": "n1",
+                    "user_id": "u1",
+                    "scope": "private",
+                },
+            }
+        )
+    )
+
+    assert topic == "ume-dead-letter-events"
+    assert payload["metadata"]["policy_result"] == "rejected"
+    assert payload["metadata"]["schema_version"] == "unknown"
+    assert payload["metadata"]["type_family"] == "node"
+    assert payload["metadata"]["routing"]["topic"] == "ume-dead-letter-events"
+
+
+def test_stream_routing_quarantine_to_dead_letter_with_dlq_payload():
+    topic, payload = _run_stream_once(
+        _encoded(
+            {
+                "event_type": "CREATE_NODE",
+                "timestamp": 1,
+                "node_id": "n1",
+                "payload": "invalid",
+            }
+        )
+    )
+
+    assert topic == "ume-dead-letter-events"
+    assert payload["metadata"]["policy_result"] == "quarantined"
+    assert payload["metadata"]["schema_version"] == "unknown"
+    assert payload["metadata"]["type_family"] == "unknown"
+    assert payload["dlq"]["stage"] == "validate"
+
+
+def test_stream_routing_malformed_input_to_dead_letter_with_dlq_payload():
+    topic, payload = _run_stream_once(b"not-json")
+
+    assert topic == "ume-dead-letter-events"
+    assert payload["metadata"]["policy_result"] == "rejected"
+    assert payload["metadata"]["schema_version"] == "unknown"
+    assert payload["metadata"]["routing"]["reason"] == "policy_denied"
+    assert payload["dlq"] == {
+        "stage": "decode",
+        "reason": "malformed_json",
+        "details": {"raw_payload_present": True},
+    }


### PR DESCRIPTION
### Motivation

- Ensure the stream processor emits a consistent outbound envelope (success / reject / quarantine / malformed) so downstream services do not need to recompute routing or policy context.
- Preserve policy outcome metadata (`policy_result`, `schema_version`, `type_family`) in every published payload to enable accurate DLQ handling and observability.
- Provide a stable DLQ envelope shape with diagnostic fields when canonical data is unavailable.

### Description

- Changed the Faust stream processor to serialize `envelope.canonical_event` (or a DLQ envelope) into the outgoing message payload and to always publish JSON bytes rather than forwarding raw ingress bytes by topic. (`src/ume/pipeline/stream_processor.py`)
- Added `_outbound_payload` to normalize outbound envelope shape and inject routing metadata under `metadata.routing` including `topic`, `reason`, `family`, `schema_version`, and `policy_result`. (`src/ume/pipeline/stream_processor.py`)
- Ensure routing input includes the policy outcome so rejects/quarantines are routed consistently and preserved in the published payload. (`src/ume/pipeline/stream_processor.py`)
- Extended policy deny semantics to include `quarantine`/`quarantined` so quarantined events route to dead-letter consistently. (`src/ume/pipeline/router.py`)
- Added tests covering valid event, policy reject, quarantine, and malformed input to assert both topic selection and outbound payload contract. (`tests/test_stream_processor.py`)
- Updated `docs/TOPIC_ROUTING.md` with the canonical outbound contract, DLQ envelope example, and routing guidance.

### Testing

- Ran linter: `ruff check src/ume/pipeline/stream_processor.py src/ume/pipeline/router.py tests/test_stream_processor.py` and it passed.
- Ran unit tests: `pytest -q tests/test_stream_processor.py tests/test_pipeline_router.py` and all tests passed (`9 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a834ceb65c8326b2fca8b38bd0c9db)