### PR TITLE
Add deterministic replay modes, golden fixtures, and replay-regression CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,21 @@ jobs:
           poetry run pytest --cov=ume --cov-report xml --cov-fail-under=30 -m "not integration"
           poetry run pytest tests/test_dossier_migration.py
 
+
+  replay-regression:
+    runs-on: ubuntu-latest
+    needs: lint-and-install
+    if: needs.lint-and-install.outputs.run == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-poetry
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: poetry install --with dev --extras vector --extras embedding
+      - name: Run replay regression suite
+        run: poetry run pytest tests/test_replay_regression.py
+
   integration-tests:
     runs-on: ubuntu-latest
     needs: lint-and-install

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -207,12 +207,12 @@ List entries in the event ledger.
 
 ### GET `/ledger/replay`
 Return a snapshot of the graph reconstructed from ledger events.
-- **Query parameters**: optional `end_offset`, optional `end_timestamp`.
+- **Query parameters**: optional `end_offset`, optional `end_timestamp`, optional `replay_mode` (`current_policy` or `strict_historical`).
 Example request:
 
 ```bash
 curl -X GET -H "Authorization: Bearer <token>" \
-  "http://localhost:8000/ledger/replay?end_offset=50"
+  "http://localhost:8000/ledger/replay?end_offset=50&replay_mode=strict_historical"
 ```
 
 If `end_timestamp` is supplied, replay stops once an event newer than the
@@ -220,7 +220,7 @@ timestamp is encountered.
 
 ### GET `/graph/history`
 Return a snapshot of the graph as it existed at a past point in time.
-- **Query parameters**: optional `offset`, optional `timestamp`.
+- **Query parameters**: optional `offset`, optional `timestamp`, optional `replay_mode` (`current_policy` or `strict_historical`).
 Example request:
 
 ```bash

--- a/docs/PROJECTION_ENGINE.md
+++ b/docs/PROJECTION_ENGINE.md
@@ -60,3 +60,25 @@ KAFKA_BOOTSTRAP_SERVERS=localhost:9092
 KAFKA_CLEAN_EVENTS_TOPIC=ume-clean-events
 KAFKA_GROUP_ID=ume_client_group
 ```
+
+
+## Replay guarantees
+
+Replay behavior is deterministic for a fixed input ledger and schema transform set.
+
+For the same ordered event log, identical replay cutoffs (`end_offset`/`end_timestamp`), and the same schema transformation bundle, UME guarantees:
+
+- the same accepted/rejected/quarantined event set for the selected replay mode;
+- the same final node and edge state in the reconstructed graph;
+- stable schema-versioned mutation behavior for mixed-version ledgers.
+
+Determinism is enforced with golden replay fixtures in `tests/data/replay_golden/` and CI replay regression tests.
+
+### Replay modes
+
+Replay policy side effects are configurable through replay mode selection:
+
+- `current_policy` (default): re-runs policy evaluation using currently loaded policy stages. This is useful for forward-looking audits and simulations after policy updates.
+- `strict_historical`: trusts persisted `policy_result` values in each ledger record and skips historical policy re-evaluation. This is useful for exact historical reconstruction and incident forensics.
+
+When `strict_historical` is selected, deny/reject/quarantine outcomes in ledger metadata are treated as terminal and are not re-evaluated against the current policy stack.

--- a/src/ume/ledger_routes.py
+++ b/src/ume/ledger_routes.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Query, HTTPException
 from pydantic import BaseModel
 
 from .event_ledger import event_ledger
-from .replay import build_graph_from_ledger
+from .replay import ReplayMode, build_graph_from_ledger
 from . import api_deps as deps
 
 router = APIRouter()
