### PR TITLE
Introduce structured policy input and backend-agnostic graph read views for policy evaluation

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -187,3 +187,31 @@ can negotiate support before executing capability-dependent operations.
 API capability metadata is exposed at `GET /health/capabilities`. Vector query
 routes also verify `vector_similarity` support and return `501` when the selected
 backend does not provide it.
+
+## 8) Policy input contract (OPA/Rego)
+
+Policy plugins now receive a stable structured input document with the following shape:
+
+```json
+{
+  "event": {
+    "event_id": "...",
+    "event_type": "...",
+    "timestamp": 0,
+    "node_id": "...",
+    "target_node_id": "...",
+    "label": "...",
+    "payload": {}
+  },
+  "graph": {
+    "mode": "snapshot|neighborhood",
+    "nodes": {},
+    "edges": []
+  },
+  "actor": {"id": "...", "type": "..."},
+  "source": {"transport": "api|kafka|...", "service": "..."},
+  "metadata": {"redacted": false, "canonical_metadata": {}}
+}
+```
+
+`graph.mode=snapshot` is used for small graphs; large graphs receive a bounded neighborhood view centered on event nodes. This keeps policy decisions backend-agnostic while letting Rego evaluate existing node/edge state.

--- a/docs/CONFIG_TEMPLATES.md
+++ b/docs/CONFIG_TEMPLATES.md
@@ -144,6 +144,16 @@ is enabled.
 | `LLM_FERRY_API_KEY` | *(unset)* | API key used by `LLMFerry` for authentication. |
 | `UME_OPA_URL` | *(unset)* | Base URL of a remote OPA server used by `RegoPolicyEngine`. |
 | `UME_OPA_TOKEN` | *(unset)* | Bearer token sent with OPA requests. |
+| `UME_POLICY_GRAPH_MAX_SNAPSHOT_NODES` | `500` | If graph node count is <= this limit, policy input includes a full graph snapshot. |
+| `UME_POLICY_GRAPH_NEIGHBORHOOD_DEPTH` | `1` | Neighborhood hop depth used when a full snapshot is skipped. |
+| `UME_POLICY_GRAPH_MAX_NEIGHBORHOOD_NODES` | `200` | Maximum nodes included in neighborhood mode before truncation. |
+
+### OPA/Rego input shape
+
+Requests to OPA use an input document shaped as `{event, graph, actor, source, metadata}`.
+`event` contains normalized event fields; `graph` contains either `mode: snapshot`
+with full `nodes`/`edges` or `mode: neighborhood` with bounded context;
+`actor` and `source` provide principal and ingress metadata.
 
 `UME_RATE_LIMIT_REDIS` may be set to a Redis URL to enable shared rate limiting.
 If unset, the API uses an in-memory limiter.
@@ -170,4 +180,3 @@ stack:
 4. Inspect logs with `docker compose logs -f ume-api`.
 5. Confirm all services report `healthy` with `docker compose ps`.
 6. Stop all containers with `docker compose down` when finished.
-

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -102,6 +102,9 @@ class Settings(BaseSettings):  # type: ignore[misc]
     OPA_TOKEN: str | None = None
 
     REGO_POLICY_PATHS: str | None = None
+    UME_POLICY_GRAPH_MAX_SNAPSHOT_NODES: int = 500
+    UME_POLICY_GRAPH_NEIGHBORHOOD_DEPTH: int = 1
+    UME_POLICY_GRAPH_MAX_NEIGHBORHOOD_NODES: int = 200
 
     # OpenTelemetry
     UME_OTLP_ENDPOINT: str | None = None

--- a/src/ume/plugins/alignment/__init__.py
+++ b/src/ume/plugins/alignment/__init__.py
@@ -42,9 +42,9 @@ def register_plugin(plugin: AlignmentPlugin) -> None:
 
     original_validate = plugin.validate
 
-    def wrapped_validate(event: Event) -> None:
+    def wrapped_validate(event: Event, *args: object, **kwargs: object) -> None:
         try:
-            original_validate(event)
+            original_validate(event, *args, **kwargs)
         except PolicyViolationError as exc:
             user_id = settings.UME_AGENT_ID
             log_audit_entry(user_id, str(exc))

