### PR TITLE
docs: clarify backend/bootstrap sources and harden docs terminology check

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -8,6 +8,12 @@ codebase today.
 
 **Primary API:** `ume.factories.create_graph_adapter()` (`src/ume/factories.py`).
 
+**Source files (authoritative):**
+
+- `src/ume/factories.py`
+- `src/ume/adapters/bootstrap.py`
+- `src/ume/adapters/registry.py`
+
 ```text
 create_graph_adapter()
   -> register_builtin_graph_backends()          # src/ume/adapters/bootstrap.py
@@ -45,6 +51,11 @@ Python package entry points, in addition to built-ins.
 **Primary API:** `ume.vector_store.create_vector_store()` (alias of
 `create_default_store`) in `src/ume/vector_store.py`.
 
+**Source files (authoritative):**
+
+- `src/ume/vector_store.py`
+- `src/ume/vector_backends/` (registry, built-ins, plugin loading)
+
 ```text
 create_vector_store() / create_default_store()
   -> read UME_VECTOR_BACKEND (env or settings)
@@ -71,6 +82,10 @@ should use `create_vector_store()`.
 
 **Primary API:** `ume.bootstrap.runtime.bootstrap_runtime()` in
 `src/ume/bootstrap/runtime.py`.
+
+**Source file (authoritative):**
+
+- `src/ume/bootstrap/runtime.py`
 
 `bootstrap_runtime()` performs explicit runtime wiring so importing `ume`
 remains lightweight:

--- a/scripts/check_arch_terms.py
+++ b/scripts/check_arch_terms.py
@@ -18,23 +18,34 @@ DOC_FILES = [
 DEPRECATED_PATTERNS: dict[str, str] = {
     r"\bUME_GRAPH_ADAPTER\b": "Use UME_GRAPH_BACKEND",
     r"\bget_adapter\b": "Use create_graph_adapter",
+    r"\badapter map\b": "Use graph backend plugin registry terminology",
+    r"\bvector adapter\b": "Use vector backend terminology",
 }
-
-ALLOWED_CONTEXT_SNIPPETS = (
-    "Concept Mapping (legacy -> current)",
-    "| `UME_GRAPH_ADAPTER` | `UME_GRAPH_BACKEND` |",
-    "| `get_adapter(...)` | `create_graph_adapter(...)` |",
-)
 
 
 def find_matches(path: Path) -> list[str]:
     matches: list[str] = []
     text = path.read_text(encoding="utf-8")
+    in_concept_mapping = False
     for lineno, line in enumerate(text.splitlines(), start=1):
-        if any(snippet in line for snippet in ALLOWED_CONTEXT_SNIPPETS):
+        stripped = line.strip()
+        if (
+            stripped.lower().startswith("#")
+            and "concept mapping (legacy -> current)" in stripped.lower()
+        ):
+            in_concept_mapping = True
             continue
+        if (
+            in_concept_mapping
+            and stripped.startswith("#")
+            and "concept mapping (legacy -> current)" not in stripped.lower()
+        ):
+            in_concept_mapping = False
+
         for pattern, guidance in DEPRECATED_PATTERNS.items():
             if re.search(pattern, line):
+                if in_concept_mapping and line.lstrip().startswith("|"):
+                    continue
                 matches.append(
                     f"{path}:{lineno}: found deprecated term matching /{pattern}/. {guidance}."
                 )


### PR DESCRIPTION
### Motivation
- Provide a single source-of-truth architecture spec that explicitly points to the authoritative source files for graph backend creation, vector backend creation, and runtime bootstrap so contributors know where to look in code.
- Prevent accidental reintroduction of legacy terminology in core docs by expanding the docs-consistency checker to catch more deprecated phrases and only allow legacy terms in the explicit Concept Mapping table.

### Description
- Updated `docs/ARCHITECTURE_OVERVIEW.md` to list authoritative source files for graph backend creation (`src/ume/factories.py`, `src/ume/adapters/bootstrap.py`, `src/ume/adapters/registry.py`), vector backend creation (`src/ume/vector_store.py`, `src/ume/vector_backends/`), and runtime bootstrap (`src/ume/bootstrap/runtime.py`).
- Hardened `scripts/check_arch_terms.py` to detect additional deprecated phrases (`adapter map`, `vector adapter`) and to permit legacy terms only inside the Concept Mapping markdown table while failing the check if deprecated terms appear elsewhere in core docs.
- Kept the existing CI enforcement in `.github/workflows/ci.yml` which already invokes `python scripts/check_arch_terms.py` on PRs so the new checks run in CI as well.

### Testing
- Compiled the updated script with `python -m py_compile scripts/check_arch_terms.py` which succeeded.
- Ran the checker locally with `python scripts/check_arch_terms.py` which printed `Architecture terminology check passed.` and returned success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9093d83948326a115c3d51df22df2)