### PR TITLE
ci: stage coverage gates, add diff-cover, split suites, and publish quality rubric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,21 @@ jobs:
       - name: Run schema compatibility checks
         run: poetry run python scripts/check_schema_compatibility.py
 
-  unit-tests:
+  architecture-tests-required:
+    runs-on: ubuntu-latest
+    needs: [lint-and-install, schema-compatibility]
+    if: needs.lint-and-install.outputs.run == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-poetry
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: poetry install --with dev --extras vector --extras embedding
+      - name: Run architecture suite
+        run: poetry run pytest tests/architecture
+
+  unit-tests-required:
     runs-on: ubuntu-latest
     needs: [lint-and-install, schema-compatibility]
     if: needs.lint-and-install.outputs.run == 'true'
@@ -64,14 +78,11 @@ jobs:
       UME_AUDIT_SIGNING_KEY: test-key
       UME_ENCRYPTION_ENABLED: 'true'
       UME_ENCRYPTION_KEY: c2VjcmV0a2V5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIz
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python-poetry
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
       - name: Install dependencies
         run: poetry install --with dev --extras vector --extras embedding
       - name: Set up Node.js
@@ -82,10 +93,62 @@ jobs:
         run: |
           npm --prefix frontend install
           npm --prefix frontend test -- --config frontend/vitest.config.js
-      - name: Run unit tests with coverage
+      - name: Run unit tests with coverage report
         run: |
-          poetry run pytest --cov=ume --cov-report xml --cov-fail-under=30 -m "not integration"
+          poetry run pytest --cov=ume --cov-report xml -m "not integration"
           poetry run pytest tests/test_dossier_migration.py
+      - name: Coverage stage 1 (fail under 50%)
+        run: poetry run coverage report --fail-under=50
+      - name: Upload unit coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-coverage-xml
+          path: coverage.xml
+
+  changed-lines-coverage-required:
+    runs-on: ubuntu-latest
+    needs: [lint-and-install, unit-tests-required]
+    if: needs.lint-and-install.outputs.run == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-python-poetry
+        with:
+          python-version: '3.12'
+      - name: Install diff-cover
+        run: poetry run python -m pip install diff-cover
+      - name: Download unit coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-coverage-xml
+      - name: Enforce changed-lines coverage
+        run: poetry run diff-cover coverage.xml --compare-branch=origin/main --fail-under=85
+
+  unit-tests-optional:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs: [lint-and-install, unit-tests-required]
+    if: needs.lint-and-install.outputs.run == 'true'
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+        coverage-threshold: [65, 75]
+    env:
+      UME_AUDIT_SIGNING_KEY: test-key
+      UME_ENCRYPTION_ENABLED: 'true'
+      UME_ENCRYPTION_KEY: c2VjcmV0a2V5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIz
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-poetry
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: poetry install --with dev --extras vector --extras embedding
+      - name: Run optional unit suite
+        run: poetry run pytest --cov=ume --cov-report term -m "not integration"
+      - name: Coverage optional gate
+        run: poetry run coverage report --fail-under=${{ matrix.coverage-threshold }}
 
 
   replay-regression:
@@ -102,18 +165,15 @@ jobs:
       - name: Run replay regression suite
         run: poetry run pytest tests/test_replay_regression.py
 
-  integration-tests:
+  integration-tests-required:
     runs-on: ubuntu-latest
     needs: lint-and-install
     if: needs.lint-and-install.outputs.run == 'true'
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-python-poetry
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
       - name: Install dependencies
         run: poetry install --with dev --extras vector --extras embedding
       - name: Run integration tests
@@ -123,7 +183,7 @@ jobs:
 
   compose-smoke:
     runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests]
+    needs: [architecture-tests-required, unit-tests-required, changed-lines-coverage-required, integration-tests-required]
     steps:
       - uses: actions/checkout@v4
       - name: Start stack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,12 +84,37 @@ pre-commit run detect-secrets --files path/to/file
 
 ### Pull Requests
 
