### PR TITLE
Add configurable policy stage registry, pipeline contract, and extension docs

### DIFF
--- a/docs/ACCESS_CONTROL.md
+++ b/docs/ACCESS_CONTROL.md
@@ -137,6 +137,9 @@ should not expect a serialized graph snapshot.
 Consent can be granted or revoked programmatically using the
 `ConsentLedger` class from `ume.consent_ledger`.
 
+For policy pipeline extension, ordering, and stage registry configuration, see
+[`docs/POLICY_PIPELINE.md`](./POLICY_PIPELINE.md).
+
 ### Ledger Encryption Migration
 
 UME can optionally encrypt the audit log and SQLite ledgers. Enable this by

--- a/docs/POLICY_PIPELINE.md
+++ b/docs/POLICY_PIPELINE.md
@@ -1,0 +1,62 @@
+# Policy Pipeline Extension Guide
+
+The policy pipeline is split into **decision** and **transform** stages.
+
+## Stage contract
+
+All stages implement `run(context: PolicyContext) -> Optional[PolicyResult]`.
+
+- **Inputs**
+  - Stages receive a mutable `PolicyContext`.
+  - `pre_parse_*` stages normalize `raw_payload` / `transport_data` into
+    `canonical_event` and `effective_event`.
+- **Side effects**
+  - Stages should mutate only `PolicyContext`.
+  - Stages should not emit audit logs directly; `PolicyPipeline` emits final
+    decisions and post-apply audit records.
+- **Decision precedence**
+  1. `DENY` / `QUARANTINE` (terminal)
+  2. `REDACTED`
+  3. `ALLOW`
+- **Idempotency**
+  - Stage behavior should be deterministic for equivalent input.
+  - Transform stages should preserve stable results when re-run.
+
+## Declarative stage registry
+
+`build_default_policy_pipeline(...)` uses a stage registry and supports
+configuration in either:
+
+- Environment variable: `UME_POLICY_PIPELINE_STAGES`
+- JSON config file via `config_path`:
+
+```json
+{
+  "policy_pipeline": {
+    "stages": [
+      "pre_parse_transport",
+      "pre_apply_consent",
+      "pre_apply_alignment",
+      "pre_persist_redaction",
+      "post_apply_auditing"
+    ]
+  }
+}
+```
+
+When both are provided, the environment variable takes precedence.
+
+## Built-in stages
+
+- `pre_parse_transport` (decision)
+- `pre_apply_consent` (decision)
+- `pre_apply_alignment` (decision)
+- `pre_persist_redaction` (transform)
+- `post_apply_auditing` (post_apply)
+
+## Adding a custom stage
+
+1. Create a class with a `name` and `run(context)` method.
+2. Register it via `PolicyStageRegistration` in a `StageRegistry` instance.
+3. Pass your registry to `build_default_policy_pipeline(registry=...)`.
+4. Include the stage name in `UME_POLICY_PIPELINE_STAGES` or your config file.

--- a/src/ume/policy/pipeline.py
+++ b/src/ume/policy/pipeline.py
@@ -1,7 +1,21 @@
+"""Policy pipeline contracts and default stage implementations.
+
+Public stage contract:
+- Inputs: each stage receives ``PolicyContext`` and may rely on fields produced by
+  earlier stages (for example ``canonical_event`` and ``effective_event``).
+- Side effects: stages should mutate only ``PolicyContext`` and not emit audit logs
+  directly; audit emission is centralized in :class:`PolicyPipeline`.
+- Decision precedence: terminal decisions are resolved in this order:
+  ``DENY``/``QUARANTINE`` then ``REDACTED`` then ``ALLOW``.
+- Idempotency: stage implementations are expected to be deterministic and safe to
+  run repeatedly for equivalent inputs.
+"""
+
 from __future__ import annotations
 
 import json
 import logging
+import os
 from hashlib import sha256
 from dataclasses import dataclass, field
 from enum import Enum
@@ -90,6 +104,78 @@ class PolicyStage(Protocol):
         ...
 
 
