### PR TITLE
Add SSE graph digest stream endpoint, contracts, docs, and integration tests

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -221,6 +221,26 @@ curl -X POST http://localhost:8000/snapshot/load \
   -d '{"path":"backup.json"}'
 ```
 
+### GET `/graph/digest/stream`
+Consume real-time graph digest events via SSE.
+- **Auth**: bearer token required.
+- **Query parameters**:
+  - `cursor` (optional): absolute starting ledger offset.
+  - `lastEventId` (optional): reconnect from `lastEventId + 1`.
+- **Headers**:
+  - `Last-Event-ID` (optional): standard SSE resume marker; takes precedence over `lastEventId`.
+- **SSE events**:
+  - `graph_digest`: payload follows `ume.realtime_contracts.GraphDigestEvent`.
+  - `control`: payload follows `ume.realtime_contracts.GraphDigestControlEvent` with `heartbeat` and `backpressure` kinds.
+
+Example request:
+
+```bash
+curl -N "http://localhost:8000/graph/digest/stream?cursor=0"   -H "Authorization: Bearer <token>"   -H "Accept: text/event-stream"
+```
+
+See [`docs/REALTIME_STREAMING.md`](REALTIME_STREAMING.md) for the full contract and backpressure behavior.
+
 ### GET `/ledger/events`
 List entries in the event ledger.
 - **Query parameters**: `start` (default `0`), optional `end`, optional `limit`.

--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -1,0 +1,47 @@
+# Frontend architecture
+
+This document describes UI architecture in a framework-neutral way, then records the concrete framework choice for this repository.
+
+## Framework-neutral architecture
+
+### Goals
+
+- Keep presentation, data access, and state management separated.
+- Make API integration explicit and testable.
+- Preserve portability to any SPA-capable framework.
+
+### Layers
+
+1. **View layer**
+   - Renders pages/components.
+   - Delegates side effects to hooks/services.
+2. **State layer**
+   - Stores session/auth state and view model state.
+   - Exposes deterministic update functions.
+3. **Data access layer**
+   - Encapsulates HTTP + SSE calls to UME backend.
+   - Handles token attachment, retries, and stream resume policy.
+4. **Domain utilities**
+   - Pure helpers for shaping backend payloads into view models.
+
+### Real-time consumption pattern
+
+- Use a stream client abstraction for `GET /graph/digest/stream`.
+- Persist last processed event ID per session to support reconnection.
+- Treat `control.backpressure` events as data-loss signals and trigger a catch-up flow.
+
+### Testing strategy
+
+- Unit test view/state/domain logic in isolation.
+- Integration test data-access adapters with mocked transport.
+- End-to-end test authenticated real-time subscription and reconnect behavior.
+
+## Concrete framework decision
+
+**Chosen framework: React (Vite-based SPA).**
+
+Rationale:
+
+- Existing codebase and tests are already built around React components.
+- The dashboard deployment model is static assets served alongside the API.
+- Current build/test tooling (`vite`, `vitest`) is already integrated in repository workflows.

--- a/docs/REALTIME_STREAMING.md
+++ b/docs/REALTIME_STREAMING.md
@@ -1,0 +1,77 @@
+# Real-time projection contract (SSE topic projection)
+
+UME exposes a server-side real-time projection feed over **SSE** at:
+
+- `GET /graph/digest/stream`
+
+This endpoint is the canonical HTTP topic projection API for graph digest consumption.
+
+## Authentication
+
+- Requires OAuth bearer token (`Authorization: Bearer <token>`).
+- Uses the same auth flow as other API routes (`POST /auth/token`).
+
+## Cursor and resume semantics
+
+Clients can choose where to start consumption:
+
+- `cursor` query parameter: absolute starting ledger offset.
+- `max_events` query parameter (optional): cap emitted digest events, useful for bounded consumers/tests.
+- `lastEventId` query parameter: last consumed SSE event ID; server resumes from `lastEventId + 1`.
+- `Last-Event-ID` header: standard SSE reconnect header; takes precedence over `lastEventId` query parameter.
+
+If both `cursor` and a reconnect marker are present, the server starts from the larger value.
+
+## Event types
+
+### `graph_digest`
+
+Event payload follows `ume.realtime_contracts.GraphDigestEvent`.
+
+```json
+{
+  "offset": 42,
+  "event_id": "evt-123",
+  "event_type": "CREATE_NODE",
+  "source_service": "api",
+  "schema_version": "3.0.0",
+  "timestamp": 1730400000,
+  "node_id": "n1",
+  "target_node_id": null,
+  "label": null,
+  "payload_hash": "8f7d..."
+}
+```
+
+### `control`
+
+Control channel payload follows `ume.realtime_contracts.GraphDigestControlEvent`.
+
+`kind` values:
+
+- `heartbeat`: emitted while idle so clients can detect liveness.
+- `backpressure`: emitted when the bounded queue dropped buffered events.
+
+```json
+{
+  "kind": "backpressure",
+  "cursor_offset": 120,
+  "dropped_events": 8
+}
+```
+
+## Backpressure behavior
+
+The stream uses a bounded in-memory queue. When the consumer cannot keep up:
+
+1. oldest buffered frame(s) are dropped,
+2. server keeps streaming latest digest frames,
+3. a `control`/`backpressure` event reports how many were dropped.
+
+Clients should treat `backpressure` as a gap signal and resynchronize using the reported `cursor_offset`.
+
+## Transport notes
+
+- SSE media type is `text/event-stream`.
+- `id` field is set to the ledger offset for replay-safe resume.
+- Message order is monotonic by ledger offset.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,8 @@
 
 This directory contains a small React dashboard for the UME API. It allows you to log in, view graph statistics and recent audit events, toggle alignment policies, monitor PII redaction activity, and edit Rego policies.
 
+Architecture guidance is documented in [`docs/FRONTEND_ARCHITECTURE.md`](../docs/FRONTEND_ARCHITECTURE.md), which captures framework-neutral layering and the explicit decision to use React for this repository.
+
 ## Development
 
 Install dependencies with npm (Node 18+ required):

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import hashlib
+import json
 import time
 from typing import Any, AsyncGenerator, Dict, List
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Body
+from fastapi import APIRouter, Body, Depends, HTTPException, Header, Query
 try:  # pragma: no cover - optional dependency
     from fastapi_limiter.depends import RateLimiter
 except Exception:  # pragma: no cover - provide stub for tests without limiter
@@ -30,6 +33,8 @@ from .query import Neo4jQueryEngine, build_events_query
 from .event import EventError
 from .processing import ProcessingError
 from .graph_schema import DEFAULT_SCHEMA
+from .event_ledger import event_ledger
+from .realtime_contracts import GraphDigestControlEvent, GraphDigestEvent
 from .rbac_adapter import AccessDeniedError
 from ume.services.ingest import ingest_event, ingest_events_batch
 
@@ -229,6 +234,26 @@ class EventRequest(BaseModel):
         }
     
 
+def _event_payload_hash(payload: Dict[str, Any] | None) -> str:
+    serialized = json.dumps(payload or {}, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _to_graph_digest(offset: int, event: Dict[str, Any]) -> GraphDigestEvent:
+    return GraphDigestEvent(
+        offset=offset,
+        event_id=event.get("event_id") or event.get("eventId"),
+        event_type=str(event.get("event_type") or event.get("eventType") or "UNKNOWN"),
+        source_service=event.get("source") or event.get("sourceService"),
+        schema_version=event.get("schema_version") or event.get("schemaVersion"),
+        timestamp=event.get("timestamp"),
+        node_id=event.get("node_id"),
+        target_node_id=event.get("target_node_id") or event.get("targetNodeId"),
+        label=event.get("label"),
+        payload_hash=_event_payload_hash(event.get("payload")),
+    )
+
+
 @router.get("/query")
 def run_cypher(
     cypher: str,
@@ -309,6 +334,90 @@ async def api_constrained_path_stream(
         for node in filtered:
             yield {"data": node}
             await asyncio.sleep(0)
+
+    return EventSourceResponse(_gen())
+
+
+@router.get("/graph/digest/stream")
+async def api_graph_digest_stream(
+    cursor: int | None = Query(None, ge=0, description="Start streaming from this ledger offset"),
+    last_event_id: int | None = Query(None, ge=0, alias="lastEventId"),
+    last_event_id_header: int | None = Header(None, alias="Last-Event-ID"),
+    max_events: int | None = Query(None, ge=1, description="Optional cap for emitted digest events"),
+    _: str = Depends(deps.get_current_role),
+) -> EventSourceResponse:
+    """Stream ledger-backed graph digest events via SSE with bounded buffering."""
+
+    queue: asyncio.Queue[dict[str, str]] = asyncio.Queue(maxsize=64)
+    dropped_events = 0
+    stop_event = asyncio.Event()
+
+    resume_from = last_event_id_header if last_event_id_header is not None else last_event_id
+    start_offset = max((cursor if cursor is not None else 0), (resume_from + 1) if resume_from is not None else 0)
+
+    async def _producer() -> None:
+        nonlocal dropped_events
+        next_offset = start_offset
+        emitted = 0
+        heartbeat_interval_s = 5.0
+        last_heartbeat = time.monotonic()
+        while not stop_event.is_set():
+            batch = event_ledger.range(start=next_offset, limit=100)
+            if batch:
+                for offset, event in batch:
+                    digest = _to_graph_digest(offset, event)
+                    frame = {"event": "graph_digest", "id": str(offset), "data": digest.model_dump_json()}
+                    if queue.full():
+                        try:
+                            queue.get_nowait()
+                            dropped_events += 1
+                        except asyncio.QueueEmpty:
+                            pass
+                    await queue.put(frame)
+                    next_offset = offset + 1
+                    emitted += 1
+                    if max_events is not None and emitted >= max_events:
+                        stop_event.set()
+                        break
+                if dropped_events > 0:
+                    ctrl = GraphDigestControlEvent(
+                        kind="backpressure",
+                        cursor_offset=next_offset - 1,
+                        dropped_events=dropped_events,
+                    )
+                    await queue.put({"event": "control", "data": ctrl.model_dump_json()})
+                    dropped_events = 0
+                last_heartbeat = time.monotonic()
+            else:
+                now = time.monotonic()
+                if now - last_heartbeat >= heartbeat_interval_s:
+                    heartbeat = GraphDigestControlEvent(
+                        kind="heartbeat",
+                        cursor_offset=max(next_offset - 1, -1),
+                    )
+                    await queue.put({"event": "control", "data": heartbeat.model_dump_json()})
+                    last_heartbeat = now
+                await asyncio.sleep(0.1)
+
+    async def _gen() -> AsyncGenerator[dict[str, str], None]:
+        producer_task = asyncio.create_task(_producer())
+        try:
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=0.2)
+                except asyncio.TimeoutError:
+                    if stop_event.is_set() and queue.empty():
+                        break
+                    continue
+                yield event
+                await asyncio.sleep(0)
+                if stop_event.is_set() and queue.empty():
+                    break
+        finally:
+            stop_event.set()
+            producer_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await producer_task
 
     return EventSourceResponse(_gen())
 

--- a/src/ume/realtime_contracts.py
+++ b/src/ume/realtime_contracts.py
@@ -1,0 +1,31 @@
+"""Contract models for real-time graph projection streams."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class GraphDigestEvent(BaseModel):
+    """Compact graph mutation digest emitted by the real-time stream."""
+
+    offset: int
+    event_id: str | None = None
+    event_type: str
+    source_service: str | None = None
+    schema_version: str | None = None
+    timestamp: int | None = None
+    node_id: str | None = None
+    target_node_id: str | None = None
+    label: str | None = None
+    payload_hash: str
+
+
+class GraphDigestControlEvent(BaseModel):
+    """Out-of-band stream control events (heartbeat/backpressure)."""
+
+    kind: Literal["heartbeat", "backpressure"]
+    cursor_offset: int
+    dropped_events: int = 0
+

--- a/tests/integration/test_realtime_stream.py
+++ b/tests/integration/test_realtime_stream.py
@@ -1,0 +1,94 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume.config import settings
+from ume.event_ledger import EventLedger
+from ume.graph import MockGraph
+import ume.graph_routes as graph_routes
+
+
+def _token(client: TestClient) -> str:
+    response = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return response.json()["access_token"]
+
+
+def _seed_ledger(ledger: EventLedger, count: int) -> None:
+    for offset in range(count):
+        ledger.append(
+            offset,
+            {
+                "eventType": "CREATE_NODE",
+                "eventId": f"evt-{offset}",
+                "timestamp": offset + 1,
+                "sourceService": "test",
+                "node_id": f"n{offset}",
+                "payload": {"node_id": f"n{offset}", "attributes": {"name": f"N{offset}"}},
+            },
+        )
+
+
+def _read_graph_digest_payloads(client: TestClient, *, token: str, expected: int, headers: dict[str, str] | None = None):
+    payloads: list[dict[str, object]] = []
+    req_headers = {"Authorization": f"Bearer {token}", "Accept": "text/event-stream"}
+    if headers:
+        req_headers.update(headers)
+    with client.stream("GET", f"/graph/digest/stream?max_events={expected}", headers=req_headers) as response:
+        assert response.status_code == 200
+        pending_graph_digest = False
+        for line in response.iter_lines():
+            if not line:
+                continue
+            if line.startswith("event: graph_digest"):
+                pending_graph_digest = True
+                continue
+            if pending_graph_digest and line.startswith("data: "):
+                payloads.append(json.loads(line[len("data: ") :]))
+                pending_graph_digest = False
+                if len(payloads) >= expected:
+                    break
+    return payloads
+
+
+def test_graph_digest_stream_requires_auth_and_emits_digests(tmp_path, monkeypatch) -> None:
+    configure_graph(MockGraph())
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+    app.state.vector_store = type("VS", (), {"close": lambda self: None})()
+
+    ledger = EventLedger(str(tmp_path / "realtime_auth.db"))
+    _seed_ledger(ledger, 2)
+    monkeypatch.setattr(graph_routes, "event_ledger", ledger)
+
+    with TestClient(app) as client:
+        unauth = client.get("/graph/digest/stream")
+        assert unauth.status_code == 401
+
+        payloads = _read_graph_digest_payloads(client, token=_token(client), expected=2)
+
+    assert [item["offset"] for item in payloads] == [0, 1]
+    assert payloads[0]["event_id"] == "evt-0"
+
+
+def test_graph_digest_stream_reconnects_from_last_event_id(tmp_path, monkeypatch) -> None:
+    configure_graph(MockGraph())
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+    app.state.vector_store = type("VS", (), {"close": lambda self: None})()
+
+    ledger = EventLedger(str(tmp_path / "realtime_reconnect.db"))
+    _seed_ledger(ledger, 4)
+    monkeypatch.setattr(graph_routes, "event_ledger", ledger)
+
+    with TestClient(app) as client:
+        token = _token(client)
+        resumed = _read_graph_digest_payloads(
+            client,
+            token=token,
+            expected=2,
+            headers={"Last-Event-ID": "1"},
+        )
+
+    assert [item["offset"] for item in resumed] == [2, 3]


### PR DESCRIPTION
### Motivation

- Provide a canonical server-side topic-projection API for real-time graph updates so downstream consumers can subscribe to compact digests of graph mutations.
- Expose a resumable, authenticated SSE endpoint with explicit backpressure signaling to support robust client reconnect and catch-up flows.
- Clarify frontend architecture in a framework-neutral way and record the concrete framework choice for this repository.
- Verify authenticated real-time consumption and reconnect behavior via automated integration tests.

### Description

- Added `src/ume/realtime_contracts.py` with `GraphDigestEvent` and `GraphDigestControlEvent` Pydantic models to formalize digest and control payloads.
- Implemented `GET /graph/digest/stream` in `src/ume/graph_routes.py` which streams ledger-backed digest frames as SSE, enforces bearer auth, supports resume semantics via `cursor`, `lastEventId` and `Last-Event-ID`, uses a bounded in-memory queue with a backpressure `control` event, emits `heartbeat` control frames when idle, and provides an optional `max_events` cap for bounded consumption/tests.
- Added deterministic digest construction including a payload hash via `_to_graph_digest` and `_event_payload_hash` helpers to produce compact, replay-safe payloads.
- Documented the contract and usage in `docs/REALTIME_STREAMING.md` and updated `docs/API_REFERENCE.md` with the new `GET /graph/digest/stream` entry, and added `docs/FRONTEND_ARCHITECTURE.md` plus a link from `frontend/README.md` declaring React (Vite) as the concrete UI choice.
- Added integration tests `tests/integration/test_realtime_stream.py` that verify authentication enforcement, digest emission, and reconnection semantics using `Last-Event-ID`.

### Testing

- Ran linter checks with `poetry run ruff check src/ume/graph_routes.py src/ume/realtime_contracts.py tests/integration/test_realtime_stream.py` and the check passed.
- Executed the new integration suite with `poetry run pytest tests/integration/test_realtime_stream.py` and the two tests in that file passed.
- During test runs missing test dependencies were installed as needed (`fastapi`, `sse-starlette`, `networkx`, `protobuf`, `python-multipart`) to allow the integration tests to execute successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aef27e5ca4832689cd3cc6b19295cb)