### PR TITLE
Unify v3 external producer contract and move transport normalization to adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The current system consists of the following main components:
 
 ### Event Schema
 
-The events exchanged in UME follow a canonical schema. Each event contains a minimal
+The events exchanged in UME follow a single flat external producer contract. Each event contains a minimal
 set of common fields and any number of type‑specific attributes.
 
 **Example Event:**
@@ -152,9 +152,8 @@ set of common fields and any number of type‑specific attributes.
 | `sourceService` | Name of the service that emitted the event. |
 | `payload` | Event‑specific attributes. |
 
-`parse_event()` accepts both `eventType` (preferred) and legacy `event_type`
-as the event type key. Timestamps are accepted as Unix epoch integers or
-ISO&nbsp;8601 strings (including `Z` suffix) and are normalized internally to an
+Ingress adapters convert the external contract into UME's internal canonical envelope (`metadata` + `graph` + `payload`) before parsing.
+Timestamps are accepted as Unix epoch integers or ISO&nbsp;8601 strings (including `Z` suffix) and are normalized internally to an
 epoch integer on the parsed `Event`.
 
 All official event types such as `CREATE_NODE` or `CREATE_EDGE` have
@@ -196,7 +195,7 @@ event-type-specific checks:
 
 Compatibility note:
 
