### PR TITLE
Add strict vs lenient ingestion validation and quarantine routing

### DIFF
--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -92,6 +92,7 @@ class Settings(BaseSettings):  # type: ignore[misc]
 
     # API token used for test clients and simple auth
     UME_API_TOKEN: str | None = None
+    UME_INGEST_LENIENT_VALIDATION: bool = False
 
     # gRPC authentication token
     UME_GRPC_TOKEN: str | None = None

--- a/src/ume/ingestion_api.py
+++ b/src/ume/ingestion_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -43,15 +44,13 @@ async def post_event(request: Request) -> JSONResponse:
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON")
     try:
-        snake_data = event_to_snake(data)
-        try:
-            validate_event_dict(data)
-        except ValidationError:
-            # In test environments schemas may be unavailable; accept the event
-            # to exercise metrics but log the validation failure.
-            logger.debug("event validation failed", exc_info=True)
+        validate_event_dict(data)
     except ValidationError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        if not settings.UME_INGEST_LENIENT_VALIDATION:
+            raise HTTPException(status_code=400, detail=_validation_error_detail(exc))
+        return _publish_quarantined_event(data, exc)
+
+    snake_data = event_to_snake(data)
 
     if producer is None:
         raise HTTPException(status_code=503, detail="Producer not initialized")
@@ -67,6 +66,47 @@ async def post_event(request: Request) -> JSONResponse:
         raise HTTPException(status_code=500, detail="Failed to publish event")
 
     return JSONResponse(status_code=202, content={"status": "accepted"})
+
+
+def _event_type_for_metric(data: dict[str, Any]) -> str:
+    event_type = data.get("eventType") or data.get("event_type")
+    if isinstance(event_type, str) and event_type:
+        return event_type.lower()
+    return "invalid"
+
+
+def _validation_error_detail(exc: ValidationError) -> dict[str, Any]:
+    return {
+        "error": "event validation failed",
+        "message": exc.message,
+        "path": [str(item) for item in exc.path],
+        "schema_path": [str(item) for item in exc.schema_path],
+        "validator": exc.validator,
+        "validator_value": exc.validator_value,
+    }
+
+
+def _publish_quarantined_event(data: dict[str, Any], exc: ValidationError) -> JSONResponse:
+    if producer is None:
+        raise HTTPException(status_code=503, detail="Producer not initialized")
+
+    quarantine_message = {
+        "error": _validation_error_detail(exc),
+        "event": data,
+        "ingestion": {"mode": "lenient", "reason": "validation_failed"},
+    }
+    try:
+        producer.produce(
+            settings.KAFKA_QUARANTINE_TOPIC,
+            json.dumps(quarantine_message).encode("utf-8"),
+        )
+        producer.poll(0)
+        INGEST_EVENTS_TOTAL.labels(event_type=_event_type_for_metric(data)).inc()
+    except KafkaException as kafka_exc:
+        logger.error("Failed to publish quarantined event: %s", kafka_exc)
+        raise HTTPException(status_code=500, detail="Failed to publish event")
+
+    return JSONResponse(status_code=202, content={"status": "quarantined"})
 
 
 @app.on_event("shutdown")  # type: ignore[misc]

--- a/tests/test_ingestion_api.py
+++ b/tests/test_ingestion_api.py
@@ -4,6 +4,7 @@ import pytest
 
 from ume.ingestion_api import app, settings
 import ume.ingestion_api as ingestion_api
+from ume.metrics import INGEST_EVENTS_TOTAL
 
 
 class FakeProducer:
@@ -26,8 +27,19 @@ class FakeProducer:
 def client(monkeypatch):
     prod = FakeProducer()
     monkeypatch.setattr(ingestion_api, "Producer", lambda conf: prod)
+    object.__setattr__(settings, "UME_INGEST_LENIENT_VALIDATION", False)
+    INGEST_EVENTS_TOTAL.clear()
     with TestClient(app) as test_client:
         yield test_client, prod
