### PR TITLE
Add projection worker, switch compose to it, and add compose smoke check

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,6 +42,7 @@ services:
         condition: service_healthy
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "redpanda:29092"
+      UME_DB_PATH: "/data/ume_graph.db"
     healthcheck:
       test: ["CMD-SHELL", "pgrep -f privacy_agent.py || exit 1"]
       interval: 10s
@@ -110,7 +111,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.api
-    command: poetry run python src/ume/consumer_demo.py
+    command: poetry run python -m ume.services.projection_worker
     depends_on:
       redpanda:
         condition: service_healthy
@@ -118,11 +119,33 @@ services:
       - ../.env
     environment:
       KAFKA_BOOTSTRAP_SERVERS: "redpanda:29092"
+      UME_DB_PATH: "/data/ume_graph.db"
+    volumes:
+      - ume-db:/data
     healthcheck:
-      test: ["CMD-SHELL", "pgrep -f consumer_demo.py || exit 1"]
+      test: ["CMD-SHELL", "pgrep -f ume.services.projection_worker || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+
+  graph-smoke-check:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.api
+    command: poetry run python examples/compose_projection_smoke_check.py
+    profiles: ["smoke"]
+    depends_on:
+      redpanda:
+        condition: service_healthy
+      graph-consumer:
+        condition: service_healthy
+    env_file:
+      - ../.env
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: "redpanda:29092"
+      UME_DB_PATH: "/data/ume_graph.db"
+    volumes:
+      - ume-db:/data
 
   prometheus:
     image: prom/prometheus

--- a/examples/compose_projection_smoke_check.py
+++ b/examples/compose_projection_smoke_check.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Compose smoke check for projection worker graph mutations."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from confluent_kafka import Producer
+
+from ume.config import settings
+from ume.resources import create_graph
+from ume.utils import ssl_config
+
+SMOKE_NODE_ID = "compose-smoke-node"
+
+
+def _produce_smoke_event() -> None:
+    conf = {"bootstrap.servers": settings.KAFKA_BOOTSTRAP_SERVERS}
+    conf.update(ssl_config())
+    producer = Producer(conf)
+    event = {
+        "eventType": "CREATE_NODE",
+        "eventId": "compose-smoke-event-1",
+        "timestamp": int(time.time()),
+        "nodeId": SMOKE_NODE_ID,
+        "payload": {"type": "SmokeCheck", "source": "compose"},
+    }
+    producer.produce(settings.KAFKA_CLEAN_EVENTS_TOPIC, json.dumps(event).encode("utf-8"))
+    producer.flush()
+
+
+def _wait_for_projection(timeout_s: float = 20.0) -> dict | None:
+    graph = create_graph()
+    try:
+        deadline = time.time() + timeout_s
+        while time.time() < deadline:
+            node = graph.get_node(SMOKE_NODE_ID)
+            if node is not None:
+                return node
+            time.sleep(0.5)
+    finally:
+        close = getattr(graph, "close", None)
+        if callable(close):
+            close()
+    return None
+
+
+def main() -> int:
+    _produce_smoke_event()
+    node = _wait_for_projection()
+    if node is None:
+        raise SystemExit("compose smoke check failed: projection side effect not observed")
+    print(f"compose smoke check passed: projected node {SMOKE_NODE_ID} -> {node}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ume/services/projection_worker.py
+++ b/src/ume/services/projection_worker.py
@@ -1,0 +1,115 @@
+"""Dedicated worker for projecting clean events into the graph."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from confluent_kafka import Consumer, KafkaError, KafkaException
+
+from ..config import settings
+from ..events.types import EventType
+from ..graph_adapter import IGraphAdapter
+from ..logging_utils import configure_logging
+from ..pipeline.core import EventPipelineOrchestrator, PipelineOutcome
+from ..resources import create_graph
+from ..utils import ssl_config
+from .event_processor import EventProcessorService
+from .mutate import build_graph_projector
+
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
+BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
+TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
+GROUP_ID = settings.KAFKA_GROUP_ID
+VALID_EVENT_TYPES = {event_type.value for event_type in EventType}
+
+
+def run_projection_worker(
+    graph: IGraphAdapter,
+    *,
+    group_id: str | None = None,
+    consumer: Consumer | None = None,
+    orchestrator: EventPipelineOrchestrator | None = None,
+) -> None:
+    """Consume clean events and project graph mutations using the orchestrator pipeline."""
+
+    gid = group_id or GROUP_ID
+    owns_consumer = False
+    if consumer is None:
+        conf = {
+            "bootstrap.servers": BOOTSTRAP_SERVERS,
+            "group.id": gid,
+            "auto.offset.reset": "earliest",
+        }
+        conf.update(ssl_config())
+        try:
+            consumer = Consumer(conf)
+            consumer.subscribe([TOPIC])
+        except KafkaException as exc:  # pragma: no cover - network errors
+            logger.error("Failed to start projection worker: %s", exc)
+            return
+        owns_consumer = True
+
+    processor = EventProcessorService(orchestrator=orchestrator)
+    projector = build_graph_projector(graph, classify=False)
+
+    logger.info("Projection worker started with group_id %s", gid)
+    try:
+        while True:
+            try:
+                msg = consumer.poll(1.0)
+            except KafkaException as exc:  # pragma: no cover - network errors
+                logger.error("Poll failed: %s", exc)
+                continue
+            if msg is None:
+                continue
+            if msg.error():
+                if msg.error().code() != KafkaError._PARTITION_EOF:
+                    logger.error("Kafka error: %s", msg.error())
+                continue
+
+            try:
+                payload = json.loads(msg.value().decode("utf-8"))
+            except (ValueError, json.JSONDecodeError) as exc:
+                logger.error("Failed to parse Kafka payload: %s", exc)
+                continue
+
+            envelope = processor.process_payload(
+                payload,
+                source="projection_worker",
+                adapter="kafka",
+                raw_payload=msg.value(),
+                projector=projector,
+            )
+            if envelope.event and envelope.event.event_type not in VALID_EVENT_TYPES:
+                envelope.outcome = PipelineOutcome.REJECTED
+                envelope.stage = "project"
+                envelope.reason = f"unknown_event_type:{envelope.event.event_type}"
+
+            if envelope.outcome in {PipelineOutcome.REJECTED, PipelineOutcome.QUARANTINED}:
+                logger.warning(
+                    "Event rejected at %s stage [%s]: %s",
+                    envelope.stage,
+                    envelope.details.get("error_category", "processing_failure"),
+                    envelope.reason,
+                )
+                continue
+    except KeyboardInterrupt:  # pragma: no cover - manual interrupt
+        logger.info("Projection worker shutting down")
+    finally:
+        if owns_consumer:
+            consumer.close()
+
+
+def main() -> None:
+    """Bootstrap runtime resources and run the projection worker."""
+
+    graph = create_graph()
+    run_projection_worker(graph)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/tests/compose/test_projection_smoke_compose.py
+++ b/tests/compose/test_projection_smoke_compose.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_compose_graph_consumer_uses_projection_worker() -> None:
+    compose_text = Path("docker/docker-compose.yml").read_text()
+    assert "command: poetry run python -m ume.services.projection_worker" in compose_text
+    assert "consumer_demo.py" not in compose_text
+
+
+def test_compose_includes_graph_smoke_check() -> None:
+    compose_text = Path("docker/docker-compose.yml").read_text()
+    assert "graph-smoke-check:" in compose_text
+    assert "examples/compose_projection_smoke_check.py" in compose_text

--- a/tests/test_projection_worker.py
+++ b/tests/test_projection_worker.py
@@ -1,0 +1,50 @@
+import json
+
+from ume import MockGraph
+from ume.services import projection_worker
+
+
+class DummyMessage:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+
+    def value(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+    def error(self):
+        return None
+
+
+class DummyConsumer:
+    def __init__(self, payloads: list[dict]) -> None:
+        self._messages = [DummyMessage(payload) for payload in payloads]
+        self._index = 0
+
+    def poll(self, timeout: float = 1.0):
+        if self._index >= len(self._messages):
+            raise KeyboardInterrupt
+        msg = self._messages[self._index]
+        self._index += 1
+        return msg
+
+    def close(self) -> None:
+        return None
+
+
+def test_projection_worker_consumes_clean_events_and_mutates_graph() -> None:
+    consumer = DummyConsumer(
+        [
+            {
+                "eventType": "CREATE_NODE",
+                "eventId": "evt-1",
+                "timestamp": 1,
+                "nodeId": "n1",
+                "payload": {"node_id": "n1", "attributes": {"type": "User"}},
+            }
+        ]
+    )
+
+    graph = MockGraph()
+    projection_worker.run_projection_worker(graph, consumer=consumer)
+
+    assert graph.get_node("n1") == {"type": "User"}


### PR DESCRIPTION
### Motivation
- Provide a production-ready entrypoint that projects sanitized (clean) events into the graph using the orchestrator pipeline instead of using a demo consumer script in production compose. 
- Add a lightweight smoke verification that can run in compose to assert that producing a known clean event produces the expected graph mutation.

### Description
- Added `src/ume/services/projection_worker.py`, a dedicated projection worker that boots runtime/logging, consumes `KAFKA_CLEAN_EVENTS_TOPIC`, runs events through `EventProcessorService` (orchestrator-backed) and applies graph mutations via a projector, with a `main()` bootstrap path.
- Updated `docker/docker-compose.yml` so the `graph-consumer` service runs the new worker (`python -m ume.services.projection_worker`), adds `UME_DB_PATH` and a shared `ume-db` volume for graph persistence, and updates the healthcheck to look for the worker instead of `consumer_demo.py`.
- Added an optional compose smoke service `graph-smoke-check` (profile `smoke`) that runs `examples/compose_projection_smoke_check.py` against the same DB volume to verify side effects after producing a known `CREATE_NODE` event.
- Created `examples/compose_projection_smoke_check.py`, which produces a deterministic clean event and polls the graph for the projected node; it exits non-zero when the expected side effect is not observed.
- Added tests: `tests/test_projection_worker.py` to validate worker behavior with a dummy consumer and `tests/compose/test_projection_smoke_compose.py` to assert compose wiring (worker command and absence of demo reference).
- Kept demo scripts available in the repository (under `src/ume/*_demo.py`), but removed production compose references to demo consumer scripts per the requirement.

### Testing
- Ran linter: `poetry run ruff check src/ume/services/projection_worker.py tests/test_projection_worker.py tests/compose/test_projection_smoke_compose.py` and it passed (`All checks passed!`).
- Ran unit/compose tests: `poetry run pytest tests/test_projection_worker.py tests/compose/test_projection_smoke_compose.py tests/compose/test_monitoring_services.py` and all collected tests passed (`4 passed, 1 warning`).
- Verified local test output shows the worker applied the mutation in the dummy consumer scenario and compose file contains the new `graph-smoke-check` service and worker command.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab04384aa88326b626892b8ce3404d)