### PR TITLE
Canonicalize projection pipeline via EventProcessorService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (though currently in pre-release/development phase).
 
+## [Unreleased]
+### Added
+- Added `ume.services.event_processor.EventProcessorService` as the canonical service entrypoint for event processing across CLI/API/Kafka/gRPC paths.
+- Added parity tests asserting equivalent mutation outcomes across CLI/Kafka/gRPC ingress adapters for canonical events.
+
+### Changed
+- Documented the canonical projection pipeline contract in `docs/PROJECTION_ENGINE.md` with authoritative stages: ingress normalization, schema validation, policy evaluation, mutation apply, and post-apply listeners/audit.
+- Routed service ingestion helpers and CLI/consumer integrations through `EventProcessorService` to centralize orchestration.
+
+### Deprecated
+- Deprecated compatibility pipeline entrypoints: `ume.projection_engine.run_projection_engine`, `ume.pipeline.graph_consumer.run_graph_consumer`, `ume.services.mutate.run_mutation`, and `ume.services.mutate.run_mutation_async`.
+- Removal timeline for deprecated entrypoints: 2026-01-31.
+
 ## [0.1.1] - 2025-06-19
 ### Changed
 - CI now runs `pre-commit` across all files, removing separate Ruff and mypy steps.

--- a/docs/PROJECTION_ENGINE.md
+++ b/docs/PROJECTION_ENGINE.md
@@ -1,56 +1,62 @@
-# Projection Engine
+# Projection Engine Contract
 
-`ume.projection_engine` consumes sanitized events from Kafka and applies them to the configured graph adapter. It keeps the local graph in sync with the latest events published by the Privacy Agent.
+This document defines the **canonical projection pipeline contract** for UME.
 
-## Deterministic projection rules
+## Canonical implementation
 
-Projection is deterministic when the same ordered event stream is replayed:
+The authoritative implementation is:
 
-1. Events are parsed through the policy pipeline before projection.
-2. Any invalid event is mapped to one explicit outcome: `reject`, `quarantine`, or `dead_letter`.
-3. Invalid events are serialized into the event ledger as `REJECTED_EVENT` records for audit/replay parity.
-4. Graph state changes are performed only by `apply_event_to_graph` handler execution.
-5. Projection/replay skips unknown or otherwise non-applicable events and continues in offset order.
+- `ume.pipeline.core.EventPipelineOrchestrator` for stage orchestration.
+- Transport adapters in `ume.events.adapters` + `ume.events.ingress` for ingress normalization.
+- `ume.services.event_processor.EventProcessorService` as the single service entrypoint used by CLI/API/consumer integrations.
+
+Legacy entrypoints in `ume.projection_engine`, `ume.pipeline.graph_consumer`, and direct `ume.services.mutate.run_mutation*` calls are compatibility wrappers and are deprecated.
+
+## Authoritative stage sequence
+
+All ingress paths (Kafka, CLI, gRPC, API) MUST execute the same stages in the same order:
+
+1. **Ingress normalization**
+   - Decode transport payload.
+   - Convert transport-specific fields to canonical event shape.
+2. **Schema validation**
+   - Validate canonical structure + required graph mutation fields.
+3. **Policy evaluation**
+   - Evaluate allow/deny/quarantine/redaction policy pipeline.
+4. **Mutation apply**
+   - Apply accepted effective event to the graph projector.
+5. **Post-apply listeners/audit**
+   - Run post-apply listeners and emit audit metadata.
+
+Outcomes are normalized as `applied`, `redacted`, `rejected`, or `quarantined`.
+
+## Deprecation timeline
+
+Deprecated compatibility entrypoints:
+
+- `ume.projection_engine.run_projection_engine`
+- `ume.pipeline.graph_consumer.run_graph_consumer`
+- `ume.services.mutate.run_mutation`
+- `ume.services.mutate.run_mutation_async`
+
+Timeline:
+
+- Deprecated now (warnings emitted at runtime).
+- Removal target: **2026-01-31**.
+- Migration target: `ume.services.event_processor.DEFAULT_EVENT_PROCESSOR`.
 
 ## Configuration
 
-The engine reads the following settings from `Settings`:
+Canonical consumer deployments still use:
 