+@dataclass(frozen=True)
+class PolicyStageRegistration:
+    """Declarative registration record for configurable policy pipelines.
+
+    Contract
+    --------
+    Stage input:
+      * Stages receive a shared :class:`PolicyContext` instance and may mutate it.
+      * Input event data is progressively normalized from ``raw_payload`` or
+        ``transport_data`` into ``canonical_event`` and ``effective_event``.
+
+    Side effects:
+      * Stages should only perform deterministic, idempotent mutations against
+        ``PolicyContext`` and avoid externally-visible side effects.
+      * Audit/log emission is handled centrally by :class:`PolicyPipeline`.
+
+    Decision precedence:
+      * Decision stages are always evaluated before transform stages.
+      * Terminal precedence is ``DENY`` / ``QUARANTINE`` > ``REDACTED`` > ``ALLOW``.
+
+    Idempotency:
+      * Running the same stage sequence multiple times with equivalent context
+        should yield equivalent decisions and equivalent canonical payload hashes.
+    """
+
+    name: str
+    phase: str
+    stage_type: str
+    factory: Callable[[], PolicyStage]
+    order: int = 100
+
+
+class StageRegistry:
+    """Registry that builds policy stage instances from declarative configuration."""
+
+    def __init__(self) -> None:
+        self._registrations: Dict[str, PolicyStageRegistration] = {}
+        self._insert_order: Dict[str, int] = {}
+
+    def register(self, registration: PolicyStageRegistration) -> None:
+        self._insert_order.setdefault(registration.name, len(self._insert_order))
+        self._registrations[registration.name] = registration
+
+    def _ordered(self, registrations: List[PolicyStageRegistration]) -> List[PolicyStageRegistration]:
+        return sorted(
+            registrations,
+            key=lambda item: (item.order, self._insert_order[item.name], item.name),
+        )
+
+    def registrations_from_names(self, names: List[str]) -> List[PolicyStageRegistration]:
+        stages: List[PolicyStageRegistration] = []
+        for name in names:
+            registration = self._registrations.get(name)
+            if registration is None:
+                raise ValueError(f"unknown policy stage: {name}")
+            stages.append(registration)
+        return self._ordered(stages)
+
+    def resolve_names(self, *, config_path: str | None = None) -> List[str]:
+        default = [registration.name for registration in self._ordered(list(self._registrations.values()))]
+        configured: List[str] = []
+        if config_path:
+            with open(config_path, "r", encoding="utf-8") as handle:
+                doc = json.load(handle)
+            configured = [str(name) for name in doc.get("policy_pipeline", {}).get("stages", [])]
+
+        env_config = os.getenv("UME_POLICY_PIPELINE_STAGES")
+        if env_config:
+            configured = [name.strip() for name in env_config.split(",") if name.strip()]
+        return configured or default
+
+
 class TransportValidationStage:
     name = "pre_parse_transport"
 
@@ -159,6 +245,13 @@ class AlignmentStage:
                 stage=self.name,
                 reason=str(exc),
             )
+        except Exception as exc:  # pragma: no cover - defensive mapping
+            return _result(
+                PolicyDecision.QUARANTINE,
+                context,
+                stage=self.name,
+                reason=f"alignment_plugin_error: {exc.__class__.__name__}",
+            )
         return None
 
 
@@ -214,19 +307,25 @@ class PolicyPipeline:
     def __init__(
         self,
         *,
-        pre_parse: List[PolicyStage],
-        pre_apply: List[PolicyStage],
-        pre_persist: List[PolicyStage],
+        decision_stages: List[PolicyStage],
+        transform_stages: List[PolicyStage],
         post_apply: List[PolicyStage],
     ) -> None:
-        self._pre_parse = pre_parse
-        self._pre_apply = pre_apply
-        self._pre_persist = pre_persist
+        self._decision_stages = decision_stages
+        self._transform_stages = transform_stages
         self._post_apply = post_apply
 
     def evaluate(self, context: PolicyContext) -> PolicyResult:
         redaction_result: Optional[PolicyResult] = None
-        for stage in [*self._pre_parse, *self._pre_apply, *self._pre_persist]:
+        for stage in self._decision_stages:
+            result = stage.run(context)
+            if result is None:
+                continue
+            if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE}:
+                self._emit(result.audit_event)
+                return result
+
+        for stage in self._transform_stages:
             result = stage.run(context)
             if result is None:
                 continue
