### PR TITLE
Add durable vector outbox with dispatcher, retries, and deterministic replay

### DIFF
--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -51,6 +51,7 @@ from .retention import (
 from .rbac_adapter import AccessDeniedError
 from .graph_adapter import IGraphAdapter  # noqa: F401
 from .vector_store import VectorStoreListener
+from .vector_outbox import VectorOutboxDispatcher
 from .factories import create_vector_store, graph_capability_negotiation, vector_capability_negotiation
 from ._internal.listeners import register_listener, unregister_listener
 
@@ -94,6 +95,7 @@ TOKEN_CLEANUP_INTERVAL = 60.0
 _token_cleanup_task: asyncio.Task | None = None
 _ledger_compaction_stop: Callable[[], None] | None = None
 _vector_listener: VectorStoreListener | None = None
+_vector_outbox_dispatcher: VectorOutboxDispatcher | None = None
 
 
 logger = logging.getLogger(__name__)
@@ -227,19 +229,26 @@ async def _start_token_cleanup() -> None:
 @app.on_event("startup")
 def _register_vector_listener() -> None:
     """Register VectorStoreListener for automatic indexing."""
-    global _vector_listener
+    global _vector_listener, _vector_outbox_dispatcher
     store = getattr(app.state, "vector_store", None)
     if store is None:
         return
     listener = VectorStoreListener(store)
     register_listener(listener)
     _vector_listener = listener
+    from .event_ledger import event_ledger
+    dispatcher = VectorOutboxDispatcher(event_ledger, store)
+    dispatcher.start()
+    _vector_outbox_dispatcher = dispatcher
 
 
 @app.on_event("shutdown")
 def _unregister_vector_listener() -> None:
     """Remove the VectorStoreListener if it was registered."""
-    global _vector_listener
+    global _vector_listener, _vector_outbox_dispatcher
+    if _vector_outbox_dispatcher is not None:
+        _vector_outbox_dispatcher.stop()
+        _vector_outbox_dispatcher = None
     if _vector_listener is not None:
         unregister_listener(_vector_listener)
         _vector_listener = None

--- a/src/ume/event_ledger.py
+++ b/src/ume/event_ledger.py
@@ -4,11 +4,13 @@ import json
 import sqlite3
 import os
 import tempfile
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Tuple, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - typing import
     from cryptography.fernet import Fernet
+    from .vector_outbox import VectorOutboxRecord
 else:  # pragma: no cover - cryptography optional
     try:
         from cryptography.fernet import Fernet  # type: ignore
@@ -64,6 +66,27 @@ class EventLedger:
                     last_offset INTEGER
                 )
                 """
+            )
+            self.conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS vector_outbox (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ledger_offset INTEGER,
+                    event_id TEXT NOT NULL,
+                    node_id TEXT NOT NULL,
+                    embedding_json TEXT NOT NULL,
+                    idempotency_key TEXT NOT NULL UNIQUE,
+                    state TEXT NOT NULL DEFAULT 'pending',
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    created_at REAL NOT NULL,
+                    available_at REAL NOT NULL,
+                    delivered_at REAL,
+                    last_error TEXT
+                )
+                """
+            )
+            self.conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_vector_outbox_pending ON vector_outbox (state, available_at, id)"
             )
 
     def append(self, offset: int, event: Dict[str, Any]) -> None:
@@ -132,6 +155,142 @@ class EventLedger:
         """Delete events with offsets lower than ``max_offset``."""
         with self.conn:
             self.conn.execute("DELETE FROM events WHERE offset < ?", (max_offset,))