- - Ensure `pre-commit` hooks pass and that `pytest` succeeds before opening a PR. Unit tests must run with coverage reporting, verified with:
-   ```bash
-   pytest --cov=ume --cov-fail-under=30
-   ```
+ - Ensure `pre-commit` hooks pass and that `pytest` succeeds before opening a PR.
 - All PRs are reviewed by a maintainer and must pass CI (tests, Ruff lint, formatting checks, and mypy) before merging.
 - The CI workflow automatically skips these checks when a pull request only modifies documentation or code comments.
+
+### CI quality gates (required vs optional)
+
+The CI suite is split into explicit required and optional quality gates:
+
+- **Required gates (must pass to merge):**
+  - Lint/install bootstrap and schema-compatibility checks.
+  - Architecture suite (`tests/architecture`) on Python 3.12.
+  - Unit suite on Python 3.12 with staged total coverage gate at **50%**.
+  - Changed-lines coverage enforcement with `diff-cover` at **85%** against `origin/main`.
+  - Integration suite on Python 3.12.
+  - Docker compose smoke checks.
+- **Optional gates (informational, non-blocking):**
+  - Additional unit matrix runs on Python 3.10/3.11 with staged aspirational coverage gates at **65%** and **75%**.
+
+The staged thresholds are designed to ratchet quality progressively (`30 → 50 → 65 → 75`) while avoiding sudden contributor disruption.
+
+### Test depth rubric by feature risk
+
+Use this rubric to decide required test depth for a change:
+
+| Feature risk level | Typical examples | Required test depth |
+| --- | --- | --- |
+| **Low** | Refactors with no behavior change, minor wiring updates, safe defaults | Update/add focused unit tests; changed-lines coverage must stay ≥85% |
+| **Medium** | New domain logic, policy edge-cases, adapter behavior updates | Unit tests + architecture coverage where boundaries are touched; add at least one integration path if behavior crosses process or persistence boundaries |
+| **High** | Auth/authz changes, mutation/event pipeline changes, transport adapters, data migration/compatibility behavior | Comprehensive unit tests, architecture tests, and integration tests covering happy-path + failure modes + bypass/abuse cases; include replay/regression coverage where applicable |
+
+When unsure, classify the change at the next higher risk tier.
 
 ### Security checklist for new routes/events/adapters
 


### PR DESCRIPTION
### Motivation

- Make CI quality gates explicit and progressive to raise coverage without blocking contributors suddenly. 
- Enforce changed-lines coverage so PRs meet local impact coverage expectations. 
- Separate architecture/unit/integration concerns so required vs optional checks are clear and maintainable. 
- Publish a test-depth rubric in `CONTRIBUTING.md` mapping feature risk to required test depth for consistent review expectations. 

### Description

- Split CI into explicit required suites: `architecture-tests-required`, `unit-tests-required`, `changed-lines-coverage-required`, and `integration-tests-required`, and added an informational `unit-tests-optional` matrix. 
- Implemented staged total-coverage gates by removing the single `--cov-fail-under` and adding a required coverage report step enforcing `50%` and optional matrix gates enforcing `65%` and `75%`. 
- Added changed-lines coverage enforcement using `diff-cover` with `--fail-under=85` and upload/download of the `coverage.xml` artifact to compare against `origin/main`. 
- Updated `compose-smoke` job dependencies to require the new required gates and published the CI gates and a test-depth quality rubric in `CONTRIBUTING.md` documenting the `30 → 50 → 65 → 75` progression and risk→tests mapping. 

### Testing

- Ran `poetry run pytest -q tests/architecture`, which passed (`3 passed`).
- Attempted `poetry run pre-commit run --files .github/workflows/ci.yml CONTRIBUTING.md` and `pre-commit run --files .github/workflows/ci.yml CONTRIBUTING.md`, but `pre-commit` was not available in the environment (check required in CI). 
- Attempted to validate `ci.yml` with a small `yaml.safe_load` script, but the `PyYAML` module was not installed in the environment (not a project test failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee7a4294c83268963d636da82af85)