@@ -320,11 +419,75 @@ def build_default_policy_pipeline(
     redactor: Callable[[Dict[str, object]], tuple[Dict[str, object], bool]],
     plugin_loader: Callable[[], None] = load_plugins,
     plugin_provider: Callable[[], List[Any]] = get_plugins,
+    registry: StageRegistry | None = None,
+    config_path: str | None = None,
 ) -> PolicyPipeline:
     plugin_loader()
-    return PolicyPipeline(
-        pre_parse=[TransportValidationStage()],
-        pre_apply=[ConsentStage(), AlignmentStage(plugin_provider)],
-        pre_persist=[PiiRedactionStage(redactor)],
-        post_apply=[AuditStage()],
+    active_registry = registry or _default_stage_registry(
+        redactor=redactor,
+        plugin_provider=plugin_provider,
     )
+    stage_names = active_registry.resolve_names(config_path=config_path)
+    registrations = active_registry.registrations_from_names(stage_names)
+    decision_stages = [r.factory() for r in registrations if r.stage_type == "decision"]
+    transform_stages = [r.factory() for r in registrations if r.stage_type == "transform"]
+    post_apply = [r.factory() for r in registrations if r.stage_type == "post_apply"]
+    return PolicyPipeline(
+        decision_stages=decision_stages,
+        transform_stages=transform_stages,
+        post_apply=post_apply,
+    )
+
+
+def _default_stage_registry(
+    *,
+    redactor: Callable[[Dict[str, object]], tuple[Dict[str, object], bool]],
+    plugin_provider: Callable[[], List[Any]],
+) -> StageRegistry:
+    registry = StageRegistry()
+    registry.register(
+        PolicyStageRegistration(
+            name=TransportValidationStage.name,
+            phase="pre_parse",
+            stage_type="decision",
+            order=10,
+            factory=lambda: TransportValidationStage(),
+        )
+    )
+    registry.register(
+        PolicyStageRegistration(
+            name=ConsentStage.name,
+            phase="pre_apply",
+            stage_type="decision",
+            order=20,
+            factory=lambda: ConsentStage(),
+        )
+    )
+    registry.register(
+        PolicyStageRegistration(
+            name=AlignmentStage.name,
+            phase="pre_apply",
+            stage_type="decision",
+            order=30,
+            factory=lambda: AlignmentStage(plugin_provider),
+        )
+    )
+    registry.register(
+        PolicyStageRegistration(
+            name=PiiRedactionStage.name,
+            phase="pre_persist",
+            stage_type="transform",
+            order=40,
+            factory=lambda: PiiRedactionStage(redactor),
+        )
+    )
+    registry.register(
+        PolicyStageRegistration(
+            name=AuditStage.name,
+            phase="post_apply",
+            stage_type="post_apply",
+            order=50,
+            factory=lambda: AuditStage(),
+        )
+    )
+    return registry

--- a/tests/test_policy_pipeline_ordering.py
+++ b/tests/test_policy_pipeline_ordering.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+
+from ume.policy.pipeline import (
+    PolicyContext,
+    PolicyDecision,
+    build_default_policy_pipeline,
+)
+
+
+def _event(payload: dict[str, object] | None = None) -> dict[str, object]:
+    return {
+        "eventType": "CREATE_NODE",
+        "timestamp": 1,
+        "nodeId": "n1",
+        "payload": payload or {"attributes": {"name": "Alice"}},
+    }
+
+
+def test_deny_precedence_over_redaction(monkeypatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+    monkeypatch.setattr("ume.policy.pipeline.get_plugins", lambda: [])
+    monkeypatch.setattr("ume.policy.pipeline.consent_ledger.has_consent", lambda *_: False)
+
+    pipeline = build_default_policy_pipeline(
+        redactor=lambda payload: ({**payload, "email": "<REDACTED>"}, True)
+    )
+    result = pipeline.evaluate(
+        PolicyContext(
+            source="service",
+            transport_data=_event({"user_id": "u1", "scope": "email", "email": "user@example.com"}),
+        )
+    )
+
+    assert result.decision == PolicyDecision.DENY
+    assert result.audit_event.stage == "pre_apply_consent"
+
+
+def test_alignment_plugin_exception_maps_to_quarantine(monkeypatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+
+    class ExplodingPlugin:
+        def validate(self, _event) -> None:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("ume.policy.pipeline.get_plugins", lambda: [ExplodingPlugin()])
+
+    pipeline = build_default_policy_pipeline(
+        redactor=lambda payload: (payload, False),
+        plugin_provider=lambda: [ExplodingPlugin()],
+    )
+    result = pipeline.evaluate(PolicyContext(source="service", transport_data=_event()))
+
+    assert result.decision == PolicyDecision.QUARANTINE
+    assert result.audit_event.reason == "alignment_plugin_error: RuntimeError"
+
+
+def test_stage_registry_from_config_and_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+    monkeypatch.setattr("ume.policy.pipeline.get_plugins", lambda: [])
+
+    config = tmp_path / "policy.json"
+    config.write_text(
+        json.dumps(
+            {
+                "policy_pipeline": {
+                    "stages": [
+                        "pre_parse_transport",
+                        "pre_persist_redaction",
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    pipeline = build_default_policy_pipeline(
+        redactor=lambda payload: ({**payload, "email": "<REDACTED>"}, True),
+        config_path=str(config),
+    )
+    result = pipeline.evaluate(
+        PolicyContext(source="service", transport_data=_event({"email": "user@example.com"}))
+    )
+    assert result.decision == PolicyDecision.REDACTED
+
+    monkeypatch.setenv("UME_POLICY_PIPELINE_STAGES", "pre_parse_transport")
+    env_pipeline = build_default_policy_pipeline(
+        redactor=lambda payload: ({**payload, "email": "<REDACTED>"}, True),
+    )
+    env_result = env_pipeline.evaluate(
+        PolicyContext(source="service", transport_data=_event({"email": "user@example.com"}))
+    )
+    assert env_result.decision == PolicyDecision.ALLOW


### PR DESCRIPTION
### Motivation
- Allow pipeline composition to be configurable (env / config file) instead of only hardcoded assembly so deployments can tune policy behavior without code changes. 
- Prevent accidental coupling between deny/quarantine decision logic and redaction transforms by separating decision vs transform stages. 
- Make plugin failures deterministic by mapping unexpected plugin exceptions to quarantine instead of letting them escape. 
- Provide a clear public contract for policy stages so third-party extensions implement predictable, idempotent behavior. 

### Description
- Added a public stage contract docstring at the top of `src/ume/policy/pipeline.py` describing stage inputs, allowed side effects, decision precedence, and idempotency expectations. 
- Introduced `PolicyStageRegistration` and `StageRegistry` to declaratively register stages and a `_default_stage_registry` to provide built-in stage registrations. 
- Updated `build_default_policy_pipeline` to accept `registry` and `config_path`, to resolve stage names from a JSON config or the `UME_POLICY_PIPELINE_STAGES` env var, and to instantiate stages from the registry. 
- Reworked `PolicyPipeline` to evaluate `decision_stages` separately from `transform_stages` (deny/quarantine decisions run before transforms), and kept `post_apply` stages for auditing. 
- Added defensive exception mapping in `AlignmentStage` so unexpected plugin errors produce a `QUARANTINE` `PolicyResult` with a clear reason. 
- Added `docs/POLICY_PIPELINE.md` and linked it from `docs/ACCESS_CONTROL.md` to document extension and configuration; added `tests/test_policy_pipeline_ordering.py` to assert ordering, precedence, and env/config-driven assembly. 

### Testing
- Linted the modified files with `ruff check src/ume/policy/pipeline.py tests/test_policy_pipeline_ordering.py` which passed. 
- Ran unit tests with `pytest -q tests/test_policy_pipeline_parity.py tests/test_policy_pipeline_redaction_identity.py tests/test_policy_pipeline_ordering.py` which resulted in `8 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a302676883268b9bf92d2f1b4b04)