+
+    def enqueue_vector_outbox(
+        self,
+        *,
+        ledger_offset: int | None,
+        event_id: str,
+        node_id: str,
+        embedding: list[float],
+        idempotency_key: str,
+        created_at: float | None = None,
+    ) -> None:
+        now = created_at if created_at is not None else time.time()
+        with self.conn:
+            self.conn.execute(
+                """
+                INSERT INTO vector_outbox(
+                    ledger_offset, event_id, node_id, embedding_json, idempotency_key,
+                    state, attempts, created_at, available_at
+                ) VALUES(?, ?, ?, ?, ?, 'pending', 0, ?, ?)
+                ON CONFLICT(idempotency_key) DO NOTHING
+                """,
+                (ledger_offset, event_id, node_id, json.dumps(embedding), idempotency_key, now, now),
+            )
+
+    def get_pending_vector_outbox(
+        self,
+        *,
+        limit: int,
+        now_ts: float | None = None,
+    ) -> list["VectorOutboxRecord"]:
+        from .vector_outbox import VectorOutboxRecord
+
+        now = now_ts if now_ts is not None else time.time()
+        cur = self.conn.execute(
+            """
+            SELECT id, ledger_offset, event_id, node_id, embedding_json, idempotency_key, attempts, available_at
+            FROM vector_outbox
+            WHERE state='pending' AND available_at <= ?
+            ORDER BY id
+            LIMIT ?
+            """,
+            (now, limit),
+        )
+        return [
+            VectorOutboxRecord(
+                id=int(row["id"]),
+                ledger_offset=int(row["ledger_offset"]) if row["ledger_offset"] is not None else None,
+                event_id=str(row["event_id"]),
+                node_id=str(row["node_id"]),
+                embedding=list(json.loads(row["embedding_json"])),
+                idempotency_key=str(row["idempotency_key"]),
+                attempts=int(row["attempts"]),
+                available_at=float(row["available_at"]),
+            )
+            for row in cur.fetchall()
+        ]
+
+    def mark_vector_outbox_delivered(self, record_id: int, *, delivered_at: float | None = None) -> None:
+        ts = delivered_at if delivered_at is not None else time.time()
+        with self.conn:
+            self.conn.execute(
+                "UPDATE vector_outbox SET state='delivered', delivered_at=?, last_error=NULL WHERE id=?",
+                (ts, record_id),
+            )
+
+    def fail_vector_outbox_delivery(self, *, record_id: int, error: str, now_ts: float | None = None) -> None:
+        now = now_ts if now_ts is not None else time.time()
+        with self.conn:
+            cur = self.conn.execute("SELECT attempts FROM vector_outbox WHERE id=?", (record_id,))
+            row = cur.fetchone()
+            if row is None:
+                return
+            attempts = int(row["attempts"]) + 1
+            backoff_seconds = float(min(60, 2 ** min(attempts, 6)))
+            available_at = now + backoff_seconds
+            self.conn.execute(
+                """
+                UPDATE vector_outbox
+                SET attempts=?, last_error=?, available_at=?, state='pending'
+                WHERE id=?
+                """,
+                (attempts, error[:1024], available_at, record_id),
+            )
+
+    def vector_outbox_pending_count(self, *, now_ts: float | None = None) -> int:
+        now = now_ts if now_ts is not None else time.time()
+        cur = self.conn.execute(
+            "SELECT COUNT(*) FROM vector_outbox WHERE state='pending' AND available_at <= ?",
+            (now,),
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+
+    def vector_outbox_max_lag_seconds(self, *, now_ts: float | None = None) -> float:
+        now = now_ts if now_ts is not None else time.time()
+        cur = self.conn.execute(
+            "SELECT MIN(created_at) FROM vector_outbox WHERE state='pending'"
+        )
+        row = cur.fetchone()
+        if row is None or row[0] is None:
+            return 0.0
+        return max(now - float(row[0]), 0.0)
+
+    def vector_outbox_created_at(self, record_id: int) -> float | None:
+        cur = self.conn.execute("SELECT created_at FROM vector_outbox WHERE id=?", (record_id,))
+        row = cur.fetchone()
+        if row is None or row[0] is None:
+            return None
+        return float(row[0])
+
+    def iter_vector_outbox_for_replay(self, *, end_offset: int | None = None) -> list["VectorOutboxRecord"]:
+        from .vector_outbox import VectorOutboxRecord
+
+        query = (
+            "SELECT id, ledger_offset, event_id, node_id, embedding_json, idempotency_key, attempts, available_at "
+            "FROM vector_outbox WHERE state='delivered'"
+        )
+        params: list[Any] = []
+        if end_offset is not None:
+            query += " AND ledger_offset IS NOT NULL AND ledger_offset <= ?"
+            params.append(end_offset)
+        query += " ORDER BY COALESCE(ledger_offset, 9223372036854775807), id"
+        cur = self.conn.execute(query, params)
+        return [
+            VectorOutboxRecord(
+                id=int(row["id"]),
+                ledger_offset=int(row["ledger_offset"]) if row["ledger_offset"] is not None else None,
+                event_id=str(row["event_id"]),
+                node_id=str(row["node_id"]),
+                embedding=list(json.loads(row["embedding_json"])),
+                idempotency_key=str(row["idempotency_key"]),
+                attempts=int(row["attempts"]),
+                available_at=float(row["available_at"]),
+            )
+            for row in cur.fetchall()
+        ]
 
     def close(self) -> None:
         self.conn.close()

--- a/src/ume/metrics.py
+++ b/src/ume/metrics.py
@@ -193,6 +193,28 @@ STALE_VECTOR_COUNT = Gauge(
     "Current number of vectors exceeding the freshness limit",
 )
 
+
+VECTOR_OUTBOX_PENDING = Gauge(
+    "ume_vector_outbox_pending",
+    "Number of vector outbox records ready for delivery",
+)
+VECTOR_OUTBOX_LAG_SECONDS = Gauge(
+    "ume_vector_outbox_lag_seconds",
+    "Age in seconds of the oldest pending vector outbox record",
+)
+VECTOR_OUTBOX_DELIVERED_TOTAL = Counter(
+    "ume_vector_outbox_delivered_total",
+    "Total number of vector outbox records delivered",
+)
+VECTOR_OUTBOX_DELIVERY_ERRORS_TOTAL = Counter(
+    "ume_vector_outbox_delivery_errors_total",
+    "Total number of vector outbox delivery errors",
+)
+VECTOR_OUTBOX_DELIVERY_LATENCY_SECONDS = Histogram(
+    "ume_vector_outbox_delivery_latency_seconds",
+    "Latency from outbox enqueue to successful delivery",
+)
+
 # Ingestion metrics
 INGEST_EVENTS_TOTAL = Counter(
     "ume_ingest_events_total",

--- a/src/ume/replay.py
+++ b/src/ume/replay.py
@@ -8,9 +8,11 @@ from .graph_adapter import IGraphAdapter
 from .policy.pipeline import PolicyContext, PolicyDecision, build_default_policy_pipeline
 from .processing_errors import ProcessingError
 from .metrics import PIPELINE_REPLAY_LAG_SECONDS
+from .vector_outbox import replay_vector_index_from_ledger_outbox
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
     from .event_ledger import EventLedger
+    from .vector_store import VectorBackend
 
 
 class ReplayMode(str, Enum):
@@ -143,3 +145,13 @@ def snapshot_from_event_ledger(
         replay_mode=replay_mode,
     )
     return graph.dump()
+
+
+def rebuild_vector_index_from_outbox(
+    ledger: "EventLedger",
+    store: "VectorBackend",
+    *,
+    end_offset: int | None = None,
+) -> int:
+    """Rebuild vector index deterministically from delivered outbox entries."""
+    return replay_vector_index_from_ledger_outbox(ledger, store, end_offset=end_offset)

--- a/src/ume/services/mutate.py
+++ b/src/ume/services/mutate.py
@@ -9,6 +9,7 @@ from enum import Enum
 from typing import Any, Callable
 
 from ..event import EventError
+from ..event_ledger import event_ledger
 from ..domains.classification import apply_classification
 from ..domains.extensions import DomainExtension, run_domain_extensions
 from ..events.ingress import IngressAdapter
@@ -22,6 +23,7 @@ from ..pipeline.core import (
 from ..policy.pipeline import PolicyDecision
 from ..policy.graph_view import build_graph_read_view
 from ..processing import DEFAULT_VERSION, apply_event_to_graph
+from ..vector_outbox import enqueue_vector_outbox_event
 
 
 class MutationErrorCategory(str, Enum):
@@ -170,6 +172,11 @@ def build_graph_projector(
         context.details.setdefault("schema_resolution_source", resolution.source)
         details = run_domain_extensions(context, active_extensions)
         apply_event_to_graph(event, graph, schema_version=effective_version)
+        enqueue_vector_outbox_event(
+            event_ledger,
+            event,
+            ledger_offset=None,
+        )
         return {**details, "schema_version": effective_version}
 
     return _project

--- a/src/ume/vector_outbox.py
+++ b/src/ume/vector_outbox.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+
+from .event import Event
+from .event_ledger import EventLedger
+from .metrics import (
+    VECTOR_OUTBOX_DELIVERY_ERRORS_TOTAL,
+    VECTOR_OUTBOX_DELIVERY_LATENCY_SECONDS,
+    VECTOR_OUTBOX_DELIVERED_TOTAL,
+    VECTOR_OUTBOX_LAG_SECONDS,
+    VECTOR_OUTBOX_PENDING,
+)
+from .vector_store import VectorBackend
+
+
+@dataclass(frozen=True)
+class VectorOutboxRecord:
+    id: int
+    ledger_offset: int | None
+    event_id: str
+    node_id: str
+    embedding: list[float]
+    idempotency_key: str
+    attempts: int
+    available_at: float
+
+
+def _extract_vector_write(event: Event) -> tuple[str, list[float]] | None:
+    if event.event_type not in {"CREATE_NODE", "UPDATE_NODE_ATTRIBUTES"}:
+        return None
+    payload = event.payload
+    node_id = event.node_id or payload.get("node_id")
+    attrs = payload.get("attributes")
+    if not isinstance(node_id, str) or not isinstance(attrs, dict):
+        return None
+    emb = attrs.get("embedding")
+    if not isinstance(emb, list):
+        return None
+    vector: list[float] = []
+    for val in emb:
+        if not isinstance(val, (float, int)):
+            return None
+        vector.append(float(val))
+    return node_id, vector
+
+
+class VectorOutboxDispatcher:
+    def __init__(
+        self,
+        ledger: EventLedger,
+        store: VectorBackend,
+        *,
+        poll_interval_seconds: float = 0.25,
+        max_batch_size: int = 100,
+    ) -> None:
+        self._ledger = ledger
+        self._store = store
+        self._poll_interval_seconds = poll_interval_seconds
+        self._max_batch_size = max_batch_size
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+    def _run_loop(self) -> None:
+        while not self._stop_event.is_set():
+            processed = self.process_available()
+            if processed == 0:
+                self._stop_event.wait(self._poll_interval_seconds)
+
+    def process_available(self) -> int:
+        now = time.time()
+        records = self._ledger.get_pending_vector_outbox(limit=self._max_batch_size, now_ts=now)
+        if not records:
+            self._refresh_metrics(now)
+            return 0
+        for record in records:
+            self._deliver(record, now)
+        self._refresh_metrics(time.time())
+        return len(records)
+
+    def _deliver(self, record: VectorOutboxRecord, now: float) -> None:
+        try:
+            self._store.add(record.node_id, record.embedding)
+        except Exception as exc:
+            self._ledger.fail_vector_outbox_delivery(
+                record_id=record.id,
+                error=str(exc),
+                now_ts=now,
+            )
+            VECTOR_OUTBOX_DELIVERY_ERRORS_TOTAL.inc()
+            return
+        self._ledger.mark_vector_outbox_delivered(record.id, delivered_at=now)
+        created = self._ledger.vector_outbox_created_at(record.id)
+        if created is not None:
+            VECTOR_OUTBOX_DELIVERY_LATENCY_SECONDS.observe(max(now - created, 0.0))
+        VECTOR_OUTBOX_DELIVERED_TOTAL.inc()
+
+    def _refresh_metrics(self, now: float) -> None:
+        pending = self._ledger.vector_outbox_pending_count(now_ts=now)
+        VECTOR_OUTBOX_PENDING.set(float(pending))
+        lag = self._ledger.vector_outbox_max_lag_seconds(now_ts=now)
+        VECTOR_OUTBOX_LAG_SECONDS.set(lag)
+
+
+def enqueue_vector_outbox_event(
+    ledger: EventLedger,
+    event: Event,
+    *,
+    ledger_offset: int | None,
+) -> bool:
+    extracted = _extract_vector_write(event)
+    if extracted is None:
+        return False
+    node_id, embedding = extracted
+    unique_key = f"{event.event_id}:{node_id}"
+    if not event.event_id:
+        unique_key = str(uuid.uuid4())
+    ledger.enqueue_vector_outbox(
+        ledger_offset=ledger_offset,
+        event_id=event.event_id,
+        node_id=node_id,
+        embedding=embedding,
+        idempotency_key=unique_key,
+    )
+    return True
+
+
+def replay_vector_index_from_ledger_outbox(
+    ledger: EventLedger,
+    store: VectorBackend,
+    *,
+    end_offset: int | None = None,
+) -> int:
+    """Deterministically rebuild vector index by reprocessing delivered outbox records."""
+    count = 0
+    for record in ledger.iter_vector_outbox_for_replay(end_offset=end_offset):
+        store.add(record.node_id, record.embedding)
+        count += 1
+    return count

--- a/tests/test_vector_outbox.py
+++ b/tests/test_vector_outbox.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import time
+
+from ume.event_ledger import EventLedger
+from ume.graph import MockGraph
+from ume.services import mutate
+from ume.event import Event
+from ume.vector_outbox import VectorOutboxDispatcher, replay_vector_index_from_ledger_outbox
+
+
+class _FlakyStore:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, list[float]]] = []
+        self._fail_once = True
+
+    def add(self, item_id: str, vector: list[float], *, persist: bool = False) -> None:
+        self.calls.append((item_id, list(vector)))
+        if self._fail_once:
+            self._fail_once = False
+            raise RuntimeError("inject-vector-write-failure")
+
+
+class _RecordingStore:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, list[float]]] = []
+
+    def add(self, item_id: str, vector: list[float], *, persist: bool = False) -> None:
+        self.calls.append((item_id, list(vector)))
+
+
+def test_outbox_record_created_after_successful_graph_mutation(monkeypatch, tmp_path) -> None:
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    graph = MockGraph()
+    monkeypatch.setattr(mutate, "event_ledger", ledger)
+
+    projector = mutate.build_graph_projector(graph, classify=False)
+    event = Event(
+        event_type="CREATE_NODE",
+        timestamp=1700000000,
+        payload={"node_id": "n1", "attributes": {"embedding": [0.1, 0.2], "name": "alpha"}},
+        event_id="evt-graph-1",
+        node_id="n1",
+        schema_version="1.0.0",
+    )
+
+    class _Ctx:
+        canonical_event = {"metadata": {"schema_version": "1.0.0"}}
+        effective_event = event
+        details: dict[str, object] = {}
+
+    projector(_Ctx())
+
+    pending = ledger.get_pending_vector_outbox(limit=10, now_ts=time.time())
+    assert len(pending) == 1
+    assert pending[0].node_id == "n1"
+    assert pending[0].embedding == [0.1, 0.2]
+    ledger.close()
+
+
+def test_outbox_retry_and_idempotency_with_failure_injection(tmp_path, monkeypatch) -> None:
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    ledger.enqueue_vector_outbox(
+        ledger_offset=10,
+        event_id="evt-1",
+        node_id="n1",
+        embedding=[1.0, 2.0],
+        idempotency_key="evt-1:n1",
+        created_at=100.0,
+    )
+    # duplicate key must not create a second record
+    ledger.enqueue_vector_outbox(
+        ledger_offset=10,
+        event_id="evt-1",
+        node_id="n1",
+        embedding=[1.0, 2.0],
+        idempotency_key="evt-1:n1",
+        created_at=100.0,
+    )
+
+    store = _FlakyStore()
+    dispatcher = VectorOutboxDispatcher(ledger, store)
+
+    monkeypatch.setattr("ume.vector_outbox.time.time", lambda: 101.0)
+    assert dispatcher.process_available() == 1
+
+    records = ledger.get_pending_vector_outbox(limit=10, now_ts=101.0)
+    assert records == []
+
+    monkeypatch.setattr("ume.vector_outbox.time.time", lambda: 200.0)
+    assert dispatcher.process_available() == 1
+
+    assert len(store.calls) == 2
+    replayable = ledger.iter_vector_outbox_for_replay()
+    assert len(replayable) == 1
+    assert replayable[0].attempts == 1
+    ledger.close()
+
+
+def test_replay_vector_index_from_ledger_outbox_is_deterministic(tmp_path) -> None:
+    ledger = EventLedger(str(tmp_path / "ledger.db"))
+    ledger.enqueue_vector_outbox(
+        ledger_offset=1,
+        event_id="evt-1",
+        node_id="n1",
+        embedding=[1.0, 0.0],
+        idempotency_key="evt-1:n1",
+        created_at=1.0,
+    )
+    ledger.enqueue_vector_outbox(
+        ledger_offset=2,
+        event_id="evt-2",
+        node_id="n2",
+        embedding=[0.0, 1.0],
+        idempotency_key="evt-2:n2",
+        created_at=2.0,
+    )
+    ledger.mark_vector_outbox_delivered(1, delivered_at=3.0)
+    ledger.mark_vector_outbox_delivered(2, delivered_at=4.0)
+
+    store = _RecordingStore()
+    count = replay_vector_index_from_ledger_outbox(ledger, store)
+
+    assert count == 2
+    assert store.calls == [("n1", [1.0, 0.0]), ("n2", [0.0, 1.0])]
+    ledger.close()


