### PR TITLE
feat(architecture): define kernel/domain boundaries with dependency linting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,17 @@ If you find a bug or have an idea for a new feature, please check our issue trac
 - Compatibility re-exports in `ume.__init__` are temporary deprecation shims;
   prefer direct module imports in new contributions.
 
+
+### Architecture boundaries (kernel vs domains)
+
+- Kernel packages live under `src/ume/kernel/` and define core contracts (`events`, `policy`, `graph_adapter`, `processing`, `ledger`).
+- Feature/domain logic lives under `src/ume/domains/<domain_name>/`.
+- **Dependency rule:** kernel modules must not import from `ume.domains`.
+- Add new enrichment/business modules as domain extensions and wire them through extension points in service orchestration (see `ume.domains.extensions`).
+- Boundary checks are enforced by:
+  - `python scripts/lint_dependencies.py`
+  - `pytest tests/architecture`
+
 ### Coding Style
 
 - **Black** is used for code formatting. Run `black` on your changes before committing.

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -4,6 +4,33 @@ This document is the canonical architecture reference for backend selection and
 runtime bootstrap in UME. It describes the *actual* creation paths used by the
 codebase today.
 
+
+## Layered package layout
+
+UME now uses explicit package boundaries:
+
+- `ume.kernel`: core platform contracts and orchestration primitives
+  - `ume.kernel.events`
+  - `ume.kernel.policy`
+  - `ume.kernel.graph_adapter`
+  - `ume.kernel.processing`
+  - `ume.kernel.ledger`
+- `ume.domains.<name>`: feature/domain packs implementing domain-specific logic
+
+### Extension points for domain logic
+
+Domain modules integrate through extension hooks instead of direct coupling to core pipeline modules.
+Use `ume.domains.extensions.DomainExtension` and `run_domain_extensions(...)` to attach domain behavior from mutation/pipeline entry points.
+
+### Static dependency enforcement
+
+Kernel/domain boundaries are statically enforced:
+
+- Linter: `python scripts/lint_dependencies.py`
+- Tests: `tests/architecture/test_dependency_boundaries.py`
+
+These checks fail when any kernel module imports `ume.domains` directly.
+
 ## 1) Graph backend creation flow
 
 **Primary API:** `ume.factories.create_graph_adapter()` (`src/ume/factories.py`).

