### PR TITLE
Add versioned event contract bundles, transformers, and CI compatibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,21 @@ jobs:
           npm ci
           npm run build
 
-  unit-tests:
+  schema-compatibility:
     runs-on: ubuntu-latest
     needs: lint-and-install
+    if: needs.lint-and-install.outputs.run == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-poetry
+        with:
+          python-version: '3.12'
+      - name: Run schema compatibility checks
+        run: poetry run python scripts/check_schema_compatibility.py
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: [lint-and-install, schema-compatibility]
     if: needs.lint-and-install.outputs.run == 'true'
     env:
       UME_AUDIT_SIGNING_KEY: test-key

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -92,6 +92,30 @@ mirror the `/snapshot/save` and `/snapshot/load` HTTP endpoints. Both accept a
 `SnapshotPath` message containing the target file path and return an empty
 response on success.
 
+
+## Event Contract Version Policy
+
+UME event contracts are versioned with semantic versions and validated against JSON Schema bundles under `src/ume/schemas/v{major}`.
+
+### Required vs optional fields
+
+- **Always required (all majors):** `eventType`, `timestamp`.
+- **Version 1.x / 2.x:** identity fields (`eventId`, `sourceService`) are optional for compatibility with historical emitters.
+- **Version 3.x:** `eventId` and `sourceService` are required on all events; replay transformers can synthesize these when upgrading old ledgers.
+- Event-type schemas define additional required fields (`node_id`, `target_node_id`, `label`, `payload`) based on operation type.
+
+### Additive vs breaking changes
+
+- **Additive change (minor/patch):** adding optional fields, widening enum choices, adding optional payload keys.
+- **Breaking change (major):** removing required fields, changing field meaning/type incompatibly, or making previously optional fields required.
+- Breaking changes must include explicit migration transformers in `src/ume/events/versioning.py` and pass compatibility checks.
+
+### Deprecation window
+
+- Contract fields targeted for removal are first marked deprecated for **two minor releases** (or **90 days**, whichever is longer).
+- During deprecation, producers should emit both old/new representations when possible.
+- Removal only occurs in the next major bundle after migration guidance and replay transforms are available.
+
 ## Ingestion API
 
 The standalone ingestion service listens on port `8001` and publishes raw events to Kafka.

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -104,3 +104,15 @@ projection workers) before constructing graph/vector resources.
   or `ume.vector_backends` (vector).
 - For service startup, call `bootstrap_runtime("ume")` in the process entry
   point before first use of optional integrations.
+
+
+## 6) Canonical event contract lifecycle
+
+UME keeps machine-validated contract bundles under `src/ume/schemas/v1`, `v2`, and `v3`. Runtime validation resolves the bundle by `metadata.schema_version` major.
+
+- **Required vs optional fields:** core required fields are stable; v3 introduces required identity metadata (`eventId`, `sourceService`) while v1/v2 remain permissive for legacy replay.
+- **Additive changes:** new optional keys may ship in-place within a major line.
+- **Breaking changes:** required-field removals or type/semantic changes require a major bump plus explicit upgrade/downgrade transformers (`upgrade_event`, `downgrade_event`).
+- **Deprecation window:** minimum two minor releases or 90 days before removing deprecated fields in the next major.
+
+CI enforces compatibility with `scripts/check_schema_compatibility.py`, and replay compatibility is covered by `tests/test_event_contract.py`.