### PR DESCRIPTION
### Motivation

- Persist vector-write intent immediately after successful graph mutation so vector backends can be updated asynchronously and deterministically rebuilt later.
- Deliver vectors to backends with retry/backoff and idempotency to tolerate partial failures between graph and vector stores.
- Surface outbox backlog/lag/error/delivery metrics for observability and support deterministic replay from ledger + outbox.
- Provide failure-injection tests to validate partial graph/vector write scenarios and idempotency behavior.

### Description

- Added a durable `vector_outbox` table and helpers to the ledger with fields for `ledger_offset`, `event_id`, `node_id`, JSON-encoded embedding, unique `idempotency_key`, `state`, `attempts`, `created_at`, `available_at`, `delivered_at`, and `last_error`, plus indexes and helper methods (`enqueue_vector_outbox`, `get_pending_vector_outbox`, `mark_vector_outbox_delivered`, `fail_vector_outbox_delivery`, `vector_outbox_*` helpers, `iter_vector_outbox_for_replay`).
- Implemented `src/ume/vector_outbox.py` which extracts vector writes from events, enqueues outbox records, runs a background `VectorOutboxDispatcher` that batches/dispatches pending records to a `VectorBackend`, applies retries with exponential backoff and idempotency, and exposes `replay_vector_index_from_ledger_outbox` for deterministic rebuilds.
- Wired the mutation pipeline to enqueue outbox records after successful `apply_event_to_graph` by calling `enqueue_vector_outbox_event` from the graph projector so graph mutations record outbox intent atomically to the ledger.
- Started/stopped the outbox dispatcher during API lifecycle (`startup`/`shutdown`) using the configured vector store so delivery runs continuously in API processes, and added new metrics for pending, lag, delivery count, errors, and delivery latency.
- Exposed a replay helper `rebuild_vector_index_from_outbox` that replays delivered outbox records into a vector backend in deterministic order.
- Added `tests/test_vector_outbox.py` with failure-injection and replay tests covering outbox creation, retry/idempotency, and deterministic replay ordering.

### Testing

- Ran linter checks with `python -m ruff check src/ume/event_ledger.py src/ume/vector_outbox.py src/ume/services/mutate.py src/ume/replay.py src/ume/api.py tests/test_vector_outbox.py` and the checks passed.
- Executed the focused unit tests `pytest -q tests/test_vector_outbox.py` and they passed (`3 passed`).
- Ran `pytest -q tests/test_processing.py` which produced unrelated pre-existing failures in this environment (3 failing tests) that are not caused by the outbox change.
- Attempted `pytest -q tests/test_api_ledger.py` but collection failed in this runtime due to missing `fastapi` package, so full integration test run was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0da29f748326b85eac53ef7aa42b)