--- a/scripts/lint_dependencies.py
+++ b/scripts/lint_dependencies.py
@@ -1,0 +1,63 @@
+"""Static dependency linter for architecture boundaries."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+KERNEL_DIR = ROOT / "src" / "ume" / "kernel"
+DISALLOWED = "ume.domains"
+
+
+def _module_name(path: Path) -> str:
+    rel = path.relative_to(ROOT / "src")
+    return ".".join(rel.with_suffix("").parts)
+
+
+def _is_disallowed_import(node: ast.AST, module_name: str) -> bool:
+    if isinstance(node, ast.Import):
+        return any(alias.name == DISALLOWED or alias.name.startswith(f"{DISALLOWED}.") for alias in node.names)
+    if isinstance(node, ast.ImportFrom):
+        if node.level:
+            package = module_name.split(".")[:-1]
+            base = package[:]
+            up = node.level - 1
+            if up > len(base):
+                resolved = ""
+            else:
+                resolved = ".".join(base[: len(base) - up])
+            if node.module:
+                resolved = f"{resolved}.{node.module}" if resolved else node.module
+        else:
+            resolved = node.module or ""
+        return resolved == DISALLOWED or resolved.startswith(f"{DISALLOWED}.")
+    return False
+
+
+def lint_kernel_dependencies() -> list[str]:
+    violations: list[str] = []
+    for path in sorted(KERNEL_DIR.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        module_name = _module_name(path)
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if _is_disallowed_import(node, module_name):
+                violations.append(f"{path.relative_to(ROOT)} imports {DISALLOWED}")
+    return violations
+
+
+def main() -> int:
+    violations = lint_kernel_dependencies()
+    if violations:
+        print("Kernel dependency violations found:")
+        for violation in violations:
+            print(f"- {violation}")
+        return 1
+    print("Kernel dependency lint passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ume/domains/__init__.py
+++ b/src/ume/domains/__init__.py
@@ -1,0 +1,4 @@
+"""Feature domain packs.
+
+Domain logic lives in this namespace and may depend on kernel modules.
+"""

--- a/src/ume/domains/classification/__init__.py
+++ b/src/ume/domains/classification/__init__.py
@@ -1,0 +1,5 @@
+"""Classification domain pack."""
+
+from .extensions import apply_classification
+
+__all__ = ["apply_classification"]

--- a/src/ume/domains/classification/extensions.py
+++ b/src/ume/domains/classification/extensions.py
@@ -1,0 +1,37 @@
+"""Classification extension hooks."""
+
+from __future__ import annotations
+
+from ...classification import classify_event
+from ...kernel.policy import PolicyContext
+
+
+def apply_classification(context: PolicyContext) -> dict[str, int]:
+    """Annotate event payload with classification metadata."""
+
+    event = context.effective_event
+    if event is None:
+        return {}
+    tag_results = classify_event(event)
+    event.payload["classification"] = [
+        {
+            "tag": r.tag,
+            "confidence": r.confidence,
+            "domain": r.domain,
+            "subdomain": r.subdomain,
+            "sensitivity": r.sensitivity,
+        }
+        for r in tag_results
+    ]
+    if tag_results:
+        attributes = event.payload.setdefault("attributes", {})
+        attributes["tags"] = [r.tag for r in tag_results]
+        attributes["tag_confidence"] = [r.confidence for r in tag_results]
+        for result in tag_results:
+            if result.domain and "domain" not in attributes:
+                attributes["domain"] = result.domain
+            if result.subdomain and "subdomain" not in attributes:
+                attributes["subdomain"] = result.subdomain
+            if result.sensitivity and "sensitivity" not in attributes:
+                attributes["sensitivity"] = result.sensitivity
+    return {"classification_count": len(tag_results)}

--- a/src/ume/domains/extensions.py
+++ b/src/ume/domains/extensions.py
@@ -1,0 +1,24 @@
+"""Domain extension point contracts used by mutation and pipeline entry points."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class DomainExtension(Protocol):
+    """Protocol for pluggable domain enrichment hooks."""
+
+    def __call__(self, context: Any) -> dict[str, Any] | None:
+        ...
+
+
+def run_domain_extensions(context: Any, extensions: list[DomainExtension]) -> dict[str, Any]:
+    """Execute domain extensions and merge returned details."""
+
+    details: dict[str, Any] = {}
+    for extension in extensions:
+        extension_details = extension(context)
+        if extension_details:
+            details.update(extension_details)
+    return details

--- a/src/ume/kernel/__init__.py
+++ b/src/ume/kernel/__init__.py
@@ -1,0 +1,29 @@
+"""Kernel package exports for stable core boundaries.
+
+The kernel contains foundational primitives shared by domain packs.
+Domain packs must depend on this layer, while kernel code must not import domains.
+"""
+
+from .events import Event
+from .graph_adapter import IGraphAdapter
+from .ledger import EventLedger
+from .policy import (
+    PolicyContext,
+    PolicyDecision,
+    PolicyPipeline,
+    build_default_policy_pipeline,
+)
+from .processing import DEFAULT_VERSION, ProcessingError, apply_event_to_graph
+
+__all__ = [
+    "Event",
+    "EventLedger",
+    "IGraphAdapter",
+    "PolicyContext",
+    "PolicyDecision",
+    "PolicyPipeline",
+    "ProcessingError",
+    "DEFAULT_VERSION",
+    "apply_event_to_graph",
+    "build_default_policy_pipeline",
+]

--- a/src/ume/kernel/events.py
+++ b/src/ume/kernel/events.py
@@ -1,0 +1,5 @@
+"""Kernel events API."""
+
+from ..event import Event
+
+__all__ = ["Event"]

--- a/src/ume/kernel/graph_adapter.py
+++ b/src/ume/kernel/graph_adapter.py
@@ -1,0 +1,5 @@
+"""Kernel graph adapter contracts."""
+
+from ..graph_adapter import IGraphAdapter
+
+__all__ = ["IGraphAdapter"]