--- a/src/ume/plugins/alignment/rego_engine.py
+++ b/src/ume/plugins/alignment/rego_engine.py
@@ -60,8 +60,24 @@ class RegoPolicyEngine(AlignmentPlugin):
         else:
             raise FileNotFoundError(f"Policy path {path} not found")
 
-    def validate(self, event: Event) -> None:
-        data: dict[str, Any] = event.__dict__
+    def validate(self, event: Event, *, policy_input: dict[str, Any] | None = None) -> None:
+        data: dict[str, Any] = policy_input or {
+            "event": {
+                "event_id": event.event_id,
+                "event_type": event.event_type,
+                "timestamp": event.timestamp,
+                "node_id": event.node_id,
+                "target_node_id": event.target_node_id,
+                "label": event.label,
+                "payload": event.payload,
+                "correlation_id": event.correlation_id,
+                "schema_version": event.schema_version,
+            },
+            "graph": {},
+            "actor": event.subject_entity or {},
+            "source": {"service": event.source_service} if event.source_service else {},
+            "metadata": {},
+        }
         if self._opa_client is not None:
             result = self._opa_client.query(self._opa_path, data)
             allowed = bool(result)

--- a/src/ume/policy/graph_view.py
+++ b/src/ume/policy/graph_view.py
@@ -1,0 +1,56 @@
+"""Helpers for building backend-agnostic graph read views for policy input."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..event import Event
+from ..graph_adapter import IGraphAdapter
+
+
+def build_graph_read_view(
+    graph: IGraphAdapter,
+    *,
+    event: Event,
+    max_snapshot_nodes: int,
+    neighborhood_depth: int,
+    max_neighborhood_nodes: int,
+) -> dict[str, Any]:
+    node_ids = graph.get_all_node_ids()
+    if len(node_ids) <= max_snapshot_nodes:
+        snapshot = graph.dump()
+        return {
+            "mode": "snapshot",
+            "node_count": len(node_ids),
+            "nodes": snapshot.get("nodes", {}),
+            "edges": snapshot.get("edges", []),
+            "truncated": False,
+        }
+
+    center_ids = [node_id for node_id in [event.node_id, event.target_node_id] if node_id]
+    if not center_ids:
+        payload_node = event.payload.get("node_id")
+        payload_target = event.payload.get("target_node_id")
+        center_ids = [node_id for node_id in [payload_node, payload_target] if isinstance(node_id, str)]
+
+    nodes: dict[str, Any] = {}
+    edges: list[Any] = []
+    for center in center_ids[:2]:
+        subgraph = graph.extract_subgraph(center, depth=neighborhood_depth)
+        for node_id, attributes in subgraph.get("nodes", {}).items():
+            if len(nodes) >= max_neighborhood_nodes:
+                break
+            nodes[node_id] = attributes
+        if len(nodes) >= max_neighborhood_nodes:
+            break
+        edges.extend(subgraph.get("edges", []))
+
+    return {
+        "mode": "neighborhood",
+        "node_count": len(nodes),
+        "nodes": nodes,
+        "edges": edges,
+        "center_node_ids": center_ids,
+        "depth": neighborhood_depth,
+        "truncated": len(nodes) >= max_neighborhood_nodes,
+    }

--- a/src/ume/policy/pipeline.py
+++ b/src/ume/policy/pipeline.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import inspect
 from hashlib import sha256
 from dataclasses import dataclass, field
 from enum import Enum
@@ -72,6 +73,7 @@ class PolicyContext:
     canonical_event: Dict[str, Any] | None = None
     original_event: Event | None = None
     effective_event: Event | None = None
+    graph_read_view: Dict[str, Any] | None = None
     redacted: bool = False
     details: Dict[str, Any] = field(default_factory=dict)
 
@@ -88,6 +90,46 @@ class PolicyContext:
     def event(self) -> Event | None:
         """Backward-compatible alias for the effective event."""
         return self.effective_event
+
+    @property
+    def policy_input(self) -> Dict[str, Any]:
+        event = self.effective_event
+        actor: Dict[str, Any] = {}
+        if event is not None and isinstance(event.subject_entity, dict):
+            actor = dict(event.subject_entity)
+        if not actor:
+            user_id = self.event_payload.get("user_id")
+            if user_id is not None:
+                actor = {"id": str(user_id), "type": "user"}
+
+        event_doc: Dict[str, Any] = {}
+        if event is not None:
+            event_doc = {
+                "event_id": event.event_id,
+                "event_type": event.event_type,
+                "timestamp": event.timestamp,
+                "node_id": event.node_id,
+                "target_node_id": event.target_node_id,
+                "label": event.label,
+                "payload": event.payload,
+                "correlation_id": event.correlation_id,
+                "schema_version": event.schema_version,
+            }
+
+        source_doc: Dict[str, Any] = {"transport": self.source}
+        if event is not None and event.source_service:
+            source_doc["service"] = event.source_service
+
+        return {
+            "event": event_doc,
+            "graph": self.graph_read_view or {},
+            "actor": actor,
+            "source": source_doc,
+            "metadata": {
+                "redacted": self.redacted,
+                "canonical_metadata": (self.canonical_event or {}).get("metadata", {}),
+            },
+        }
 
 
 @dataclass
@@ -237,7 +279,7 @@ class AlignmentStage:
             )
         try:
             for plugin in self._plugin_provider():
-                plugin.validate(context.effective_event)
+                _validate_with_context(plugin, context)
         except PolicyViolationError as exc:
             return _result(
                 PolicyDecision.DENY,
@@ -403,6 +445,7 @@ def _context_audit_details(context: PolicyContext) -> Dict[str, Any]:
     if context.canonical_event is not None and isinstance(context.canonical_event.get("payload"), dict):
         effective_payload = context.canonical_event["payload"]
 
+    graph_read_view = context.graph_read_view or {}
     return {
         "original_event_id": context.original_event.event_id if context.original_event else None,
         "original_event_type": context.original_event.event_type if context.original_event else None,
@@ -411,7 +454,20 @@ def _context_audit_details(context: PolicyContext) -> Dict[str, Any]:
         "original_payload_hash": _payload_hash(original_payload),
         "effective_payload_hash": _payload_hash(effective_payload),
         "redacted": context.redacted,
+        "graph_view_mode": graph_read_view.get("mode"),
+        "graph_view_nodes": len(graph_read_view.get("nodes", {}))
+        if isinstance(graph_read_view.get("nodes"), dict)
+        else None,
     }
+
+
+def _validate_with_context(plugin: Any, context: PolicyContext) -> None:
+    validate = getattr(plugin, "validate")
+    params = inspect.signature(validate).parameters
+    if "policy_input" in params:
+        validate(context.effective_event, policy_input=context.policy_input)
+        return
+    validate(context.effective_event)
 
 
 def build_default_policy_pipeline(

--- a/src/ume/services/mutate.py
+++ b/src/ume/services/mutate.py
@@ -13,6 +13,7 @@ from ..domains.classification import apply_classification
 from ..domains.extensions import DomainExtension, run_domain_extensions
 from ..events.ingress import IngressAdapter
 from ..events.versioning import resolve_schema_version
+from ..config import settings
 from ..graph_adapter import IGraphAdapter
 from ..pipeline.core import (
     EventPipelineOrchestrator,
@@ -20,6 +21,7 @@ from ..pipeline.core import (
     PipelineOutcome,
 )
 from ..policy.pipeline import PolicyDecision
+from ..policy.graph_view import build_graph_read_view
 from ..processing import DEFAULT_VERSION, apply_event_to_graph
 from ..schema_manager import DEFAULT_SCHEMA_MANAGER
 
@@ -150,6 +152,13 @@ def build_graph_projector(
         event = context.effective_event
         if canonical is None or event is None:
             raise EventError("missing_canonical_or_event")
+        context.graph_read_view = build_graph_read_view(
+            graph,
+            event=event,
+            max_snapshot_nodes=settings.UME_POLICY_GRAPH_MAX_SNAPSHOT_NODES,
+            neighborhood_depth=settings.UME_POLICY_GRAPH_NEIGHBORHOOD_DEPTH,
+            max_neighborhood_nodes=settings.UME_POLICY_GRAPH_MAX_NEIGHBORHOOD_NODES,
+        )
         effective_version = resolve_schema_version(
             canonical,
             explicit_version=schema_version,

--- a/tests/test_audit_logging.py
+++ b/tests/test_audit_logging.py
@@ -3,6 +3,7 @@ import os
 
 os.environ.setdefault("UME_AUDIT_SIGNING_KEY", "test-key")
 import pytest
+from ume.policy.pipeline import PolicyContext, build_default_policy_pipeline
 
 # Skip heavy optional dependencies if they aren't installed
 for _mod in (
@@ -262,6 +263,27 @@ def test_parse_s3_valid() -> None:
     assert key == "path/to/key"
 
 
+def test_policy_audit_contains_graph_view_details(monkeypatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+    monkeypatch.setattr("ume.policy.pipeline.get_plugins", lambda: [])
+
+    pipeline = build_default_policy_pipeline(redactor=lambda payload: (payload, False))
+    context = PolicyContext(
+        source="service",
+        transport_data={
+            "eventType": "CREATE_NODE",
+            "timestamp": 1,
+            "nodeId": "n1",
+            "payload": {"attributes": {"name": "Alice"}},
+        },
+        graph_read_view={"mode": "snapshot", "nodes": {"n1": {}}, "edges": []},
+    )
+    result = pipeline.evaluate(context)
+
+    assert result.audit_event.details["graph_view_mode"] == "snapshot"
+    assert result.audit_event.details["graph_view_nodes"] == 1
+
+
 @pytest.mark.parametrize(
     "path",
     [
@@ -285,4 +307,3 @@ def test_write_lines_creates_directory(tmp_path):
 
     assert path.exists()
     assert _read_lines(str(path)) == ["entry1"]
-

--- a/tests/test_opa_integration.py
+++ b/tests/test_opa_integration.py
@@ -1,22 +1,28 @@
 import pytest
+from types import SimpleNamespace
 
 from ume.event import Event, EventType
 from ume.plugins.alignment.rego_engine import RegoPolicyEngine, PolicyViolationError  # type: ignore[attr-defined]
 from ume.policy.opa_client import OPAClient
 
 httpx = pytest.importorskip("httpx")
-respx = pytest.importorskip("respx")
 
 
 def test_opa_client_query() -> None:
     client = OPAClient(base_url="http://opa")
-    with respx.mock(assert_all_called=True) as mock:
-        route = mock.post("http://opa/v1/data/ume/allow").mock(
-            return_value=httpx.Response(200, json={"result": True})
+    calls: list[dict[str, object]] = []
+
+    def fake_post(url: str, json: dict[str, object], headers: dict[str, str]) -> SimpleNamespace:
+        calls.append({"url": url, "json": json, "headers": headers})
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {"result": True},
         )
-        result = client.query("ume/allow", {"foo": "bar"})
-        assert route.called
-        assert result is True
+
+    client._client.post = fake_post  # type: ignore[method-assign]
+    result = client.query("ume/allow", {"foo": "bar"})
+    assert result is True
+    assert calls[0]["url"] == "http://opa/v1/data/ume/allow"
 
 
 def test_rego_engine_delegates_to_opa() -> None:
@@ -26,11 +32,19 @@ def test_rego_engine_delegates_to_opa() -> None:
         timestamp=0,
         payload={"node_id": "n1", "attributes": {}},
     )
-    with respx.mock(assert_all_called=True) as mock:
-        mock.post("http://opa/v1/data/ume/allow").mock(
-            return_value=httpx.Response(200, json={"result": True})
-        )
-        engine.validate(event)
+    captured: dict[str, object] = {}
+
+    def fake_query(path: str, input_data: dict[str, object]) -> bool:
+        captured["path"] = path
+        captured["input"] = input_data
+        return True
+
+    engine._opa_client.query = fake_query  # type: ignore[method-assign]
+    engine.validate(event)
+    payload = captured["input"]
+    assert captured["path"] == "ume/allow"
+    assert payload["event"]["event_type"] == EventType.CREATE_NODE
+    assert payload["graph"] == {}
 
 
 def test_rego_engine_opa_denied() -> None:
@@ -40,9 +54,6 @@ def test_rego_engine_opa_denied() -> None:
         timestamp=0,
         payload={"node_id": "n1", "attributes": {}},
     )
-    with respx.mock(assert_all_called=True) as mock:
-        mock.post("http://opa/v1/data/ume/allow").mock(
-            return_value=httpx.Response(200, json={"result": False})
-        )
-        with pytest.raises(PolicyViolationError):
-            engine.validate(event)
+    engine._opa_client.query = lambda *_args, **_kwargs: False  # type: ignore[method-assign]
+    with pytest.raises(PolicyViolationError):
+        engine.validate(event)

--- a/tests/test_policy_pipeline_ordering.py
+++ b/tests/test_policy_pipeline_ordering.py
@@ -92,3 +92,33 @@ def test_stage_registry_from_config_and_env(tmp_path, monkeypatch) -> None:
         PolicyContext(source="service", transport_data=_event({"email": "user@example.com"}))
     )
     assert env_result.decision == PolicyDecision.ALLOW
+
+
+def test_alignment_plugin_receives_structured_policy_input(monkeypatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+
+    class CapturingPlugin:
+        def __init__(self) -> None:
+            self.last_input = None
+
+        def validate(self, _event, *, policy_input=None) -> None:
+            self.last_input = policy_input
+
+    plugin = CapturingPlugin()
+    pipeline = build_default_policy_pipeline(
+        redactor=lambda payload: (payload, False),
+        plugin_provider=lambda: [plugin],
+    )
+
+    context = PolicyContext(source="service", transport_data=_event({"user_id": "u1"}))
+    context.graph_read_view = {
+        "mode": "snapshot",
+        "nodes": {"n1": {"type": "person"}},
+        "edges": [],
+    }
+    result = pipeline.evaluate(context)
+
+    assert result.decision == PolicyDecision.ALLOW
+    assert plugin.last_input["event"]["event_type"] == "CREATE_NODE"
+    assert plugin.last_input["graph"]["nodes"]["n1"]["type"] == "person"
+    assert plugin.last_input["actor"]["id"] == "u1"


### PR DESCRIPTION
### Motivation

- Provide a stable, structured policy input contract so alignment policies (OPA/Rego and local plugins) can reason about existing graph state, actor identity, and ingress metadata instead of ad-hoc `event.__dict__` inputs. 
- Keep policy evaluation backend-agnostic and bounded in cost by returning either a full snapshot for small graphs or a bounded neighborhood view for large graphs. 
- Improve observability of policy outcomes by capturing graph view metadata in policy audit events.

### Description

- Added `PolicyContext.graph_read_view` and a `PolicyContext.policy_input` property that yields the stable input document `{event, graph, actor, source, metadata}` for policy plugins. 
- Added `_validate_with_context` wrapper and updated `AlignmentStage` to call it so plugins that accept a `policy_input` keyword receive the structured input while preserving compatibility with existing plugin signatures. 
- Updated `RegoPolicyEngine.validate` to accept an optional `policy_input` and send the structured input to OPA/local Rego instead of `event.__dict__`, with a compatibility fallback. 
- Made the plugin registration wrapper in `plugins.alignment` forward arbitrary args/kwargs so wrapped `validate` methods remain compatible. 
- Introduced `src/ume/policy/graph_view.py` with `build_graph_read_view(...)` that produces either a full `snapshot` or a `neighborhood` read view using only `IGraphAdapter` methods. 
- Populated `context.graph_read_view` at projection time in the graph projector (`build_graph_projector`) using new settings (`UME_POLICY_GRAPH_MAX_SNAPSHOT_NODES`, `UME_POLICY_GRAPH_NEIGHBORHOOD_DEPTH`, `UME_POLICY_GRAPH_MAX_NEIGHBORHOOD_NODES`). 
- Added documentation about the OPA/Rego input shape and the graph-size/neighborhood limits to `docs/ARCHITECTURE_OVERVIEW.md` and `docs/CONFIG_TEMPLATES.md`. 
- Added and updated tests to assert: plugins receive structured `policy_input`, OPA client payload shape, and that policy audit events include `graph_view_mode`/`graph_view_nodes` metadata.

### Testing

- Ran linter with `ruff` on modified files: `src/ume/policy/pipeline.py`, `src/ume/policy/graph_view.py`, `src/ume/plugins/alignment/*.py`, `src/ume/services/mutate.py`, and updated tests; linter passed. 
- Executed focused unit tests: `pytest -q tests/test_policy_pipeline_ordering.py tests/test_opa_integration.py tests/test_audit_logging.py::test_policy_audit_contains_graph_view_details`, which passed (8 tests, 0 failures). 
- A broader run of `pytest -q tests/test_policy_pipeline_ordering.py tests/test_opa_integration.py tests/test_audit_logging.py` initially surfaced unrelated environment/test harness issues (HTTP mocking/backends) that were addressed by making tests self-contained; targeted test suite validations now succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bbec822c8326bcd0f4df1ed9b5ec)