-- `KAFKA_BOOTSTRAP_SERVERS` &ndash; comma separated list of brokers.
-- `KAFKA_CLEAN_EVENTS_TOPIC` &ndash; topic containing sanitized events.
-- `KAFKA_GROUP_ID` &ndash; consumer group used for the projection engine.
+- `KAFKA_BOOTSTRAP_SERVERS`
+- `KAFKA_CLEAN_EVENTS_TOPIC`
+- `KAFKA_GROUP_ID`
 
-These may be provided in your environment or a `.env` file:
+Example:
 
 ```bash
 KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 KAFKA_CLEAN_EVENTS_TOPIC=ume-clean-events
 KAFKA_GROUP_ID=ume_client_group
-```
-
-## Running under systemd
-
-```ini
-[Unit]
-Description=UME Projection Engine
-After=network.target
-
-[Service]
-EnvironmentFile=/opt/ume/.env
-ExecStart=/opt/ume/.venv/bin/ume-projection
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-```
-
-## Docker Compose
-
-```yaml
-  ume-projection:
-    image: ume:latest
-    command: ume-projection
-    env_file: ./ume.env
-    depends_on:
-      - redpanda
 ```

--- a/src/ume/cli/prompt.py
+++ b/src/ume/cli/prompt.py
@@ -19,7 +19,8 @@ if _src_path.exists() and str(_src_path) not in sys.path:
 from ume.config import settings
 import ume
 from ume.events.contract import canonicalize_event
-from ume.services.mutate import MutationError, build_graph_projector, raise_for_rejected_outcome, run_mutation
+from ume.services.mutate import MutationError
+from ume.services.event_processor import DEFAULT_EVENT_PROCESSOR
 
 # Support tests that provide a lightweight ``ume`` stub without all attributes.
 load_graph_into_existing = getattr(ume, "load_graph_into_existing", lambda *_args, **_kw: None)
@@ -97,13 +98,12 @@ class UMEPrompt(Cmd):
                 "payload": {"node_id": node_id, "attributes": attributes},
                 "timestamp": self._get_timestamp(),
             }
-            envelope = run_mutation(
+            DEFAULT_EVENT_PROCESSOR.mutate_graph_or_raise(
                 canonicalize_event(event_data),
+                graph=self.graph,
                 source="cli_prompt",
                 adapter="cli",
-                projector=build_graph_projector(self.graph, classify=False),
             )
-            raise_for_rejected_outcome(envelope)
             print(f"Node '{node_id}' created.")
         except (json.JSONDecodeError, EventError, ProcessingError, MutationError) as e:
             print(f"Error: {e}")
@@ -127,13 +127,12 @@ class UMEPrompt(Cmd):
                 "label": label,
                 "timestamp": self._get_timestamp(),
             }
-            envelope = run_mutation(
+            DEFAULT_EVENT_PROCESSOR.mutate_graph_or_raise(
                 canonicalize_event(event_data),
+                graph=self.graph,
                 source="cli_prompt",
                 adapter="cli",
-                projector=build_graph_projector(self.graph, classify=False),
             )
-            raise_for_rejected_outcome(envelope)
             print(f"Edge ({source_id})->({target_id}) [{label}] created.")
         except (EventError, ProcessingError, MutationError) as e:
             print(f"Error: {e}")
@@ -157,13 +156,12 @@ class UMEPrompt(Cmd):
                 "label": label,
                 "timestamp": self._get_timestamp(),
             }