--- a/src/ume/kernel/ledger.py
+++ b/src/ume/kernel/ledger.py
@@ -1,0 +1,5 @@
+"""Kernel event ledger persistence exports."""
+
+from ..event_ledger import EventLedger
+
+__all__ = ["EventLedger"]

--- a/src/ume/kernel/policy.py
+++ b/src/ume/kernel/policy.py
@@ -1,0 +1,15 @@
+"""Kernel policy API."""
+
+from ..policy.pipeline import (
+    PolicyContext,
+    PolicyDecision,
+    PolicyPipeline,
+    build_default_policy_pipeline,
+)
+
+__all__ = [
+    "PolicyContext",
+    "PolicyDecision",
+    "PolicyPipeline",
+    "build_default_policy_pipeline",
+]

--- a/src/ume/kernel/processing.py
+++ b/src/ume/kernel/processing.py
@@ -1,0 +1,6 @@
+"""Kernel processing orchestration exports."""
+
+from ..processing import DEFAULT_VERSION, apply_event_to_graph
+from ..processing_errors import ProcessingError
+
+__all__ = ["DEFAULT_VERSION", "apply_event_to_graph", "ProcessingError"]

--- a/src/ume/pipeline/core.py
+++ b/src/ume/pipeline/core.py
@@ -9,7 +9,6 @@ import logging
 from time import perf_counter
 from typing import Any, Awaitable, Callable, Mapping
 