+    INGEST_EVENTS_TOTAL.clear()
+
+
+def _ingest_event_count(event_type: str) -> float:
+    for metric in INGEST_EVENTS_TOTAL.collect():
+        for sample in metric.samples:
+            if sample.name.endswith("_total") and sample.labels.get("event_type") == event_type:
+                return float(sample.value)
+    return 0.0
 
 
 def test_post_event_publishes_to_kafka(client):
@@ -45,11 +57,35 @@ def test_post_event_publishes_to_kafka(client):
         (settings.KAFKA_RAW_EVENTS_TOPIC, json.dumps(event).encode("utf-8"))
     ]
     assert prod.poll_calls == 1
+    assert _ingest_event_count("create_node") == 1
 
 
-def test_invalid_event_returns_400(client):
+def test_invalid_event_returns_400_in_strict_mode(client):
     test_client, prod = client
     res = test_client.post("/events", json={"eventType": "CREATE_NODE"})
     assert res.status_code == 400
+    assert res.json()["detail"]["error"] == "event validation failed"
     assert prod.produced == []
+    assert _ingest_event_count("create_node") == 0
 
+
+def test_invalid_event_quarantined_in_lenient_mode(client):
+    test_client, prod = client
+    object.__setattr__(settings, "UME_INGEST_LENIENT_VALIDATION", True)
+
+    bad_event = {"eventType": "CREATE_NODE"}
+    res = test_client.post("/events", json=bad_event)
+
+    assert res.status_code == 202
+    assert res.json() == {"status": "quarantined"}
+    assert len(prod.produced) == 1
+    produced_topic, produced_payload = prod.produced[0]
+    assert produced_topic == settings.KAFKA_QUARANTINE_TOPIC
+    quarantine_payload = json.loads(produced_payload.decode("utf-8"))
+    assert quarantine_payload["event"] == bad_event
+    assert quarantine_payload["ingestion"] == {
+        "mode": "lenient",
+        "reason": "validation_failed",
+    }
+    assert quarantine_payload["error"]["error"] == "event validation failed"
+    assert _ingest_event_count("create_node") == 1


### PR DESCRIPTION
### Motivation
- Make ingestion validation behavior explicit and configurable instead of silently swallowing schema `ValidationError`s.  
- Provide actionable feedback in strict mode and a safe quarantine path in lenient mode so invalid events are handled deterministically.  
- Ensure ingestion metrics still reflect accepted/quarantined events.

### Description
- Added a new config flag `UME_INGEST_LENIENT_VALIDATION` (default `False`) in `src/ume/config/__init__.py` to control strict vs lenient ingestion behavior.  
- Updated `src/ume/ingestion_api.py` to remove the unconditional swallow of `ValidationError` and branch on the new setting: in strict mode the API returns HTTP 400 with structured validation details via `_validation_error_detail`, and in lenient mode invalid events are routed to `KAFKA_QUARANTINE_TOPIC` with structured error + ingestion metadata via `_publish_quarantined_event` and the endpoint returns `202 {"status": "quarantined"}`.  
- Added helpers `_event_type_for_metric`, `_validation_error_detail`, and `_publish_quarantined_event` to shape error payloads, label metrics, and publish quarantined messages.  
- Extended `tests/test_ingestion_api.py` to cover strict-mode 400 responses with structured details, lenient-mode quarantine routing (topic and payload assertions), and ingestion metric assertions using `INGEST_EVENTS_TOTAL`.

### Testing
- Ran linter: `ruff check src/ume/ingestion_api.py src/ume/config/__init__.py tests/test_ingestion_api.py` which passed.  
- Ran unit tests for the modified file: `pytest -q tests/test_ingestion_api.py` which failed in this environment during collection due to a missing test runtime dependency (`fastapi` not installed), so the new tests could not be executed here.  
- New tests were added to `tests/test_ingestion_api.py` to validate both strict and lenient flows and to assert metric updates (these tests are included but require `fastapi` and test dependencies to run successfully in CI or a fully provisioned dev environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a83dfb05e88326ab1567fdce95e998)