-            envelope = run_mutation(
+            DEFAULT_EVENT_PROCESSOR.mutate_graph_or_raise(
                 canonicalize_event(event_data),
+                graph=self.graph,
                 source="cli_prompt",
                 adapter="cli",
-                projector=build_graph_projector(self.graph, classify=False),
             )
-            raise_for_rejected_outcome(envelope)
             print(f"Edge ({source_id})->({target_id}) [{label}] deleted.")
         except (EventError, ProcessingError, MutationError) as e:
             print(f"Error: {e}")

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
 
 from confluent_kafka import Consumer, KafkaException, KafkaError
 
@@ -13,8 +14,8 @@ from ..event_ledger import event_ledger
 from ..graph_adapter import IGraphAdapter
 from ..logging_utils import configure_logging
 from ..utils import ssl_config
-from .core import EventPipelineOrchestrator, PipelineEnvelope, PipelineOutcome
-from ..services.mutate import build_graph_projector, run_mutation
+from .core import PipelineEnvelope, PipelineOutcome
+from ..services.event_processor import EventProcessorService
 from .invalid_events import build_rejected_event_ledger_entry, outcome_for_pipeline_outcome
 
 
@@ -58,7 +59,12 @@ def run_graph_consumer(
             return
         owns_consumer = True
 
-    orchestrator = EventPipelineOrchestrator()
+    warnings.warn(
+        "ume.pipeline.graph_consumer.run_graph_consumer is deprecated; use ume.services.event_processor.EventProcessorService in integrations by 2026-01-31",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    processor = EventProcessorService()
 
     def _record_invalid_event(*, offset: int, envelope: PipelineEnvelope) -> None:
         try:
@@ -96,24 +102,17 @@ def run_graph_consumer(
                 logger.error("Failed to parse Kafka payload: %s", exc)
                 continue
 
-            base_projector = build_graph_projector(graph, classify=False)
-
-            def _project(context):
-                event = context.effective_event
-                if event is None:
-                    raise ValueError("effective_event_missing")
-                if event.event_type not in VALID_EVENT_TYPES:
-                    raise ValueError(f"unknown_event_type:{event.event_type}")
-                return base_projector(context)
-
-            envelope = run_mutation(
+            envelope = processor.mutate_graph(
                 payload,
+                graph=graph,
                 source="kafka_graph_consumer",
                 adapter="kafka",
                 raw_payload=msg.value(),
-                projector=_project,
-                orchestrator=orchestrator,
             )
+            if envelope.event and envelope.event.event_type not in VALID_EVENT_TYPES:
+                envelope.outcome = PipelineOutcome.REJECTED
+                envelope.stage = "project"
+                envelope.reason = f"unknown_event_type:{envelope.event.event_type}"
 
             if envelope.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
                 _record_invalid_event(offset=msg.offset(), envelope=envelope)

--- a/src/ume/projection_engine.py
+++ b/src/ume/projection_engine.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
 
 from confluent_kafka import Consumer, KafkaError, KafkaException
 
@@ -11,7 +12,8 @@ from .config import settings
 from .utils import ssl_config, event_to_snake
 from .event import EventError
 from .events.types import EventType
-from .services.mutate import MutationError, build_graph_projector, raise_for_rejected_outcome, run_mutation
+from .services.mutate import MutationError, raise_for_rejected_outcome
+from .services.event_processor import EventProcessorService
 from .graph_adapter import IGraphAdapter
 from .logging_utils import configure_logging
 
@@ -32,6 +34,11 @@ def run_projection_engine(
     consumer: Consumer | None = None,
 ) -> None:
     """Consume sanitized events and update ``graph`` accordingly."""
+    warnings.warn(
+        "ume.projection_engine.run_projection_engine is deprecated; use ume.services.event_processor.EventProcessorService-based consumers by 2026-01-31",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     gid = group_id or GROUP_ID
     owns_consumer = False
     if consumer is None:
@@ -49,6 +56,7 @@ def run_projection_engine(
             return
         owns_consumer = True
 
+    processor = EventProcessorService()
     logger.info("Projection engine started with group_id %s", gid)
     try:
         while True:
@@ -67,23 +75,15 @@ def run_projection_engine(
             try:
                 data_camel = json.loads(msg.value().decode("utf-8"))
                 data = event_to_snake(data_camel)
-                base_projector = build_graph_projector(graph, classify=False)
-
-                def _project(context):
-                    event = context.effective_event
-                    if event is None:
-                        raise EventError("effective_event_missing")
-                    if event.event_type not in VALID_EVENT_TYPES:
-                        raise EventError(f"unknown_event_type:{event.event_type}")
-                    return base_projector(context)
-
-                envelope = run_mutation(
+                envelope = processor.mutate_graph(
                     data,
+                    graph=graph,
                     source="projection_engine",
                     adapter="kafka",
                     raw_payload=msg.value(),
-                    projector=_project,
                 )
+                if envelope.event and envelope.event.event_type not in VALID_EVENT_TYPES:
+                    raise EventError(f"unknown_event_type:{envelope.event.event_type}")
                 raise_for_rejected_outcome(envelope)
             except (json.JSONDecodeError, EventError, MutationError) as exc:
                 logger.error("Invalid event skipped: %s", exc)

--- a/src/ume/services/__init__.py
+++ b/src/ume/services/__init__.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from importlib import import_module
 
-__all__ = ["ingest_event", "ingest_events_batch"]
+__all__ = ["ingest_event", "ingest_events_batch", "EventProcessorService", "DEFAULT_EVENT_PROCESSOR"]
 
 
 def __getattr__(name: str):
     if name in {"ingest_event", "ingest_events_batch"}:
         module = import_module("ume.services.ingest")
+        return getattr(module, name)
+    if name in {"EventProcessorService", "DEFAULT_EVENT_PROCESSOR"}:
+        module = import_module("ume.services.event_processor")
         return getattr(module, name)
     raise AttributeError(name)

--- a/src/ume/services/event_processor.py
+++ b/src/ume/services/event_processor.py
@@ -1,0 +1,106 @@
+"""Canonical event processing entrypoint for CLI/API/Kafka/gRPC integrations."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ..event import Event, EventError
+from ..events.ingress import IngressAdapter
+from ..graph_adapter import IGraphAdapter
+from ..pipeline.core import EventPipelineOrchestrator, PipelineEnvelope
+from .mutate import (
+    MutationError,
+    build_graph_projector,
+    raise_for_rejected_outcome,
+    run_mutation,
+    run_mutation_async,
+)
+
+
+class EventProcessorService:
+    """Single service boundary for canonical event processing."""
+
+    def __init__(self, *, orchestrator: EventPipelineOrchestrator | None = None) -> None:
+        self._orchestrator = orchestrator or EventPipelineOrchestrator()
+
+    def process_payload(
+        self,
+        payload: dict[str, Any],
+        *,
+        source: str,
+        adapter: IngressAdapter = "default",
+        raw_payload: bytes | None = None,
+        projector: Callable[[Any], dict[str, Any] | None] | None = None,
+    ) -> PipelineEnvelope:
+        return run_mutation(
+            payload,
+            source=source,
+            adapter=adapter,
+            raw_payload=raw_payload,
+            projector=projector,
+            orchestrator=self._orchestrator,
+        )
+
+    async def process_payload_async(
+        self,
+        payload: dict[str, Any],
+        *,
+        source: str,
+        adapter: IngressAdapter = "default",
+        raw_payload: bytes | None = None,
+        projector: Callable[[Any], Any] | None = None,
+    ) -> PipelineEnvelope:
+        return await run_mutation_async(
+            payload,
+            source=source,
+            adapter=adapter,
+            raw_payload=raw_payload,
+            projector=projector,
+            orchestrator=self._orchestrator,
+        )
+
+    def mutate_graph(
+        self,
+        payload: dict[str, Any],
+        *,
+        graph: IGraphAdapter,
+        source: str,
+        adapter: IngressAdapter = "default",
+        raw_payload: bytes | None = None,
+        schema_version: str | None = None,
+        classify: bool = False,
+    ) -> PipelineEnvelope:
+        return self.process_payload(
+            payload,
+            source=source,
+            adapter=adapter,
+            raw_payload=raw_payload,
+            projector=build_graph_projector(
+                graph,
+                schema_version=schema_version,
+                classify=classify,
+            ),
+        )
+
+    def mutate_graph_or_raise(self, *args: Any, **kwargs: Any) -> PipelineEnvelope:
+        envelope = self.mutate_graph(*args, **kwargs)
+        raise_for_rejected_outcome(envelope)
+        return envelope
+
+    def validate_or_raise(
+        self,
+        payload: dict[str, Any],
+        *,
+        source: str,
+        adapter: IngressAdapter = "default",
+    ) -> Event:
+        envelope = self.process_payload(payload, source=source, adapter=adapter)
+        try:
+            raise_for_rejected_outcome(envelope)
+        except MutationError as exc:
+            raise EventError(str(exc)) from exc
+        if envelope.event is None:
+            raise EventError("missing_event")
+        return envelope.event
+
+DEFAULT_EVENT_PROCESSOR = EventProcessorService()

--- a/src/ume/services/ingest.py
+++ b/src/ume/services/ingest.py
@@ -15,13 +15,12 @@ from ..graph_adapter import IGraphAdapter
 from ..async_graph_adapter import IAsyncGraphAdapter, ingest_event_async
 from ..anomaly_detection import AnomalyDetector
 from ..schema_manager import DEFAULT_SCHEMA_MANAGER
-from ..pipeline.core import EventPipelineOrchestrator
 from .mutate import (
     MutationError,
     build_graph_projector,
     raise_for_rejected_outcome,
-    run_mutation,
 )
+from .event_processor import DEFAULT_EVENT_PROCESSOR
 
 if TYPE_CHECKING:  # pragma: no cover - typing import for mypy
     from ume_client import events_pb2 as events_pb2_type
@@ -31,7 +30,6 @@ else:
 events_pb2 = cast(Any, _events_pb2)
 
 _anomaly_detector = AnomalyDetector()
-_orchestrator = EventPipelineOrchestrator()
 
 __all__ = [
     "validate_event",
@@ -47,13 +45,12 @@ __all__ = [
 
 def validate_event(data: Dict[str, Any]) -> Event:
     """Canonicalize and parse incoming transport data into :class:`~ume.event.Event`."""
-    canonical, event = ingest_transport_payload(data)
-    result = run_mutation(data, source="service_validate", orchestrator=_orchestrator)
-    try:
-        raise_for_rejected_outcome(result)
-    except MutationError as exc:
-        raise EventError(str(exc)) from exc
-    return result.event or event
+    _, event = ingest_transport_payload(data)
+    validated = DEFAULT_EVENT_PROCESSOR.validate_or_raise(
+        data,
+        source="service_validate",
+    )
+    return validated or event
 
 
 def apply_event(
@@ -108,11 +105,10 @@ def ingest_event(
     data: Dict[str, Any], graph: IGraphAdapter, *, schema_version: str | None = None
 ) -> None:
     """Validate ``data``, classify it, and apply the resulting event to ``graph``."""
-    result = run_mutation(
+    result = DEFAULT_EVENT_PROCESSOR.process_payload(
         data,
         source="service_ingest",
         projector=_build_graph_projector(graph, schema_version=schema_version),
-        orchestrator=_orchestrator,
     )
     try:
         raise_for_rejected_outcome(result)
@@ -211,12 +207,11 @@ def ingest_envelope(
 ) -> None:
     """Ingest an :class:`EventEnvelope` into ``graph``."""
     event_dict = envelope_to_event_dict(envelope)
-    result = run_mutation(
+    result = DEFAULT_EVENT_PROCESSOR.process_payload(
         event_dict,
         source="service_ingest",
         adapter="grpc",
         projector=_build_graph_projector(graph, schema_version=schema_version),
-        orchestrator=_orchestrator,
     )
     try:
         raise_for_rejected_outcome(result)

--- a/src/ume/services/mutate.py
+++ b/src/ume/services/mutate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable
@@ -89,6 +90,12 @@ def run_mutation(
     projector: Callable[[Any], dict[str, Any] | None] | None = None,
     orchestrator: EventPipelineOrchestrator | None = None,
 ) -> PipelineEnvelope:
+    if orchestrator is None:
+        warnings.warn(
+            "ume.services.mutate.run_mutation is deprecated; use ume.services.event_processor.DEFAULT_EVENT_PROCESSOR.process_payload by 2026-01-31",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     active_orchestrator = orchestrator or _orchestrator
     envelope = active_orchestrator.run(
         payload,
@@ -109,6 +116,12 @@ async def run_mutation_async(
     projector: Callable[[Any], Any] | None = None,
     orchestrator: EventPipelineOrchestrator | None = None,
 ) -> PipelineEnvelope:
+    if orchestrator is None:
+        warnings.warn(
+            "ume.services.mutate.run_mutation_async is deprecated; use ume.services.event_processor.DEFAULT_EVENT_PROCESSOR.process_payload_async by 2026-01-31",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     active_orchestrator = orchestrator or _orchestrator
     envelope = await active_orchestrator.run_async(
         payload,

--- a/tests/test_mutation_entrypoint_parity.py
+++ b/tests/test_mutation_entrypoint_parity.py
@@ -6,13 +6,9 @@ pytest.importorskip("google.protobuf.json_format")
 
 from ume.event import EventError
 from ume.graph import MockGraph
+from ume.services.event_processor import DEFAULT_EVENT_PROCESSOR
 import ume.services.ingest as ingest_service
-from ume.services.mutate import (
-    MutationErrorCategory,
-    build_graph_projector,
-    categorize_envelope_error,
-    run_mutation,
-)
+from ume.services.mutate import MutationErrorCategory, categorize_envelope_error
 
 
 def _base_event() -> dict[str, object]:
@@ -24,29 +20,38 @@ def _base_event() -> dict[str, object]:
     }
 
 
-def test_cli_kafka_allow_parity() -> None:
-    cli_graph = MockGraph()
-    kafka_graph = MockGraph()
+def _process_for_graph(event: dict[str, object], *, source: str, adapter: str):
+    graph = MockGraph()
+    envelope = DEFAULT_EVENT_PROCESSOR.mutate_graph(
+        event,
+        graph=graph,
+        source=source,
+        adapter=adapter,
+    )
+    return envelope, graph.dump()
+
+
+def test_cli_kafka_grpc_allow_parity() -> None:
     event = _base_event()
 
-    cli_envelope = run_mutation(
-        event,
-        source="cli_prompt",
-        adapter="cli",
-        projector=build_graph_projector(cli_graph, classify=False),
-    )
-    kafka_envelope = run_mutation(
+    cli_envelope, cli_dump = _process_for_graph(event, source="cli_prompt", adapter="cli")
+    kafka_envelope, kafka_dump = _process_for_graph(
         event,
         source="kafka_graph_consumer",
         adapter="kafka",
-        projector=build_graph_projector(kafka_graph, classify=False),
     )
 
-    assert cli_envelope.outcome.value == kafka_envelope.outcome.value
-    assert cli_graph.dump() == kafka_graph.dump()
+    grpc_envelope, grpc_dump = _process_for_graph(
+        ingest_service.envelope_to_event_dict(ingest_service.dict_to_envelope(event)),
+        source="grpc_server",
+        adapter="grpc",
+    )
+
+    assert cli_envelope.outcome.value == kafka_envelope.outcome.value == grpc_envelope.outcome.value
+    assert cli_dump == kafka_dump == grpc_dump
 
 
-def test_cli_kafka_api_policy_deny_parity(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_kafka_grpc_policy_deny_parity(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("ume.policy.pipeline.consent_ledger.has_consent", lambda *_: False)
     event = _base_event()
     event["payload"] = {
@@ -55,45 +60,41 @@ def test_cli_kafka_api_policy_deny_parity(monkeypatch: pytest.MonkeyPatch) -> No
         "attributes": {"name": "Alice"},
     }
 
-    cli_envelope = run_mutation(
-        event,
-        source="cli_prompt",
-        adapter="cli",
-        projector=build_graph_projector(MockGraph(), classify=False),
-    )
-    kafka_envelope = run_mutation(
-        event,
-        source="kafka_graph_consumer",
-        adapter="kafka",
-        projector=build_graph_projector(MockGraph(), classify=False),
+    cli_envelope, _ = _process_for_graph(event, source="cli_prompt", adapter="cli")
+    kafka_envelope, _ = _process_for_graph(event, source="kafka_graph_consumer", adapter="kafka")
+    grpc_envelope, _ = _process_for_graph(
+        ingest_service.envelope_to_event_dict(ingest_service.dict_to_envelope(event)),
+        source="grpc_server",
+        adapter="grpc",
     )
 
     assert categorize_envelope_error(cli_envelope) == MutationErrorCategory.POLICY_DENY
     assert categorize_envelope_error(kafka_envelope) == MutationErrorCategory.POLICY_DENY
+    assert categorize_envelope_error(grpc_envelope) == MutationErrorCategory.POLICY_DENY
 
     with pytest.raises(EventError) as exc:
         ingest_service.ingest_event(event, MockGraph())
     assert str(exc.value).startswith("policy_deny:")
 
 
-def test_cli_kafka_api_validation_parity() -> None:
+def test_cli_kafka_grpc_validation_parity() -> None:
     invalid_event = {"eventType": "CREATE_NODE", "payload": {"attributes": {"x": 1}}}
 
-    cli_envelope = run_mutation(
-        invalid_event,
-        source="cli_prompt",
-        adapter="cli",
-        projector=build_graph_projector(MockGraph(), classify=False),
-    )
-    kafka_envelope = run_mutation(
+    cli_envelope, _ = _process_for_graph(invalid_event, source="cli_prompt", adapter="cli")
+    kafka_envelope, _ = _process_for_graph(
         invalid_event,
         source="kafka_graph_consumer",
         adapter="kafka",
-        projector=build_graph_projector(MockGraph(), classify=False),
+    )
+    grpc_envelope, _ = _process_for_graph(
+        invalid_event,
+        source="grpc_server",
+        adapter="grpc",
     )
 
     assert categorize_envelope_error(cli_envelope) == MutationErrorCategory.VALIDATION
     assert categorize_envelope_error(kafka_envelope) == MutationErrorCategory.VALIDATION
+    assert categorize_envelope_error(grpc_envelope) == MutationErrorCategory.VALIDATION
 
     with pytest.raises(EventError) as exc:
         ingest_service.ingest_event(invalid_event, MockGraph())


### PR DESCRIPTION
### Motivation
- Centralize event processing across CLI/API/Kafka/gRPC into a single service boundary to ensure all ingress paths follow the same canonical pipeline stages (ingress normalization, schema validation, policy evaluation, mutation apply, post-apply listeners/audit). 
- Provide a recommended canonical implementation and deprecate older direct entrypoints and ad-hoc orchestration to simplify integrations and make migration explicit.

### Description
- Added `EventProcessorService` and `DEFAULT_EVENT_PROCESSOR` in `src/ume/services/event_processor.py` as the canonical service entrypoint exposing sync/async payload processing, graph mutation helpers, and validation helpers. 
- Routed ingestion and validation helpers to use the new service by updating `src/ume/services/ingest.py` to call `DEFAULT_EVENT_PROCESSOR` for `validate_event`, `ingest_event`, and `ingest_envelope`. 
- Updated CLI to use `DEFAULT_EVENT_PROCESSOR.mutate_graph_or_raise(...)` for `new_node`, `new_edge`, and `del_edge` commands so CLI uses the canonical pipeline. 
- Introduced runtime deprecation warnings and migration guidance for legacy entrypoints in `src/ume/services/mutate.py` (`run_mutation`, `run_mutation_async`) and for consumer wrappers in `src/ume/pipeline/graph_consumer.py` and `src/ume/projection_engine.py`, and routed those wrappers to call the new service where appropriate. 
- Exported `EventProcessorService`/`DEFAULT_EVENT_PROCESSOR` from `ume.services` (lazy import) for discoverability. 
- Rewrote `docs/PROJECTION_ENGINE.md` to declare the canonical pipeline contract and listed the canonical implementation and a removal timeline for deprecated entrypoints. 
- Updated `CHANGELOG.md` with added/changed/deprecated notes and added/adjusted parity tests (`tests/test_mutation_entrypoint_parity.py`) to assert equivalent outcomes across CLI/Kafka/gRPC ingress adapters.

### Testing
- Ran linter/formatter checks: `ruff check` across modified files, and all checks passed. 
- Ran focused unit/integration tests: `pytest -q tests/test_grpc_publish_event.py tests/test_stream_processor.py` and both test modules passed (4 passed, 1 skipped across that run). 
- Ran parity tests: `pytest -q tests/test_mutation_entrypoint_parity.py` in this environment the file was skipped due to missing `google.protobuf.json_format` (automated skip), so parity assertions are present but skipped here; the test suite otherwise ran without new failures in the exercised modules. 
- Deprecation behavior: runtime warnings are emitted for deprecated entrypoints to surface migration guidance and the 2026-01-31 removal target.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a84ff6d6188326b59d53797c4df9c2)