### PR TITLE
Canonicalize projection processing through EventProcessorService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Documented the canonical projection pipeline contract in `docs/PROJECTION_ENGINE.md` with authoritative stages: ingress normalization, schema validation, policy evaluation, mutation apply, and post-apply listeners/audit.
 - Routed service ingestion helpers and CLI/consumer integrations through `EventProcessorService` to centralize orchestration.
+- Updated `EventProcessorService` to invoke `EventPipelineOrchestrator` directly, keeping `ume.services.mutate.run_mutation*` as compatibility wrappers only.
 
 ### Deprecated
 - Deprecated compatibility pipeline entrypoints: `ume.projection_engine.run_projection_engine`, `ume.pipeline.graph_consumer.run_graph_consumer`, `ume.services.mutate.run_mutation`, and `ume.services.mutate.run_mutation_async`.

--- a/docs/PROJECTION_ENGINE.md
+++ b/docs/PROJECTION_ENGINE.md
@@ -8,7 +8,7 @@ The authoritative implementation is:
 
 - `ume.pipeline.core.EventPipelineOrchestrator` for stage orchestration.
 - Transport adapters in `ume.events.adapters` + `ume.events.ingress` for ingress normalization.
-- `ume.services.event_processor.EventProcessorService` as the single service entrypoint used by CLI/API/consumer integrations.
+- `ume.services.event_processor.EventProcessorService` as the single service entrypoint used by CLI/API/consumer integrations (implemented as a thin facade over `EventPipelineOrchestrator`).
 
 Legacy entrypoints in `ume.projection_engine`, `ume.pipeline.graph_consumer`, and direct `ume.services.mutate.run_mutation*` calls are compatibility wrappers and are deprecated.
 

--- a/src/ume/consumer_demo.py
+++ b/src/ume/consumer_demo.py
@@ -14,7 +14,8 @@ from ume.config import settings
 from ume.utils import ssl_config
 from confluent_kafka import Consumer, KafkaException, KafkaError
 from ume import EventError
-from ume.events.ingress import ingest_transport_payload
+from ume.pipeline.core import PipelineOutcome
+from ume.services.event_processor import DEFAULT_EVENT_PROCESSOR
 from ume.embedding import generate_embedding
 
 configure_logging()
@@ -80,9 +81,15 @@ def main() -> None:
                     text_values = [v for v in payload.values() if isinstance(v, str)]
                     if text_values:
                         payload["embedding"] = generate_embedding(" ".join(text_values))