@@ -42,12 +42,16 @@ def list_events(
 def replay_ledger(
     end_offset: int | None = Query(None, ge=0),
     end_timestamp: int | None = Query(None, ge=0),
+    replay_mode: ReplayMode = Query(ReplayMode.CURRENT_POLICY),
     _: str = Depends(deps.get_current_role),
 ) -> Dict[str, Any]:
     """Return a snapshot of the graph up to ``end_offset`` or ``end_timestamp``."""
 
     graph = build_graph_from_ledger(
-        event_ledger, end_offset=end_offset, end_timestamp=end_timestamp
+        event_ledger,
+        end_offset=end_offset,
+        end_timestamp=end_timestamp,
+        replay_mode=replay_mode,
     )
     return graph.dump()
 
@@ -56,12 +60,16 @@ def replay_ledger(
 def graph_history(
     offset: int | None = Query(None, ge=0),
     timestamp: int | None = Query(None, ge=0),
+    replay_mode: ReplayMode = Query(ReplayMode.CURRENT_POLICY),
     _: str = Depends(deps.get_current_role),
 ) -> Dict[str, Any]:
     """Return a snapshot of the graph at ``offset`` or ``timestamp``."""
 
     graph = build_graph_from_ledger(
-        event_ledger, end_offset=offset, end_timestamp=timestamp
+        event_ledger,
+        end_offset=offset,
+        end_timestamp=timestamp,
+        replay_mode=replay_mode,
     )
     return graph.dump()
 

--- a/src/ume/replay.py
+++ b/src/ume/replay.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING
 from time import time
 
@@ -12,6 +13,33 @@ if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .event_ledger import EventLedger
 
 
+class ReplayMode(str, Enum):
+    STRICT_HISTORICAL = "strict_historical"
+    CURRENT_POLICY = "current_policy"
+
+
+_DENY_RESULTS = {"deny", "denied", "rejected", "quarantine", "quarantined"}
+
+
+def _historical_policy_result(data: dict[str, object]) -> str | None:
+    policy_result = data.get("policy_result")
+    if isinstance(policy_result, str) and policy_result.strip():
+        return policy_result.strip().lower()
+    metadata = data.get("metadata")
+    if isinstance(metadata, dict):
+        metadata_result = metadata.get("policy_result")
+        if isinstance(metadata_result, str) and metadata_result.strip():
+            return metadata_result.strip().lower()
+    return None
+
+
+def _historical_allows(data: dict[str, object]) -> bool:
+    result = _historical_policy_result(data)
+    if result is None:
+        return True
+    return result not in _DENY_RESULTS
+
+
 def replay_from_ledger(
     graph: IGraphAdapter,
     ledger: "EventLedger",
@@ -19,6 +47,7 @@ def replay_from_ledger(
     end_offset: int | None = None,
     *,
     end_timestamp: int | None = None,
+    replay_mode: ReplayMode = ReplayMode.CURRENT_POLICY,
 ) -> int:
     """Replay ledger events into ``graph`` starting from ``start_offset``."""
     last = start_offset
@@ -30,16 +59,25 @@ def replay_from_ledger(
         if end_timestamp is not None and data.get("timestamp", 0) > end_timestamp:
             break
         context = PolicyContext(source="cli_replay", transport_data=data)
-        result = pipeline.evaluate(context)
-        if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE} or context.effective_event is None:
-            continue
+        if replay_mode == ReplayMode.CURRENT_POLICY:
+            result = pipeline.evaluate(context)
+            if result.decision in {PolicyDecision.DENY, PolicyDecision.QUARANTINE} or context.effective_event is None:
+                continue
+        else:
+            result = None
+            if not _historical_allows(data):
+                continue
+            pipeline.evaluate(context)
+            if context.effective_event is None:
+                continue
         try:
             apply_event_to_graph(context.effective_event, graph, schema_version=context.effective_event.schema_version)
         except ProcessingError:
             continue
         event_timestamp = int(context.effective_event.timestamp)
         PIPELINE_REPLAY_LAG_SECONDS.labels(source="cli_replay").set(max(time() - event_timestamp, 0.0))
-        pipeline.audit_post_apply(context)
+        if replay_mode == ReplayMode.CURRENT_POLICY:
+            pipeline.audit_post_apply(context)
         last = off
     return last
 
@@ -51,6 +89,7 @@ def build_graph_from_ledger(
     end_offset: int | None = None,
     end_timestamp: int | None = None,
     db_path: str | None = ":memory:",
+    replay_mode: ReplayMode = ReplayMode.CURRENT_POLICY,
 ) -> IGraphAdapter:
     """Return ``graph`` populated from ``ledger``."""
     if graph is None:
@@ -63,6 +102,7 @@ def build_graph_from_ledger(
         start_offset=0,
         end_offset=end_offset,
         end_timestamp=end_timestamp,
+        replay_mode=replay_mode,
     )
     return graph
 
@@ -73,6 +113,7 @@ def graph_from_event_ledger(
     end_timestamp: int | None = None,
     db_path: str | None = ":memory:",
     graph: IGraphAdapter | None = None,
+    replay_mode: ReplayMode = ReplayMode.CURRENT_POLICY,
 ) -> IGraphAdapter:
     """Rebuild a graph from the global :data:`event_ledger`."""
 
@@ -84,15 +125,21 @@ def graph_from_event_ledger(
         end_offset=end_offset,
         end_timestamp=end_timestamp,
         db_path=db_path,
+        replay_mode=replay_mode,
     )
 
 
 def snapshot_from_event_ledger(
-    *, end_offset: int | None = None, end_timestamp: int | None = None
+    *,
+    end_offset: int | None = None,
+    end_timestamp: int | None = None,
+    replay_mode: ReplayMode = ReplayMode.CURRENT_POLICY,
 ) -> dict[str, object]:
     """Return a snapshot built from :data:`event_ledger`."""
 
     graph = graph_from_event_ledger(
-        end_offset=end_offset, end_timestamp=end_timestamp
+        end_offset=end_offset,
+        end_timestamp=end_timestamp,
+        replay_mode=replay_mode,
     )
     return graph.dump()

--- a/tests/data/replay_golden/mixed_schema_policy.json
+++ b/tests/data/replay_golden/mixed_schema_policy.json
@@ -1,0 +1,127 @@
+{
+  "events": [
+    {
+      "offset": 0,
+      "event": {
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "schema_version": "1.0.0",
+        "node_id": "alpha",
+        "payload": {
+          "node_id": "alpha"
+        },
+        "metadata": {
+          "policy_result": "applied"
+        }
+      }
+    },
+    {
+      "offset": 1,
+      "event": {
+        "event_type": "CREATE_NODE",
+        "timestamp": 2,
+        "schema_version": "2.0.0",
+        "node_id": "beta",
+        "payload": {
+          "node_id": "beta"
+        },
+        "metadata": {
+          "policy_result": "applied"
+        }
+      }
+    },
+    {
+      "offset": 2,
+      "event": {
+        "event_type": "CREATE_EDGE",
+        "timestamp": 3,
+        "schema_version": "1.0.0",
+        "node_id": "alpha",
+        "target_node_id": "beta",
+        "label": "RELATES_TO",
+        "payload": {},
+        "metadata": {
+          "policy_result": "applied"
+        }
+      }
+    },
+    {
+      "offset": 3,
+      "event": {
+        "event_type": "CREATE_NODE",
+        "timestamp": 4,
+        "node_id": "denied",
+        "payload": {
+          "node_id": "denied"
+        },
+        "metadata": {
+          "policy_result": "rejected"
+        }
+      }
+    },
+    {
+      "offset": 4,
+      "event": {
+        "event_type": "CREATE_NODE",
+        "timestamp": 5,
+        "node_id": "quarantined",
+        "payload": {
+          "node_id": "quarantined"
+        },
+        "metadata": {
+          "policy_result": "quarantined"
+        }
+      }
+    },
+    {
+      "offset": 5,
+      "event": {
+        "event_type": "CREATE_NODE",
+        "timestamp": 6,
+        "schema_version": "3.0.0",
+        "node_id": "historical_only",
+        "payload": {
+          "node_id": "historical_only",
+          "user_id": "user-without-consent",
+          "scope": "graph.write"
+        },
+        "metadata": {
+          "policy_result": "applied"
+        }
+      }
+    }
+  ],
+  "expected": {
+    "strict_historical": {
+      "nodes": [
+        "alpha",
+        "beta",
+        "historical_only"
+      ],
+      "edges": [
+        {
+          "source": "alpha",
+          "target": "beta",
+          "label": "RELATES_TO",
+          "schema_version": "1.0.0"
+        }
+      ]
+    },
+    "current_policy": {
+      "nodes": [
+        "alpha",
+        "beta",
+        "denied",
+        "quarantined"
+      ],
+      "edges": [
+        {
+          "source": "alpha",
+          "target": "beta",
+          "label": "RELATES_TO",
+          "schema_version": "1.0.0"
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_api_ledger.py
+++ b/tests/test_api_ledger.py
@@ -242,3 +242,41 @@ def test_bookmark_persistence_and_replay(tmp_path, monkeypatch):
     replay_from_ledger(g, ledger2, start_offset=ledger2.last_processed_offset + 1)
     assert set(g.get_all_node_ids()) == {"n2"}
 
+
+
+def test_replay_endpoint_mode_selection(tmp_path, monkeypatch):
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    ledger.append(
+        0,
+        {
+            "event_type": "CREATE_NODE",
+            "timestamp": 1,
+            "node_id": "historical",
+            "payload": {
+                "node_id": "historical",
+                "user_id": "u-no-consent",
+                "scope": "graph.write",
+            },
+            "metadata": {"policy_result": "applied"},
+        },
+    )
+    monkeypatch.setattr("ume.ledger_routes.event_ledger", ledger)
+
+    client = TestClient(app)
+    token = _token(client)
+
+    strict = client.get(
+        "/ledger/replay",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"replay_mode": "strict_historical"},
+    )
+    assert strict.status_code == 200
+    assert "historical" in strict.json()["nodes"]
+
+    current = client.get(
+        "/ledger/replay",
+        headers={"Authorization": f"Bearer {token}"},
+        params={"replay_mode": "current_policy"},
+    )
+    assert current.status_code == 200
+    assert "historical" not in current.json()["nodes"]

--- a/tests/test_replay_graph_cli.py
+++ b/tests/test_replay_graph_cli.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import types
+from enum import Enum
 
 
 def test_replay_graph_builds_graph(monkeypatch, capsys):
@@ -61,6 +62,12 @@ def test_replay_graph_builds_graph(monkeypatch, capsys):
         return graph
 
     replay_mod = types.ModuleType("ume.replay")
+
+    class ReplayMode(str, Enum):
+        STRICT_HISTORICAL = "strict_historical"
+        CURRENT_POLICY = "current_policy"
+
+    replay_mod.ReplayMode = ReplayMode
     replay_mod.graph_from_event_ledger = graph_from_event_ledger
 
     stub = types.ModuleType("ume")

--- a/tests/test_replay_regression.py
+++ b/tests/test_replay_regression.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ume.event_ledger import EventLedger
+from ume.persistent_graph import PersistentGraph
+from ume.replay import ReplayMode, replay_from_ledger
+
+
+def _load_fixture(name: str) -> dict[str, object]:
+    fixture = Path("tests/data/replay_golden") / f"{name}.json"
+    return json.loads(fixture.read_text(encoding="utf-8"))
+
+
+def _run_fixture(fixture: dict[str, object], replay_mode: ReplayMode) -> dict[str, object]:
+    ledger = EventLedger(":memory:")
+    for entry in fixture["events"]:
+        ledger.append(entry["offset"], entry["event"])
+
+    graph = PersistentGraph(":memory:")
+    replay_from_ledger(graph, ledger, 0, replay_mode=replay_mode)
+
+    edges = sorted(
+        [
+            {
+                "source": source,
+                "target": target,
+                "label": label,
+                "schema_version": attrs.get("schema_version"),
+            }
+            for source, target, label, attrs in graph.get_all_edges()
+        ],
+        key=lambda edge: (edge["source"], edge["target"], edge["label"]),
+    )
+
+    return {
+        "nodes": sorted(graph.get_all_node_ids()),
+        "edges": edges,
+    }
+
+
+def test_replay_golden_fixture_matches_expected_end_state() -> None:
+    fixture = _load_fixture("mixed_schema_policy")
+    expected = fixture["expected"]
+
+    strict_state = _run_fixture(fixture, ReplayMode.STRICT_HISTORICAL)
+    current_state = _run_fixture(fixture, ReplayMode.CURRENT_POLICY)
+
+    assert strict_state == expected["strict_historical"]
+    assert current_state == expected["current_policy"]
+
+
+def test_replay_golden_fixture_is_deterministic() -> None:
+    fixture = _load_fixture("mixed_schema_policy")
+
+    first = _run_fixture(fixture, ReplayMode.STRICT_HISTORICAL)
+    second = _run_fixture(fixture, ReplayMode.STRICT_HISTORICAL)
+    assert first == second

--- a/ume_cli.py
+++ b/ume_cli.py
@@ -28,23 +28,29 @@ quickstart = _quickstart
 from ume.cli.prompt import UMEPrompt, create_graph_adapter
 
 
-def _ledger_replay(end_offset: int | None, end_timestamp: int | None) -> None:
+def _ledger_replay(end_offset: int | None, end_timestamp: int | None, replay_mode: str) -> None:
     """Print a graph snapshot reconstructed from the event ledger."""
 
-    from ume.replay import snapshot_from_event_ledger
+    from ume.replay import ReplayMode, snapshot_from_event_ledger
 
     snapshot = snapshot_from_event_ledger(
-        end_offset=end_offset, end_timestamp=end_timestamp
+        end_offset=end_offset,
+        end_timestamp=end_timestamp,
+        replay_mode=ReplayMode(replay_mode),
     )
     print(json.dumps(snapshot, indent=2))
 
 
-def _replay_graph(db_path: str | None, end_offset: int | None) -> None:
+def _replay_graph(db_path: str | None, end_offset: int | None, replay_mode: str) -> None:
     """Rebuild a graph from the event ledger and print a summary."""
 
-    from ume.replay import graph_from_event_ledger
+    from ume.replay import ReplayMode, graph_from_event_ledger
 
-    graph = graph_from_event_ledger(db_path=db_path, end_offset=end_offset)
+    graph = graph_from_event_ledger(
+        db_path=db_path,
+        end_offset=end_offset,
+        replay_mode=ReplayMode(replay_mode),
+    )
     node_count = len(graph.get_all_node_ids())
     edge_count = len(graph.get_all_edges())
     location = f" at {db_path}" if db_path and db_path != ":memory:" else ""
@@ -488,6 +494,12 @@ def main() -> None:
     )
     replay_parser.add_argument("--end-offset", type=int)
     replay_parser.add_argument("--end-timestamp", type=int)
+    replay_parser.add_argument(
+        "--replay-mode",
+        choices=["strict_historical", "current_policy"],
+        default="current_policy",
+        help="Use strict historical outcomes from ledger metadata or re-evaluate with current policy.",
+    )
 
     replay_graph_parser = sub.add_parser(
         "replay-graph",
@@ -495,6 +507,12 @@ def main() -> None:
     )
     replay_graph_parser.add_argument("--db-path", default=":memory:")
     replay_graph_parser.add_argument("--end-offset", type=int)
+    replay_graph_parser.add_argument(
+        "--replay-mode",
+        choices=["strict_historical", "current_policy"],
+        default="current_policy",
+        help="Use strict historical outcomes from ledger metadata or re-evaluate with current policy.",
+    )
 
     plugins_parser = sub.add_parser("plugins", help="List registered plugins")
     plugins_parser.add_argument(
@@ -603,10 +621,10 @@ def main() -> None:
             _snapshot_schedule(args.interval)
             return
         if args.command == "ledger-replay":
-            _ledger_replay(args.end_offset, args.end_timestamp)
+            _ledger_replay(args.end_offset, args.end_timestamp, args.replay_mode)
             return
         if args.command == "replay-graph":
-            _replay_graph(args.db_path, args.end_offset)
+            _replay_graph(args.db_path, args.end_offset, args.replay_mode)
             return
         if args.command == "plugins":
             _list_plugins(args.capability)


### PR DESCRIPTION
### Motivation

- Ensure ledger replay produces deterministic end-state for forensic reconstruction and reproducible testing across schema upgrades and policy changes.
- Allow operators to choose between exact historical reconstruction and re-evaluating events with the current policy stack.
- Provide golden fixtures and automated regression checks to block nondeterministic handler/policy changes from being merged.

### Description

- Introduce `ReplayMode` and historical-policy interpretation helpers in `src/ume/replay.py` and make replay behavior mode-aware so `strict_historical` honors persisted `policy_result` metadata while `current_policy` re-evaluates via the active policy pipeline. Audit side-effects are gated to `current_policy` to avoid spurious historical auditing. (`src/ume/replay.py`)
- Thread `replay_mode` through public replay APIs and helpers: `replay_from_ledger`, `build_graph_from_ledger`, `graph_from_event_ledger`, and `snapshot_from_event_ledger`. (`src/ume/replay.py`)
- Add API query flags to `/ledger/replay` and `/graph/history` and CLI flags to `ledger-replay` / `replay-graph` to select replay mode. (`src/ume/ledger_routes.py`, `ume_cli.py`)
- Add a golden replay fixture exercising mixed schema versions and mixed policy outcomes plus deterministic expected end-states, and add regression tests verifying mode-specific final graph state and determinism. (`tests/data/replay_golden/mixed_schema_policy.json`, `tests/test_replay_regression.py`)
- Document replay guarantees, explain modes and operational guidance in `docs/PROJECTION_ENGINE.md`, update `docs/API_REFERENCE.md`, and add a dedicated CI job to run the replay regression suite. (`docs/PROJECTION_ENGINE.md`, `docs/API_REFERENCE.md`, `.github/workflows/ci.yml`)

### Testing

- Ran linter: `poetry run ruff check src/ume/replay.py src/ume/ledger_routes.py ume_cli.py tests/test_replay_regression.py tests/test_api_ledger.py tests/test_replay_graph_cli.py` and the checks passed.
- Ran unit/regression tests: `poetry run pytest tests/test_replay_regression.py tests/test_event_ledger.py tests/test_replay_graph_cli.py` and they passed (11 tests total passed).
- Attempted broader test runs that exercise API/CLI smoke tests; collection/execution failed in this runner for some suites due to missing runtime dev dependencies in the container (`fastapi`, `structlog`), so full integration/unit matrix was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9ac7234d883268a22879e4861bd47)