--- a/scripts/check_schema_compatibility.py
+++ b/scripts/check_schema_compatibility.py
@@ -1,0 +1,62 @@
+"""Fail CI on unplanned schema breakages across contract bundles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _required_fields(major: int, schema_name: str) -> set[str]:
+    from ume.schemas.contracts import load_bundle_schema
+
+    schema = load_bundle_schema(major, schema_name)
+    return set(schema.get("required", []))
+
+
+def _seed_event(version: str) -> dict[str, object]:
+    return {
+        "metadata": {
+            "event_type": "CREATE_NODE",
+            "timestamp": 1,
+            "schema_version": version,
+            "event_id": "seed",
+            "source": "ci",
+        },
+        "graph": {"node_id": "n1", "target_node_id": None, "label": None},
+        "payload": {"node_id": "n1", "attributes": {}},
+    }
+
+
+def main() -> int:
+    from ume.events.versioning import downgrade_event, upgrade_event
+    from ume.schemas.contracts import supported_contract_majors
+
+    majors = list(supported_contract_majors())
+
+    for prev, curr in zip(majors, majors[1:]):
+        removed_required = _required_fields(prev, "canonical_event.schema.json") - _required_fields(
+            curr, "canonical_event.schema.json"
+        )
+        if removed_required:
+            probe = _seed_event(f"{prev}.0.0")
+            upgraded = upgrade_event(probe, f"{curr}.0.0")
+            restored = downgrade_event(upgraded, f"{prev}.0.0")
+            for field in removed_required:
+                if field in {"eventId", "sourceService"}:
+                    key = "event_id" if field == "eventId" else "source"
+                    if key not in restored.get("metadata", {}):
+                        raise SystemExit(
+                            f"Breaking field removal '{field}' requires explicit migration transformer ({prev}->{curr})."
+                        )
+
+    print("Schema compatibility checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ume/events/adapters/__init__.py
+++ b/src/ume/events/adapters/__init__.py
@@ -2,6 +2,6 @@
 
 from .cli import adapt_cli_payload
 from .grpc import adapt_grpc_payload
-from .kafka import adapt_kafka_payload
+from .kafka import KafkaContractValidator, adapt_kafka_payload
 
-__all__ = ["adapt_cli_payload", "adapt_grpc_payload", "adapt_kafka_payload"]
+__all__ = ["adapt_cli_payload", "adapt_grpc_payload", "adapt_kafka_payload", "KafkaContractValidator"]

--- a/src/ume/events/adapters/kafka.py
+++ b/src/ume/events/adapters/kafka.py
@@ -1,7 +1,19 @@
 from __future__ import annotations
 
+import json
 from copy import deepcopy
 from typing import Any, Mapping
+
+from ...schema_utils import validate_event_dict
+
+try:  # pragma: no cover - optional integration dependency
+    from confluent_kafka.schema_registry import Schema, SchemaRegistryClient
+    from confluent_kafka.schema_registry.json_schema import JSONDeserializer, JSONSerializer
+except Exception:  # pragma: no cover - optional integration dependency
+    Schema = None
+    SchemaRegistryClient = None
+    JSONDeserializer = None
+    JSONSerializer = None
 
 
 def adapt_kafka_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
@@ -11,3 +23,53 @@ def adapt_kafka_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
     if "targetNodeId" in normalized and "target_node_id" not in normalized:
         normalized["target_node_id"] = normalized["targetNodeId"]
     return normalized
+
+
+class KafkaContractValidator:
+    """Validate events through schema registry when configured, else local schemas."""
+
+    def __init__(self, schema_registry_url: str | None = None) -> None:
+        self._url = schema_registry_url
+        self._registry = None
+        if schema_registry_url and SchemaRegistryClient is not None:
+            self._registry = SchemaRegistryClient({"url": schema_registry_url})
+
+    @property
+    def using_registry(self) -> bool:
+        return self._registry is not None
+
+    def validate_for_producer(self, event_dict: Mapping[str, Any], *, subject: str) -> None:
+        if self._registry is not None and Schema is not None and JSONSerializer is not None:
+            schema_text = self._lookup_subject_schema(subject)
+            serializer = JSONSerializer(
+                json.dumps(schema_text),
+                self._registry,
+                lambda value, _: dict(value),
+            )
+            serializer(dict(event_dict), None)
+            return
+        validate_event_dict(dict(event_dict))
+
+    def validate_for_consumer(self, payload: bytes, *, subject: str) -> dict[str, Any]:
+        if self._registry is not None and Schema is not None and JSONDeserializer is not None:
+            schema_text = self._lookup_subject_schema(subject)
+            deserializer = JSONDeserializer(json.dumps(schema_text), from_dict=lambda obj, _: obj)
+            parsed = deserializer(payload, None)
+            if not isinstance(parsed, dict):
+                raise ValueError("Schema registry deserializer did not return an object")
+            return parsed
+        parsed = json.loads(payload.decode("utf-8"))
+        if not isinstance(parsed, dict):
+            raise ValueError("Kafka payload must be a JSON object")
+        validate_event_dict(parsed)
+        return parsed
+
+    def _lookup_subject_schema(self, subject: str) -> dict[str, Any]:
+        if self._registry is None:
+            raise ValueError("Schema Registry client is not configured")
+        registered = self._registry.get_latest_version(subject)
+        schema_str = registered.schema.schema_str
+        loaded = json.loads(schema_str)
+        if not isinstance(loaded, dict):
+            raise ValueError("Schema registry subject does not contain a JSON object schema")
+        return loaded

--- a/src/ume/events/versioning.py
+++ b/src/ume/events/versioning.py
@@ -1,8 +1,11 @@
-"""Schema-version resolution for event ingestion."""
+"""Schema-version resolution and transformation utilities for event ingestion."""
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any, Mapping
+
+from packaging.version import Version
 
 
 def normalize_schema_version(value: Any) -> str | None:
@@ -31,3 +34,92 @@ def resolve_schema_version(
         or normalize_schema_version(fallback_version)
         or default_version
     )
+
+
+def _major(version: str) -> int:
+    return Version(version).major
+
+
+def _ensure_version(canonical_event: Mapping[str, Any], version: str) -> dict[str, Any]:
+    upgraded = deepcopy(dict(canonical_event))
+    metadata = upgraded.setdefault("metadata", {})
+    if not isinstance(metadata, dict):
+        metadata = {}
+        upgraded["metadata"] = metadata
+    metadata["schema_version"] = version
+    return upgraded
+
+
+def upgrade_event(canonical_event: Mapping[str, Any], target_version: str) -> dict[str, Any]:
+    """Upgrade ``canonical_event`` into the requested schema version."""
+    source_version = normalize_schema_version(
+        canonical_event.get("metadata", {}).get("schema_version") if isinstance(canonical_event.get("metadata"), Mapping) else None
+    ) or "1.0.0"
+
+    source_major = _major(source_version)
+    target_major = _major(target_version)
+    if target_major < source_major:
+        raise ValueError("target_version must be >= source version for upgrades")
+
+    transformed = deepcopy(dict(canonical_event))
+    while source_major < target_major:
+        if source_major == 1:
+            transformed = _upgrade_v1_to_v2(transformed)
+        elif source_major == 2:
+            transformed = _upgrade_v2_to_v3(transformed)
+        else:
+            raise ValueError(f"Unsupported upgrade path from major {source_major}")
+        source_major += 1
+    return _ensure_version(transformed, target_version)
+
+
+def downgrade_event(canonical_event: Mapping[str, Any], target_version: str) -> dict[str, Any]:
+    """Downgrade ``canonical_event`` into the requested schema version."""
+    source_version = normalize_schema_version(
+        canonical_event.get("metadata", {}).get("schema_version") if isinstance(canonical_event.get("metadata"), Mapping) else None
+    ) or "1.0.0"
+
+    source_major = _major(source_version)
+    target_major = _major(target_version)
+    if target_major > source_major:
+        raise ValueError("target_version must be <= source version for downgrades")
+
+    transformed = deepcopy(dict(canonical_event))
+    while source_major > target_major:
+        if source_major == 3:
+            transformed = _downgrade_v3_to_v2(transformed)
+        elif source_major == 2:
+            transformed = _downgrade_v2_to_v1(transformed)
+        else:
+            raise ValueError(f"Unsupported downgrade path from major {source_major}")
+        source_major -= 1
+    return _ensure_version(transformed, target_version)
+
+
+def _upgrade_v1_to_v2(canonical_event: Mapping[str, Any]) -> dict[str, Any]:
+    transformed = deepcopy(dict(canonical_event))
+    payload = transformed.setdefault("payload", {})
+    if isinstance(payload, dict):
+        payload.setdefault("extensions", {})
+    return transformed
+
+
+def _upgrade_v2_to_v3(canonical_event: Mapping[str, Any]) -> dict[str, Any]:
+    transformed = deepcopy(dict(canonical_event))
+    metadata = transformed.setdefault("metadata", {})
+    if isinstance(metadata, dict):
+        metadata.setdefault("event_id", "replay-generated")
+        metadata.setdefault("source", "replay")
+    return transformed
+
+
+def _downgrade_v3_to_v2(canonical_event: Mapping[str, Any]) -> dict[str, Any]:
+    return deepcopy(dict(canonical_event))
+
+
+def _downgrade_v2_to_v1(canonical_event: Mapping[str, Any]) -> dict[str, Any]:
+    transformed = deepcopy(dict(canonical_event))
+    payload = transformed.get("payload")
+    if isinstance(payload, dict):
+        payload.pop("extensions", None)
+    return transformed

--- a/src/ume/schema_utils.py
+++ b/src/ume/schema_utils.py
@@ -2,67 +2,62 @@
 
 from __future__ import annotations
 
-import json
-from importlib import resources
 from typing import Any, Dict, Mapping
-from packaging.version import Version, InvalidVersion
 
-from .events.contract import canonicalize_event, canonical_to_camel_dict
+from jsonschema import ValidationError, validate
+from packaging.version import InvalidVersion, Version
 
-from jsonschema import validate, ValidationError
+from .events.contract import canonical_to_camel_dict, canonicalize_event
+from .schemas.contracts import load_bundle_schema, supported_contract_majors
 
-
-_ENVELOPE_SCHEMA: Dict[str, Any] | None = None
-_CANONICAL_SCHEMA: Dict[str, Any] | None = None
-
-
-_SCHEMAS: Dict[str, Dict[str, Any]] = {}
+_ENVELOPE_SCHEMAS: Dict[int, Dict[str, Any]] = {}
+_CANONICAL_SCHEMAS: Dict[int, Dict[str, Any]] = {}
+_SCHEMAS: Dict[tuple[int, str], Dict[str, Any]] = {}
 
 
-def _load_envelope_schema() -> Dict[str, Any]:
-    """Load JSON schema for the event envelope."""
-    global _ENVELOPE_SCHEMA
-    if _ENVELOPE_SCHEMA is None:
-        with (
-            resources.files("ume.schemas")
-            .joinpath("event_envelope.schema.json")
-            .open("r", encoding="utf-8")
-        ) as f:
-            _ENVELOPE_SCHEMA = json.load(f)
-    return _ENVELOPE_SCHEMA
+def _major_from_schema_version(schema_version: str | None) -> int:
+    if schema_version is None:
+        return 1
+    try:
+        parsed = Version(str(schema_version))
+    except InvalidVersion as exc:
+        raise ValidationError("invalid schema_version") from exc
+
+    major = parsed.major
+    if major not in supported_contract_majors():
+        raise ValidationError(f"unsupported schema major version: {major}")
+    return major
 
 
-def _load_canonical_schema() -> Dict[str, Any]:
-    """Load JSON schema for canonical event fields."""
-    global _CANONICAL_SCHEMA
-    if _CANONICAL_SCHEMA is None:
-        with (
-            resources.files("ume.schemas")
-            .joinpath("canonical_event.schema.json")
-            .open("r", encoding="utf-8")
-        ) as f:
-            _CANONICAL_SCHEMA = json.load(f)
-    return _CANONICAL_SCHEMA
+def _load_envelope_schema(major: int) -> Dict[str, Any]:
+    if major not in _ENVELOPE_SCHEMAS:
+        _ENVELOPE_SCHEMAS[major] = load_bundle_schema(major, "event_envelope.schema.json")
+    return _ENVELOPE_SCHEMAS[major]
 
 
-def _load_schema(event_type: str) -> Dict[str, Any]:
-    """Load JSON schema for a specific event type."""
-    if event_type not in _SCHEMAS:
+def _load_canonical_schema(major: int) -> Dict[str, Any]:
+    if major not in _CANONICAL_SCHEMAS:
+        _CANONICAL_SCHEMAS[major] = load_bundle_schema(major, "canonical_event.schema.json")
+    return _CANONICAL_SCHEMAS[major]
+
+
+def _load_schema(event_type: str, major: int) -> Dict[str, Any]:
+    cache_key = (major, event_type)
+    if cache_key not in _SCHEMAS:
         filename = f"{event_type.lower()}.schema.json"
         try:
-            with (
-                resources.files("ume.schemas")
-                .joinpath(filename)
-                .open("r", encoding="utf-8") as f
-            ):
-                _SCHEMAS[event_type] = json.load(f)
+            _SCHEMAS[cache_key] = load_bundle_schema(major, filename)
         except FileNotFoundError as exc:
             raise ValidationError(f"Unknown event_type: {event_type}") from exc
-    return _SCHEMAS[event_type]
+    return _SCHEMAS[cache_key]
 
 
 def validate_event_dict(event_data: Dict[str, Any]) -> None:
     """Validate transport event data after normalizing to canonical contract."""
+    schema_version = event_data.get("schema_version")
+    major = _major_from_schema_version(schema_version if isinstance(schema_version, str) else None)
+    if "event" in event_data:
+        validate(instance=event_data, schema=_load_envelope_schema(major))
     canonical = canonicalize_event(event_data)
     validate_canonical_event(canonical)
 
@@ -72,16 +67,12 @@ def validate_canonical_event(canonical: Mapping[str, Any]) -> None:
     normalized = canonical_to_camel_dict(canonical)
 
     schema_version = canonical["metadata"].get("schema_version")
-    if schema_version is not None:
-        try:
-            Version(str(schema_version))
-        except InvalidVersion as exc:
-            raise ValidationError("invalid schema_version") from exc
+    major = _major_from_schema_version(schema_version)
 
-    validate(instance=normalized, schema=_load_canonical_schema())
+    validate(instance=normalized, schema=_load_canonical_schema(major))
 
     event_type = normalized.get("eventType")
     if not isinstance(event_type, str):
         raise ValidationError("eventType missing or not a string")
-    schema = _load_schema(event_type)
+    schema = _load_schema(event_type, major)
     validate(instance=normalized, schema=schema)

--- a/src/ume/schemas/contracts.py
+++ b/src/ume/schemas/contracts.py
@@ -1,0 +1,27 @@
+"""Helpers for loading versioned event contract bundles."""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+
+_SUPPORTED_MAJORS = (1, 2, 3)
+
+
+def supported_contract_majors() -> tuple[int, ...]:
+    return _SUPPORTED_MAJORS
+
+
+def bundle_path_for_major(major: int) -> Path:
+    if major not in _SUPPORTED_MAJORS:
+        raise ValueError(f"Unsupported contract major version: {major}")
+    return resources.files("ume.schemas").joinpath(f"v{major}")
+
+
+def load_bundle_schema(major: int, schema_name: str) -> dict[str, Any]:
+    path = bundle_path_for_major(major).joinpath(schema_name)
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)

--- a/src/ume/schemas/v1/bundle.json
+++ b/src/ume/schemas/v1/bundle.json
@@ -1,0 +1,15 @@
+{
+  "contract_version": "1.0.0",
+  "compatibility": {
+    "backward": "guaranteed_with_transformers",
+    "forward": "best_effort"
+  },
+  "schemas": [
+    "canonical_event.schema.json",
+    "event_envelope.schema.json",
+    "create_node.schema.json",
+    "update_node_attributes.schema.json",
+    "create_edge.schema.json",
+    "delete_edge.schema.json"
+  ]
+}

--- a/src/ume/schemas/v1/canonical_event.schema.json
+++ b/src/ume/schemas/v1/canonical_event.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UME Canonical Event",
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "eventType",
+    "timestamp"
+  ]
+}

--- a/src/ume/schemas/v1/create_edge.schema.json
+++ b/src/ume/schemas/v1/create_edge.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CREATE_EDGE",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/src/ume/schemas/v1/create_node.schema.json
+++ b/src/ume/schemas/v1/create_node.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CREATE_NODE",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "payload"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    }
+  }
+}

--- a/src/ume/schemas/v1/delete_edge.schema.json
+++ b/src/ume/schemas/v1/delete_edge.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DELETE_EDGE",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/src/ume/schemas/v1/event_envelope.schema.json
+++ b/src/ume/schemas/v1/event_envelope.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UME Event Envelope",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "event": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "schema_version",
+    "event"
+  ]
+}

--- a/src/ume/schemas/v1/update_node_attributes.schema.json
+++ b/src/ume/schemas/v1/update_node_attributes.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UPDATE_NODE_ATTRIBUTES",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "payload"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    }
+  }
+}

--- a/src/ume/schemas/v2/bundle.json
+++ b/src/ume/schemas/v2/bundle.json
@@ -1,0 +1,15 @@
+{
+  "contract_version": "2.0.0",
+  "compatibility": {
+    "backward": "guaranteed_with_transformers",
+    "forward": "best_effort"
+  },
+  "schemas": [
+    "canonical_event.schema.json",
+    "event_envelope.schema.json",
+    "create_node.schema.json",
+    "update_node_attributes.schema.json",
+    "create_edge.schema.json",
+    "delete_edge.schema.json"
+  ]
+}

--- a/src/ume/schemas/v2/canonical_event.schema.json
+++ b/src/ume/schemas/v2/canonical_event.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UME Canonical Event",
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "traceId": {
+      "type": "string"
+    },
+    "extensions": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "eventType",
+    "timestamp"
+  ]
+}

--- a/src/ume/schemas/v2/create_edge.schema.json
+++ b/src/ume/schemas/v2/create_edge.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CREATE_EDGE",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/src/ume/schemas/v2/create_node.schema.json
+++ b/src/ume/schemas/v2/create_node.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CREATE_NODE",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "payload"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    }
+  }
+}

--- a/src/ume/schemas/v2/delete_edge.schema.json
+++ b/src/ume/schemas/v2/delete_edge.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DELETE_EDGE",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/src/ume/schemas/v2/event_envelope.schema.json
+++ b/src/ume/schemas/v2/event_envelope.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UME Event Envelope",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "event": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "schema_version",
+    "event"
+  ]
+}

--- a/src/ume/schemas/v2/update_node_attributes.schema.json
+++ b/src/ume/schemas/v2/update_node_attributes.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UPDATE_NODE_ATTRIBUTES",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "payload"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    }
+  }
+}

--- a/src/ume/schemas/v3/bundle.json
+++ b/src/ume/schemas/v3/bundle.json
@@ -1,0 +1,15 @@
+{
+  "contract_version": "3.0.0",
+  "compatibility": {
+    "backward": "guaranteed_with_transformers",
+    "forward": "best_effort"
+  },
+  "schemas": [
+    "canonical_event.schema.json",
+    "event_envelope.schema.json",
+    "create_node.schema.json",
+    "update_node_attributes.schema.json",
+    "create_edge.schema.json",
+    "delete_edge.schema.json"
+  ]
+}

--- a/src/ume/schemas/v3/canonical_event.schema.json
+++ b/src/ume/schemas/v3/canonical_event.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UME Canonical Event",
+  "type": "object",
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "traceId": {
+      "type": "string"
+    },
+    "extensions": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "eventType",
+    "timestamp",
+    "eventId",
+    "sourceService"
+  ]
+}

--- a/src/ume/schemas/v3/create_edge.schema.json
+++ b/src/ume/schemas/v3/create_edge.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CREATE_EDGE",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label",
+    "eventId",
+    "sourceService"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/src/ume/schemas/v3/create_node.schema.json
+++ b/src/ume/schemas/v3/create_node.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CREATE_NODE",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "payload",
+    "eventId",
+    "sourceService"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    }
+  }
+}

--- a/src/ume/schemas/v3/delete_edge.schema.json
+++ b/src/ume/schemas/v3/delete_edge.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DELETE_EDGE",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "target_node_id",
+    "label",
+    "eventId",
+    "sourceService"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    }
+  }
+}

--- a/src/ume/schemas/v3/event_envelope.schema.json
+++ b/src/ume/schemas/v3/event_envelope.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UME Event Envelope",
+  "type": "object",
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "event": {
+      "type": "object"
+    }
+  },
+  "required": [
+    "schema_version",
+    "event"
+  ]
+}

--- a/src/ume/schemas/v3/update_node_attributes.schema.json
+++ b/src/ume/schemas/v3/update_node_attributes.schema.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "UPDATE_NODE_ATTRIBUTES",
+  "type": "object",
+  "required": [
+    "eventType",
+    "timestamp",
+    "node_id",
+    "payload",
+    "eventId",
+    "sourceService"
+  ],
+  "properties": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      }
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "object"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/test_event_contract.py
+++ b/tests/test_event_contract.py
@@ -4,18 +4,20 @@ import pytest
 
 pytest.importorskip("google.protobuf.json_format")
 
-from ume.events.contract import canonicalize_event, canonical_to_camel_dict
+from ume.events.contract import canonical_to_camel_dict, canonicalize_event
+from ume.events.versioning import downgrade_event, upgrade_event
+from ume.schema_utils import validate_canonical_event, validate_event_dict
+from ume.schemas.contracts import load_bundle_schema, supported_contract_majors
 from ume.services.ingest import dict_to_envelope, envelope_to_event_dict
-from ume.schema_utils import validate_event_dict
 
 
-def test_legacy_shapes_normalize_to_same_canonical_form() -> None:
-    expected = {
+def _canonical(version: str = "1.0.0") -> dict[str, object]:
+    return {
         "metadata": {
             "event_id": "e-1",
             "event_type": "CREATE_NODE",
             "timestamp": 1,
-            "schema_version": "1.0.0",
+            "schema_version": version,
             "source": "demo",
             "correlation_ids": {"correlation_id": "c-1"},
             "subject_entity": {"id": "u1", "type": "user"},
@@ -23,6 +25,10 @@ def test_legacy_shapes_normalize_to_same_canonical_form() -> None:
         "graph": {"node_id": "n1", "target_node_id": None, "label": None},
         "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
     }
+
+
+def test_legacy_shapes_normalize_to_same_canonical_form() -> None:
+    expected = _canonical()
 
     legacy_shapes = [
         {
@@ -66,6 +72,36 @@ def test_legacy_shapes_normalize_to_same_canonical_form() -> None:
         assert canonicalize_event(shape) == expected
 
 
+def test_contract_bundles_exist_and_can_be_loaded() -> None:
+    for major in supported_contract_majors():
+        bundle = load_bundle_schema(major, "bundle.json")
+        assert bundle["contract_version"].startswith(f"{major}.")
+        for schema_name in bundle["schemas"]:
+            schema = load_bundle_schema(major, schema_name)
+            assert schema.get("type") == "object"
+
+
+def test_contract_required_fields_only_add_within_next_major() -> None:
+    previous_required: set[str] | None = None
+    for major in supported_contract_majors():
+        current_required = set(load_bundle_schema(major, "canonical_event.schema.json").get("required", []))
+        if previous_required is not None and major in (2,):
+            # v2 is additive and must retain v1 requirements.
+            assert previous_required.issubset(current_required)
+        previous_required = current_required
+
+
+def test_upgrade_and_downgrade_transformers_support_replay_compatibility() -> None:
+    v1 = _canonical("1.0.0")
+    v3 = upgrade_event(v1, "3.0.0")
+    validate_canonical_event(v3)
+    assert v3["metadata"]["schema_version"] == "3.0.0"
+
+    back_to_v1 = downgrade_event(v3, "1.0.0")
+    validate_canonical_event(back_to_v1)
+    assert back_to_v1["metadata"]["schema_version"] == "1.0.0"
+
+
 def test_json_schema_and_protobuf_converters_accept_canonicalized_shape() -> None:
     event = {
         "event_type": "CREATE_EDGE",
@@ -85,3 +121,14 @@ def test_json_schema_and_protobuf_converters_accept_canonicalized_shape() -> Non
     envelope = dict_to_envelope(event)
     round_trip = envelope_to_event_dict(envelope)
     assert canonicalize_event(round_trip) == canonical
+
+
+def test_v3_breaking_fields_require_transform_when_missing() -> None:
+    canonical = _canonical("2.0.0")
+    canonical["metadata"].pop("event_id")
+    canonical["metadata"].pop("source")
+
+    upgraded = upgrade_event(canonical, "3.0.0")
+    validate_canonical_event(upgraded)
+    assert upgraded["metadata"]["event_id"] == "replay-generated"
+    assert upgraded["metadata"]["source"] == "replay"


### PR DESCRIPTION
### Motivation

- Establish a clear, machine-enforced contract version policy for UME events (required/optional fields, additive vs breaking semantics, deprecation window) so producers/consumers and replay tooling can interoperate safely.
- Provide discrete, versioned JSON Schema bundles and runtime resolution by semantic major so validation behavior is explicit per-contract-major and upgrades/downgrades can be automated during replays.
- Prevent accidental breaking removals of required canonical fields via CI gating and provide explicit upgrade/downgrade transformers to preserve replay compatibility.

### Description

- Documented the Event Contract Version Policy in `docs/API_REFERENCE.md` and `docs/ARCHITECTURE_OVERVIEW.md` (required/optional fields, additive vs breaking, deprecation window).
- Added versioned, machine-validated contract bundles under `src/ume/schemas/v1`, `v2`, and `v3` (each includes `bundle.json` and per-event JSON Schemas) and a loader helper `src/ume/schemas/contracts.py` to load bundle files.
- Updated `src/ume/schema_utils.py` to resolve and validate against the appropriate bundle by the semantic major derived from `schema_version` and to validate `event` envelopes when present.
- Implemented explicit `upgrade_event` / `downgrade_event` transformers and version helpers in `src/ume/events/versioning.py` to support replay-time conversions (v1→v2→v3 and reverse steps); these synthesize identity metadata when upgrading older ledgers to v3.
- Added optional Kafka Schema Registry-aware validator (`KafkaContractValidator`) with graceful fallback to local JSON Schema validation in `src/ume/events/adapters/kafka.py` and exported it via the adapters package API.
- Added a schema-compatibility guard script `scripts/check_schema_compatibility.py` and wired a `schema-compatibility` CI job that runs before the unit tests to block unplanned breaking removals.
- Expanded `tests/test_event_contract.py` to cover bundle loading, required-field evolution expectations, and upgrade/downgrade replay compatibility; minor test refactors to use the new helpers.

### Testing

- Ran linter checks: `poetry run ruff check src/ume/schema_utils.py src/ume/events/versioning.py src/ume/events/adapters/kafka.py src/ume/events/adapters/__init__.py src/ume/schemas/contracts.py tests/test_event_contract.py scripts/check_schema_compatibility.py` — all checks passed.
- Ran unit tests: `poetry run pytest tests/test_event_contract.py tests/test_schema_utils.py` — tests succeeded (`8 passed, 1 skipped` in the test run used during development).
- Ran the compatibility guard locally: `poetry run python scripts/check_schema_compatibility.py` — script completed and reported `Schema compatibility checks passed.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a852a078388326aa9186d085992c4d)