-                _, received_event = ingest_transport_payload(
-                    event_data_dict, adapter="kafka"
+                envelope = DEFAULT_EVENT_PROCESSOR.process_payload(
+                    event_data_dict,
+                    source="consumer_demo",
+                    adapter="kafka",
                 )
+                if envelope.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
+                    logger.warning("Event rejected at %s: %s", envelope.stage, envelope.reason)
+                    continue
+                received_event = envelope.event
                 logger.info(f"Received event object: {received_event}")
             except json.JSONDecodeError as e:
                 logger.error(f"Failed to decode JSON: {data}, error: {e}")

--- a/src/ume/projection_engine.py
+++ b/src/ume/projection_engine.py
@@ -12,7 +12,7 @@ from .config import settings
 from .utils import ssl_config, event_to_snake
 from .event import EventError
 from .events.types import EventType
-from .services.mutate import MutationError, raise_for_rejected_outcome
+from .services.mutate import MutationError, build_graph_projector as _build_graph_projector, raise_for_rejected_outcome
 from .services.event_processor import EventProcessorService
 from .graph_adapter import IGraphAdapter
 from .logging_utils import configure_logging
@@ -26,6 +26,10 @@ TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
 GROUP_ID = settings.KAFKA_GROUP_ID
 
 VALID_EVENT_TYPES = {e.value for e in EventType}
+
+# compatibility export retained for legacy tests/integrations
+build_graph_projector = _build_graph_projector
+
 
 def run_projection_engine(
     graph: IGraphAdapter,
@@ -57,6 +61,7 @@ def run_projection_engine(
         owns_consumer = True
 
     processor = EventProcessorService()
+    projector = build_graph_projector(graph, classify=False)
     logger.info("Projection engine started with group_id %s", gid)
     try:
         while True:
@@ -75,12 +80,12 @@ def run_projection_engine(
             try:
                 data_camel = json.loads(msg.value().decode("utf-8"))
                 data = event_to_snake(data_camel)
-                envelope = processor.mutate_graph(
+                envelope = processor.process_payload(
                     data,
-                    graph=graph,
                     source="projection_engine",
                     adapter="kafka",
                     raw_payload=msg.value(),
+                    projector=projector,
                 )
                 if envelope.event and envelope.event.event_type not in VALID_EVENT_TYPES:
                     raise EventError(f"unknown_event_type:{envelope.event.event_type}")

--- a/src/ume/services/event_processor.py
+++ b/src/ume/services/event_processor.py
@@ -12,8 +12,6 @@ from .mutate import (
     MutationError,
     build_graph_projector,
     raise_for_rejected_outcome,
-    run_mutation,
-    run_mutation_async,
 )
 
 
@@ -32,13 +30,12 @@ class EventProcessorService:
         raw_payload: bytes | None = None,
         projector: Callable[[Any], dict[str, Any] | None] | None = None,
     ) -> PipelineEnvelope:
-        return run_mutation(
+        return self._orchestrator.run(
             payload,
             source=source,
             adapter=adapter,
             raw_payload=raw_payload,
             projector=projector,
-            orchestrator=self._orchestrator,
         )
 
     async def process_payload_async(
@@ -50,13 +47,12 @@ class EventProcessorService:
         raw_payload: bytes | None = None,
         projector: Callable[[Any], Any] | None = None,
     ) -> PipelineEnvelope:
-        return await run_mutation_async(
+        return await self._orchestrator.run_async(
             payload,
             source=source,
             adapter=adapter,
             raw_payload=raw_payload,
             projector=projector,
-            orchestrator=self._orchestrator,
         )
 
     def mutate_graph(

--- a/tests/test_consumer_demo.py
+++ b/tests/test_consumer_demo.py
@@ -55,12 +55,14 @@ def test_consumer_demo_processes_messages(monkeypatch):
         consumer_demo, "KafkaError", SimpleNamespace(_PARTITION_EOF=None)
     )
     parsed = []
-    def _fake_ingress(payload, adapter="default"):
-        parsed.append(payload)
-        assert adapter == "kafka"
-        return payload, payload
 
-    monkeypatch.setattr(consumer_demo, "ingest_transport_payload", _fake_ingress)
+    def _fake_process_payload(payload, *, source, adapter):
+        parsed.append(payload)
+        assert source == "consumer_demo"
+        assert adapter == "kafka"
+        return SimpleNamespace(outcome=consumer_demo.PipelineOutcome.APPLIED, event=payload, stage="audit", reason="mutation_applied")
+
+    monkeypatch.setattr(consumer_demo.DEFAULT_EVENT_PROCESSOR, "process_payload", _fake_process_payload)
     monkeypatch.setattr(consumer_demo, "generate_embedding", lambda text: [0.0])
 
     consumer_demo.main()


### PR DESCRIPTION
### Motivation
- Centralize event ingress, policy evaluation, and projection behind a single service boundary to ensure all integrations follow the same pipeline contract. 
- Make the orchestrator (`EventPipelineOrchestrator`) the authoritative implementation while keeping older entrypoints as compatibility wrappers with deprecation warnings. 
- Ensure consumer/CLI/API/gRPC ingress produce equivalent mutation outcomes via a single, testable entrypoint. 

### Description
- `EventProcessorService` now invokes `EventPipelineOrchestrator.run` / `run_async` directly so the service is the canonical facade for orchestration and projection. 
- Consumer demo routed through the service by calling `DEFAULT_EVENT_PROCESSOR.process_payload(...)` and explicitly handling `REJECTED`/`QUARANTINED` outcomes. 
- `projection_engine` updated to call the service entrypoint with an explicit `projector` and retains a `build_graph_projector` compatibility export for legacy callers. 
- Tests and documentation updated: `tests/test_consumer_demo.py` adjusted to assert the new service-path; `docs/PROJECTION_ENGINE.md` and `CHANGELOG.md` updated to document the canonical contract and deprecation timeline. 

### Testing
- Ran linter checks: `ruff check` across modified files (`src/ume/services/event_processor.py`, `src/ume/consumer_demo.py`, `src/ume/projection_engine.py`, `tests/test_consumer_demo.py`) — all checks passed. 
- Ran unit/integration tests: `pytest -q tests/test_mutation_entrypoint_parity.py tests/test_consumer_demo.py tests/test_projection_engine_event_types.py tests/test_stream_processor.py` — result: all executed tests passed (6 passed, 1 skipped).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90f5aabf88326b233c28c89551e50)