-from ..classification import classify_event
 from ..event import Event
 from ..events.ingress import ingest_transport_payload, IngressAdapter
 from ..metrics import (
@@ -489,34 +488,3 @@ class EventPipelineOrchestrator:
         if auditor is not None:
             await auditor(envelope)
         return envelope
-
-
-def apply_classification(context: PolicyContext) -> dict[str, Any]:
-    """Annotate event payload with classification metadata."""
-
-    event = context.effective_event
-    if event is None:
-        return {}
-    tag_results = classify_event(event)
-    event.payload["classification"] = [
-        {
-            "tag": r.tag,
-            "confidence": r.confidence,
-            "domain": r.domain,
-            "subdomain": r.subdomain,
-            "sensitivity": r.sensitivity,
-        }
-        for r in tag_results
-    ]
-    if tag_results:
-        attributes = event.payload.setdefault("attributes", {})
-        attributes["tags"] = [r.tag for r in tag_results]
-        attributes["tag_confidence"] = [r.confidence for r in tag_results]
-        for r in tag_results:
-            if r.domain and "domain" not in attributes:
-                attributes["domain"] = r.domain
-            if r.subdomain and "subdomain" not in attributes:
-                attributes["subdomain"] = r.subdomain
-            if r.sensitivity and "sensitivity" not in attributes:
-                attributes["sensitivity"] = r.sensitivity
-    return {"classification_count": len(tag_results)}

--- a/src/ume/services/mutate.py
+++ b/src/ume/services/mutate.py
@@ -9,6 +9,8 @@ from enum import Enum
 from typing import Any, Callable
 
 from ..event import EventError
+from ..domains.classification import apply_classification
+from ..domains.extensions import DomainExtension, run_domain_extensions
 from ..events.ingress import IngressAdapter
 from ..events.versioning import resolve_schema_version
 from ..graph_adapter import IGraphAdapter
@@ -16,7 +18,6 @@ from ..pipeline.core import (
     EventPipelineOrchestrator,
     PipelineEnvelope,
     PipelineOutcome,
-    apply_classification,
 )
 from ..policy.pipeline import PolicyDecision
 from ..processing import DEFAULT_VERSION, apply_event_to_graph
@@ -138,7 +139,12 @@ def build_graph_projector(
     *,
     schema_version: str | None = None,
     classify: bool = True,
+    domain_extensions: list[DomainExtension] | None = None,
 ) -> Callable[[Any], dict[str, Any]]:
+    active_extensions: list[DomainExtension] = list(domain_extensions or [])
+    if classify:
+        active_extensions.append(apply_classification)
+
     def _project(context: Any) -> dict[str, Any]:
         canonical = context.canonical_event
         event = context.effective_event
@@ -150,7 +156,7 @@ def build_graph_projector(
             fallback_version=_fallback_schema_version(),
             default_version=DEFAULT_VERSION,
         )
-        details = apply_classification(context) if classify else {}
+        details = run_domain_extensions(context, active_extensions)
         apply_event_to_graph(event, graph, schema_version=effective_version)
         return {**details, "schema_version": effective_version}
 

--- a/tests/architecture/test_dependency_boundaries.py
+++ b/tests/architecture/test_dependency_boundaries.py
@@ -1,0 +1,6 @@
+from scripts.lint_dependencies import lint_kernel_dependencies
+
+
+def test_kernel_does_not_depend_on_domains() -> None:
+    violations = lint_kernel_dependencies()
+    assert not violations, "\n".join(violations)

--- a/tests/architecture/test_domain_extension_points.py
+++ b/tests/architecture/test_domain_extension_points.py
@@ -1,0 +1,37 @@
+from ume.domains.classification import apply_classification
+from ume.domains.extensions import run_domain_extensions
+from ume.event import Event
+from ume.kernel.policy import PolicyContext
+
+
+def _context() -> PolicyContext:
+    event = Event(
+        event_type="entity.created",
+        timestamp=0,
+        payload={"attributes": {"text": "pii email@example.com"}},
+    )
+    return PolicyContext(
+        source="test",
+        raw_payload=None,
+        transport_data={},
+        canonical_event={"event_type": event.event_type, "payload": event.payload},
+        original_event=event,
+        effective_event=event,
+    )
+
+
+def test_domain_extension_runner_merges_details() -> None:
+    context = _context()
+
+    def extension(_: PolicyContext) -> dict[str, int]:
+        return {"x": 1}
+
+    details = run_domain_extensions(context, [extension])
+
+    assert details == {"x": 1}
+
+
+def test_classification_extension_is_invokable_from_domain_pack() -> None:
+    context = _context()
+    details = run_domain_extensions(context, [apply_classification])
+    assert "classification_count" in details


### PR DESCRIPTION
### Motivation

- Establish a clear layered package boundary so core primitives live in a stable kernel layer and feature logic lives in namespaced domain packs. 
- Prevent accidental coupling where kernel code imports feature/domain code by enforcing a static dependency rule. 
- Provide extension points so domain logic can be attached to the pipeline without direct coupling to core pipeline modules. 
- Make it explicit where new domain logic and tests should live and add guards to prevent boundary regressions.

### Description

- Added a kernel export package under `src/ume/kernel/` that re-exports core contracts: `events`, `policy`, `graph_adapter`, `processing`, and `ledger` (new files under `src/ume/kernel/`).
- Introduced a `src/ume/domains/` namespace and a classification domain pack with `apply_classification` in `src/ume/domains/classification/extensions.py`, and added domain extension contracts in `src/ume/domains/extensions.py`.
- Removed the inlined `apply_classification` helper from `src/ume/pipeline/core.py` and wired `src/ume/services/mutate.py::build_graph_projector` to accept `domain_extensions` and merge extension results via `run_domain_extensions` before applying graph mutations.
- Added a static dependency linter `scripts/lint_dependencies.py` that fails when kernel files import `ume.domains`, and added architecture tests `tests/architecture/test_dependency_boundaries.py` and `tests/architecture/test_domain_extension_points.py` to validate boundaries and extension behavior.
- Updated docs and contribution guidance in `CONTRIBUTING.md` and `docs/ARCHITECTURE_OVERVIEW.md` to document the layered layout, extension points, and enforcement tools.

### Testing

- Ran `ruff check src/ume/kernel src/ume/domains src/ume/services/mutate.py src/ume/pipeline/core.py scripts/lint_dependencies.py tests/architecture`, which passed without issues. 
- Ran `pytest -q tests/architecture`, which succeeded (`3 passed`). 
- Executed `python scripts/lint_dependencies.py`, which reported `Kernel dependency lint passed.` and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b2d060e4832695f3f9a8912a877a)