-* Required for all events: `eventType` (or alias `event_type`) and `timestamp`.
+* Required for all external producer events: `eventType` and `timestamp`.
 * Optional for all events: `eventId`, `correlationId`, `subjectEntity`,
   `sourceService`.
 * Edge-family events (`CREATE_EDGE`, `DELETE_EDGE`, `CREATE_ONTOLOGY_RELATION`,

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -294,7 +294,7 @@ Validate and apply an event to the graph. This endpoint is also available as
 
 **Body Parameters**
 
-- `event_type` – the name of the event, e.g. `CREATE_NODE`
+- `eventType` – the name of the event, e.g. `CREATE_NODE`
 - `timestamp` – integer timestamp for the event
 - `node_id` – ID of the acting node when applicable
 - `target_node_id` – ID of the target node when applicable
@@ -309,7 +309,7 @@ Example request:
 curl -X POST http://localhost:8000/events \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -d '{"event_type":"CREATE_NODE","timestamp":1,"node_id":"n1","payload":{"node_id":"n1"}}'
+  -d '{"eventType":"CREATE_NODE","timestamp":1,"eventId":"evt-1","sourceService":"api-client","node_id":"n1","payload":{"node_id":"n1"}}'
 ```
 
 ### POST `/events/batch`
@@ -322,7 +322,7 @@ Example request:
 curl -X POST http://localhost:8000/events/batch \
   -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
-  -d '[{"event_type":"CREATE_NODE","timestamp":1,"node_id":"n1","payload":{"node_id":"n1"}}]'
+  -d '[{"eventType":"CREATE_NODE","timestamp":1,"eventId":"evt-1","sourceService":"api-client","node_id":"n1","payload":{"node_id":"n1"}}]'
 ```
 
 

--- a/src/ume/events/adapters/cli.py
+++ b/src/ume/events/adapters/cli.py
@@ -5,9 +5,11 @@ from typing import Any, Mapping
 
 
 def adapt_cli_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    normalized = dict(deepcopy(payload))
+    normalized = dict(deepcopy(payload.get("event", payload)))
     if "nodeId" in normalized and "node_id" not in normalized:
         normalized["node_id"] = normalized["nodeId"]
     if "targetNodeId" in normalized and "target_node_id" not in normalized:
         normalized["target_node_id"] = normalized["targetNodeId"]
+    if "schemaVersion" in payload and "schemaVersion" not in normalized:
+        normalized["schemaVersion"] = payload["schemaVersion"]
     return normalized

--- a/src/ume/events/adapters/grpc.py
+++ b/src/ume/events/adapters/grpc.py
@@ -5,9 +5,11 @@ from typing import Any, Mapping
 
 
 def adapt_grpc_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    normalized = dict(deepcopy(payload))
+    normalized = dict(deepcopy(payload.get("event", payload)))
     if "sourceService" in normalized and "source" not in normalized:
         normalized["source"] = normalized["sourceService"]
     if "schemaVersion" in normalized and "schema_version" not in normalized:
         normalized["schema_version"] = normalized["schemaVersion"]
+    if "schema_version" in payload and "schema_version" not in normalized:
+        normalized["schema_version"] = payload["schema_version"]
     return normalized

--- a/src/ume/events/adapters/kafka.py
+++ b/src/ume/events/adapters/kafka.py
@@ -17,11 +17,13 @@ except Exception:  # pragma: no cover - optional integration dependency
 
 
 def adapt_kafka_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    normalized = dict(deepcopy(payload))
+    normalized = dict(deepcopy(payload.get("event", payload)))
     if "nodeId" in normalized and "node_id" not in normalized:
         normalized["node_id"] = normalized["nodeId"]
     if "targetNodeId" in normalized and "target_node_id" not in normalized:
         normalized["target_node_id"] = normalized["targetNodeId"]
+    if "schemaVersion" in payload and "schemaVersion" not in normalized:
+        normalized["schemaVersion"] = payload["schemaVersion"]
     return normalized
 
 

--- a/src/ume/events/contract.py
+++ b/src/ume/events/contract.py
@@ -8,16 +8,20 @@ from typing import Any, Dict, Mapping
 _CAMEL_TO_SNAKE = {
     "eventId": "event_id",
     "eventType": "event_type",
-    "nodeId": "node_id",
-    "targetNodeId": "target_node_id",
     "schemaVersion": "schema_version",
     "correlationId": "correlation_id",
     "sourceService": "source",
     "subjectEntity": "subject_entity",
 }
 
-_SNAKE_TO_CAMEL = {v: k for k, v in _CAMEL_TO_SNAKE.items()}
-_SNAKE_TO_CAMEL["source"] = "sourceService"
+_SNAKE_TO_CAMEL = {
+    "event_id": "eventId",
+    "event_type": "eventType",
+    "schema_version": "schemaVersion",
+    "correlation_id": "correlationId",
+    "subject_entity": "subjectEntity",
+    "source": "sourceService",
+}
 
 
 @dataclass(frozen=True)
@@ -104,15 +108,42 @@ def _to_snake_keys(data: Mapping[str, Any]) -> Dict[str, Any]:
     return out
 
 
-def canonicalize_event(data: Mapping[str, Any]) -> Dict[str, Any]:
-    """Normalize any accepted transport shape into the canonical envelope dict."""
+def _to_external_contract(data: Mapping[str, Any]) -> Dict[str, Any]:
+    """Normalize adapter output to the single external producer contract."""
 
-    snake_data = _to_snake_keys(data)
-    event_data = snake_data.get("event") if isinstance(snake_data.get("event"), Mapping) else snake_data
+    if "event" in data:
+        raise ValueError("event envelope contract is not accepted; send flat event fields")
+
+    normalized = _to_snake_keys(data)
+    if "source" in normalized and "source_service" not in normalized:
+        normalized["source_service"] = normalized["source"]
+
+    external: Dict[str, Any] = {
+        "eventId": normalized.get("event_id"),
+        "eventType": normalized.get("event_type"),
+        "timestamp": normalized.get("timestamp"),
+        "payload": normalized.get("payload", {}),
+        "sourceService": normalized.get("source_service"),
+        "schemaVersion": normalized.get("schema_version"),
+        "node_id": normalized.get("node_id"),
+        "target_node_id": normalized.get("target_node_id"),
+        "label": normalized.get("label"),
+        "correlationId": normalized.get("correlation_id"),
+        "subjectEntity": normalized.get("subject_entity"),
+    }
+    return {k: v for k, v in external.items() if v is not None}
+
+
+def canonicalize_event(data: Mapping[str, Any]) -> Dict[str, Any]:
+    """Normalize flat external producer event into the canonical envelope dict."""
+
+    external_data = _to_external_contract(data)
+    snake_data = _to_snake_keys(external_data)
 
     resolved = {
-        **event_data,
-        "schema_version": snake_data.get("schema_version") or event_data.get("schema_version"),
+        **snake_data,
+        "source": snake_data.get("source_service") or snake_data.get("source"),
+        "schema_version": snake_data.get("schema_version"),
     }
     return _envelope_from_data(resolved).as_dict()
 

--- a/src/ume/producer_demo.py
+++ b/src/ume/producer_demo.py
@@ -13,9 +13,8 @@ from ume.config import settings
 from ume.logging_utils import configure_logging
 import time
 from confluent_kafka import Producer, KafkaException, Message
-from ume import Event, EventType
+from ume import EventType
 from ume.schema_utils import validate_event_dict
-from ume.events.contract import canonicalize_event, canonical_to_camel_dict
 from jsonschema import ValidationError
 
 configure_logging()
@@ -50,36 +49,23 @@ def main() -> None:
     conf.update(ssl_config())
     producer = Producer(conf)
 
-    # Construct an Event instance
+    # Construct a flat v3 external producer contract payload.
     demo_node_id = "demo_node_1"
-    event_payload_data = {
+    data_dict = {
+        "eventType": EventType.CREATE_NODE.value,
+        "timestamp": int(time.time()),
+        "eventId": "demo-create-node-1",
+        "schemaVersion": "3.0.0",
+        "sourceService": "producer_demo",
         "node_id": demo_node_id,
-        "attributes": {
-            "message": "Hello from producer_demo with Event class!",
-            "source": "producer_demo",
+        "payload": {
+            "node_id": demo_node_id,
+            "attributes": {
+                "message": "Hello from producer_demo with Event class!",
+                "source": "producer_demo",
+            },
         },
     }
-    event_to_send = Event(
-        event_type=EventType.CREATE_NODE.value,
-        timestamp=int(time.time()),
-        payload=event_payload_data,
-        source="producer_demo",  # Add source
-        node_id=demo_node_id,
-    )
-
-    # Convert Event object to dict for JSON serialization
-    data_dict = canonical_to_camel_dict(
-        canonicalize_event(
-            {
-                "event_id": event_to_send.event_id,
-                "event_type": event_to_send.event_type,
-                "timestamp": event_to_send.timestamp,
-                "payload": event_to_send.payload,
-                "source": event_to_send.source,
-                "node_id": event_to_send.node_id,
-            }
-        )
-    )
 
     try:
         validate_event_dict(data_dict)
@@ -89,7 +75,7 @@ def main() -> None:
 
     data = json.dumps(data_dict).encode("utf-8")
 
-    logger.info(f"Producing event object to topic '{TOPIC}': {event_to_send}")
+    logger.info(f"Producing external contract payload to topic '{TOPIC}': {data_dict}")
     # Asynchronously produce a message, the delivery report callback will be triggered from poll()
     try:
         producer.produce(TOPIC, value=data, callback=delivery_report)

--- a/src/ume/schema_utils.py
+++ b/src/ume/schema_utils.py
@@ -54,10 +54,9 @@ def _load_schema(event_type: str, major: int) -> Dict[str, Any]:
 
 def validate_event_dict(event_data: Dict[str, Any]) -> None:
     """Validate transport event data after normalizing to canonical contract."""
-    schema_version = event_data.get("schema_version")
+    schema_version = event_data.get("schemaVersion") or event_data.get("schema_version")
     major = _major_from_schema_version(schema_version if isinstance(schema_version, str) else None)
-    if "event" in event_data:
-        validate(instance=event_data, schema=_load_envelope_schema(major))
+    validate(instance=event_data, schema=_load_envelope_schema(major))
     canonical = canonicalize_event(event_data)
     validate_canonical_event(canonical)
 
@@ -69,7 +68,7 @@ def validate_canonical_event(canonical: Mapping[str, Any]) -> None:
     schema_version = canonical["metadata"].get("schema_version")
     major = _major_from_schema_version(schema_version)
 
-    validate(instance=normalized, schema=_load_canonical_schema(major))
+    validate(instance=canonical, schema=_load_canonical_schema(major))
 
     event_type = normalized.get("eventType")
     if not isinstance(event_type, str):

--- a/src/ume/schemas/v3/canonical_event.schema.json
+++ b/src/ume/schemas/v3/canonical_event.schema.json
@@ -1,61 +1,61 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "UME Canonical Event",
+  "title": "UME v3 Internal Canonical Event",
   "type": "object",
+  "required": ["metadata", "graph", "payload"],
   "properties": {
-    "eventType": {
-      "type": "string",
-      "minLength": 1
-    },
-    "timestamp": {
-      "oneOf": [
-        {
-          "type": "string",
-          "format": "date-time"
-        },
-        {
-          "type": "integer"
-        }
-      ]
-    },
-    "eventId": {
-      "type": "string"
-    },
-    "correlationId": {
-      "type": "string"
-    },
-    "subjectEntity": {
+    "metadata": {
       "type": "object",
-      "required": [
-        "id",
-        "type"
-      ],
+      "required": ["event_type", "timestamp", "correlation_ids"],
       "properties": {
-        "id": {
-          "type": "string"
+        "event_id": {"type": ["string", "null"]},
+        "event_type": {"type": "string", "minLength": 1},
+        "timestamp": {
+          "oneOf": [
+            {"type": "string", "format": "date-time"},
+            {"type": "integer"}
+          ]
         },
-        "type": {
-          "type": "string"
+        "schema_version": {"type": ["string", "null"]},
+        "source": {"type": ["string", "null"]},
+        "correlation_ids": {
+          "type": "object",
+          "properties": {
+            "correlation_id": {"type": ["string", "null"]}
+          },
+          "required": ["correlation_id"],
+          "additionalProperties": false
+        },
+        "subject_entity": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": ["id", "type"],
+              "properties": {
+                "id": {"type": "string"},
+                "type": {"type": "string"}
+              },
+              "additionalProperties": false
+            },
+            {"type": "null"}
+          ]
         }
-      }
+      },
+      "additionalProperties": false
     },
-    "sourceService": {
-      "type": "string"
+    "graph": {
+      "type": "object",
+      "required": ["node_id", "target_node_id", "label"],
+      "properties": {
+        "node_id": {"type": ["string", "null"]},
+        "target_node_id": {"type": ["string", "null"]},
+        "label": {"type": ["string", "null"]}
+      },
+      "additionalProperties": false
     },
     "payload": {
       "type": "object"
-    },
-    "traceId": {
-      "type": "string"
-    },
-    "extensions": {
-      "type": "object"
     }
   },
-  "required": [
-    "eventType",
-    "timestamp",
-    "eventId",
-    "sourceService"
-  ]
+  "additionalProperties": false
 }

--- a/src/ume/schemas/v3/event_envelope.schema.json
+++ b/src/ume/schemas/v3/event_envelope.schema.json
@@ -1,17 +1,60 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "UME Event Envelope",
+  "title": "UME v3 External Producer Event",
   "type": "object",
+  "required": [
+    "eventType",
+    "timestamp"
+  ],
   "properties": {
-    "schema_version": {
+    "eventType": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "date-time"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "eventId": {
       "type": "string"
     },
-    "event": {
+    "schemaVersion": {
+      "type": "string"
+    },
+    "sourceService": {
+      "type": "string"
+    },
+    "correlationId": {
+      "type": "string"
+    },
+    "subjectEntity": {
+      "type": "object",
+      "required": ["id", "type"],
+      "properties": {
+        "id": {"type": "string"},
+        "type": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "node_id": {
+      "type": "string"
+    },
+    "target_node_id": {
+      "type": "string"
+    },
+    "label": {
+      "type": "string"
+    },
+    "payload": {
       "type": "object"
     }
   },
-  "required": [
-    "schema_version",
-    "event"
-  ]
+  "additionalProperties": false
 }

--- a/tests/test_event_contract_normalization.py
+++ b/tests/test_event_contract_normalization.py
@@ -1,58 +1,44 @@
-from ume.events.contract import canonicalize_event
+from ume.events.contract import canonical_to_camel_dict, canonicalize_event
+import pytest
 
 
-def test_legacy_shapes_normalize_to_same_canonical_form() -> None:
-    expected = {
-        "metadata": {
-            "event_id": "e-1",
-            "event_type": "CREATE_NODE",
-            "timestamp": 1,
-            "schema_version": "1.0.0",
-            "source": "demo",
-            "correlation_ids": {"correlation_id": "c-1"},
-            "subject_entity": {"id": "u1", "type": "user"},
-        },
-        "graph": {"node_id": "n1", "target_node_id": None, "label": None},
+def test_external_contract_round_trip_preserves_fields() -> None:
+    external = {
+        "eventId": "e-1",
+        "eventType": "CREATE_NODE",
+        "timestamp": 1,
+        "schemaVersion": "3.0.0",
+        "sourceService": "demo",
+        "correlationId": "c-1",
+        "subjectEntity": {"id": "u1", "type": "user"},
+        "node_id": "n1",
         "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
     }
 
-    legacy_shapes = [
-        {
-            "eventId": "e-1",
-            "eventType": "CREATE_NODE",
-            "timestamp": 1,
-            "schema_version": "1.0.0",
-            "sourceService": "demo",
-            "correlationId": "c-1",
-            "subjectEntity": {"id": "u1", "type": "user"},
-            "node_id": "n1",
-            "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
-        },
-        {
-            "event_id": "e-1",
-            "event_type": "CREATE_NODE",
-            "timestamp": 1,
-            "schema_version": "1.0.0",
-            "source": "demo",
-            "correlation_id": "c-1",
-            "subject_entity": {"id": "u1", "type": "user"},
-            "node_id": "n1",
-            "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
-        },
-        {
-            "schemaVersion": "1.0.0",
-            "event": {
-                "eventId": "e-1",
-                "eventType": "CREATE_NODE",
-                "timestamp": 1,
-                "sourceService": "demo",
-                "correlationId": "c-1",
-                "subjectEntity": {"id": "u1", "type": "user"},
-                "nodeId": "n1",
-                "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
-            },
-        },
-    ]
+    canonical = canonicalize_event(external)
+    assert canonical_to_camel_dict(canonical) == external
 
-    for shape in legacy_shapes:
-        assert canonicalize_event(shape) == expected
+
+def test_external_contract_round_trip_edge_event() -> None:
+    external = {
+        "eventType": "CREATE_EDGE",
+        "timestamp": "2024-01-01T00:00:00Z",
+        "eventId": "edge-1",
+        "sourceService": "demo",
+        "node_id": "a",
+        "target_node_id": "b",
+        "label": "LINKS_TO",
+    }
+
+    canonical = canonicalize_event(external)
+    assert canonical_to_camel_dict(canonical) == {**external, "payload": {}}
+
+
+def test_event_envelope_is_rejected() -> None:
+    with pytest.raises(ValueError, match="event envelope contract"):
+        canonicalize_event(
+            {
+                "schemaVersion": "3.0.0",
+                "event": {"eventType": "CREATE_NODE", "timestamp": 1},
+            }
+        )

--- a/tests/test_producer_demo.py
+++ b/tests/test_producer_demo.py
@@ -45,5 +45,5 @@ def test_producer_demo_emits_schema_valid_create_node(monkeypatch):
 
     event = json.loads(raw.decode("utf-8"))
     assert event["eventType"] == "CREATE_NODE"
-    assert event["nodeId"] == "demo_node_1"
+    assert event["node_id"] == "demo_node_1"
     assert event["payload"]["node_id"] == "demo_node_1"


### PR DESCRIPTION
### Motivation

- Consolidate event ingestion around one external v3 producer contract (flat event object) and keep a single internal canonical envelope shape for the core pipeline.
- Prevent mixed/ambiguous contract handling by making boundary adapters responsible for transport-specific conversions so the core always receives one canonical shape.

### Description

- Introduced a flat v3 external producer contract and canonical internal envelope schemas at `src/ume/schemas/v3/event_envelope.schema.json` and `src/ume/schemas/v3/canonical_event.schema.json` respectively.
- Tightened `canonicalize_event()` in `src/ume/events/contract.py` to accept only the flat external contract (and explicitly reject legacy `{"event": ...}` envelope forms) and to produce the internal canonical envelope shape.
- Moved/expanded transport normalization into ingress adapters by updating `src/ume/events/adapters/cli.py`, `src/ume/events/adapters/kafka.py`, and `src/ume/events/adapters/grpc.py` so they flatten legacy wrappers and normalize keys before calling canonicalization.
- Updated schema validation in `src/ume/schema_utils.py` to validate the flat external envelope first, then validate the derived internal canonical envelope; updated `src/ume/producer_demo.py` to emit the v3 external contract directly and adjusted demo tests accordingly.
- Added/updated tests in `tests/test_event_contract_normalization.py` to prove `external -> canonical -> external` round-trip invariants and to assert explicit rejection of envelope-wrapped payloads, and adjusted `tests/test_producer_demo.py` expectations.
- Refreshed README and API docs to consistently describe the single external contract and the adapter→canonical pipeline.

### Testing

- Ran `pytest -q tests/test_event_contract_normalization.py tests/test_producer_demo.py tests/test_consumer_demo.py` and all tests passed.
- Ran lint checks with `ruff` on the modified files and they passed.
- Additional local iterative test runs were used during development to fix issues and arrive at the final green state reported above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9bdf969f88326a6df1984d8cc77a9)