### PR TITLE
Enforce canonical ingest contract and isolate legacy event transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ set of common fields and any number of type‑specific attributes.
 | `sourceService` | Name of the service that emitted the event. |
 | `payload` | Event‑specific attributes. |
 
-Ingress adapters convert the external contract into UME's internal canonical event (`metadata` + `graph` + `payload`) before parsing.
+Ingress accepts one authoritative external contract only (`eventType`, `eventId`, `schemaVersion`, `sourceService`, `node_id`, ...). That external shape is transformed exactly once into UME's internal canonical event (`metadata` + `graph` + `payload`) before parsing.
 Timestamps are accepted as Unix epoch integers or ISO&nbsp;8601 strings (including `Z` suffix) and are normalized internally to an
 epoch integer on the parsed `Event`.
 
@@ -204,14 +204,17 @@ event-type-specific checks:
 Compatibility note:
 
 * Required for all external producer events: `eventType` and `timestamp`.
-* Optional for all events: `eventId`, `correlationId`, `subjectEntity`,
-  `sourceService`.
+* Optional for all events: `eventId`, `correlationId`, `subjectEntity`, `sourceService`.
 * Edge-family events (`CREATE_EDGE`, `DELETE_EDGE`, `CREATE_ONTOLOGY_RELATION`,
   `DATA_SOURCE_QUERIED`, `ENTITY_DISCOVERED`) require `node_id`,
   `target_node_id`, `label`; `payload` is optional and defaults to `{}`.
 * Node-family update events (`UPDATE_NODE_ATTRIBUTES`, `DOCUMENT_ARCHIVED`)
   require `payload.attributes`; `DOCUMENT_ARCHIVED` defaults
   `attributes.archived` to `true` during processing when omitted.
+
+### Legacy migration (explicit transform only)
+
+Historical payloads (`event` envelope wrapper, snake_case metadata keys such as `event_type`) are no longer parsed directly on the primary ingress path. Use `ume.events.legacy_transform.apply_legacy_transform()` to migrate those payloads into the authoritative external contract, then call canonicalization/parsing.
 
 #### CREATE_EDGE Event
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -563,3 +563,8 @@ uvicorn ume.api:app
 Then visit [http://localhost:8000/docs](http://localhost:8000/docs) in your browser.
 The raw OpenAPI schema is available at
 [http://localhost:8000/openapi.json](http://localhost:8000/openapi.json).
+
+
+## Legacy migration section
+
+Legacy envelopes and snake_case metadata keys are supported only through `ume.events.legacy_transform.apply_legacy_transform()`. New code paths must not parse both shapes directly.

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -248,7 +248,7 @@ parsing, values are normalized to an epoch integer in the `Event` object.
 
 Current runtime behavior in `parse_event()` + `apply_event_to_graph()`:
 
-* Required for all events: `eventType` (or `event_type`) and `timestamp`.
+* Required for all events: `eventType` and `timestamp`.
 * Optional common fields: `eventId`, `correlationId`, `subjectEntity`,
   `sourceService`.
 * Node-create family (`CREATE_NODE`, `RESEARCH_JOB_STARTED`):
@@ -348,10 +348,11 @@ Producer (canonical JSON) --> ume-raw-events --> Privacy Agent --> ume-clean-eve
 As events pass from ingestion through projection they retain the canonical
 schema, ensuring consistent processing across components.
 
-Compatibility note: `eventType` is the preferred wire field. `parse_event()`
-still accepts snake_case `event_type` for backward compatibility, but new
-producers should emit `eventType`. For edge-family events, omitted `payload`
-defaults to `{}`.
+Compatibility note: the primary ingest path accepts only the authoritative external contract (`eventType`, camelCase metadata keys, graph snake_case keys). For edge-family events, omitted `payload` defaults to `{}`.
+
+### Legacy migration
+
+Historical payload variants (`event` wrapper or snake_case metadata keys) must be normalized via `ume.events.legacy_transform.apply_legacy_transform()` before canonicalization.
 
 As events move from the ingestion API through the Privacy Agent
 and into the projection engine, they keep this schema. The engine

--- a/scripts/check_schema_compatibility.py
+++ b/scripts/check_schema_compatibility.py
@@ -32,9 +32,42 @@ def _seed_event(version: str) -> dict[str, object]:
     }
 
 
+def _enforce_single_shape_parsing() -> None:
+    """Fail if non-legacy ingress code parses both modern + legacy shapes directly."""
+
+    forbidden_needles = (
+        'payload.get("event", payload)',
+        'payload.get("event")',
+        'normalized = dict(deepcopy(payload.get("event", payload)))',
+    )
+    allowed = {Path("src/ume/events/legacy_transform.py")}
+    scan_files = [
+        Path("src/ume/event.py"),
+        Path("src/ume/events/contract.py"),
+        *Path("src/ume/events/adapters").glob("*.py"),
+    ]
+
+    violations: list[str] = []
+    for rel in scan_files:
+        if rel in allowed:
+            continue
+        content = (ROOT / rel).read_text()
+        for needle in forbidden_needles:
+            if needle in content:
+                violations.append(f"{rel}: contains forbidden dual-shape parser marker {needle!r}")
+
+    if violations:
+        raise SystemExit(
+            "Direct dual-shape parsing is forbidden outside ume.events.legacy_transform:\n"
+            + "\n".join(sorted(violations))
+        )
+
+
 def main() -> int:
     from ume.events.versioning import downgrade_event, upgrade_event
     from ume.schemas.contracts import supported_contract_majors
+
+    _enforce_single_shape_parsing()
 
     majors = list(supported_contract_majors())
 

--- a/src/ume/event.py
+++ b/src/ume/event.py
@@ -70,7 +70,7 @@ def parse_event(data: Dict[str, Any]) -> Event:
 
     if not {"metadata", "graph", "payload"} <= data.keys():
         raise EventError(
-            "parse_event expects canonicalized data with 'metadata', 'graph', and 'payload'"
+            "parse_event expects canonicalized data with 'metadata', 'graph', and 'payload'; apply ume.events.legacy_transform before canonicalization for historical transport shapes"
         )
 
     metadata = data.get("metadata")

--- a/src/ume/events/adapters/cli.py
+++ b/src/ume/events/adapters/cli.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import Any, Mapping
+
+from ..legacy_transform import apply_legacy_transform
 
 
 def adapt_cli_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    normalized = dict(deepcopy(payload.get("event", payload)))
-    if "nodeId" in normalized and "node_id" not in normalized:
-        normalized["node_id"] = normalized["nodeId"]
-    if "targetNodeId" in normalized and "target_node_id" not in normalized:
-        normalized["target_node_id"] = normalized["targetNodeId"]
-    if "schemaVersion" in payload and "schemaVersion" not in normalized:
-        normalized["schemaVersion"] = payload["schemaVersion"]
-    return normalized
+    return apply_legacy_transform(payload)

--- a/src/ume/events/adapters/grpc.py
+++ b/src/ume/events/adapters/grpc.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import Any, Mapping
+
+from ..legacy_transform import apply_legacy_transform
 
 
 def adapt_grpc_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    normalized = dict(deepcopy(payload.get("event", payload)))
-    if "sourceService" in normalized and "source" not in normalized:
-        normalized["source"] = normalized["sourceService"]
-    if "schemaVersion" in normalized and "schema_version" not in normalized:
-        normalized["schema_version"] = normalized["schemaVersion"]
-    if "schema_version" in payload and "schema_version" not in normalized:
-        normalized["schema_version"] = payload["schema_version"]
-    return normalized
+    return apply_legacy_transform(payload)

--- a/src/ume/events/adapters/kafka.py
+++ b/src/ume/events/adapters/kafka.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
-from copy import deepcopy
 from typing import Any, Mapping
+
+from ..legacy_transform import apply_legacy_transform
 
 from ...schema_utils import validate_event_dict
 
@@ -17,14 +18,7 @@ except Exception:  # pragma: no cover - optional integration dependency
 
 
 def adapt_kafka_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
-    normalized = dict(deepcopy(payload.get("event", payload)))
-    if "nodeId" in normalized and "node_id" not in normalized:
-        normalized["node_id"] = normalized["nodeId"]
-    if "targetNodeId" in normalized and "target_node_id" not in normalized:
-        normalized["target_node_id"] = normalized["targetNodeId"]
-    if "schemaVersion" in payload and "schemaVersion" not in normalized:
-        normalized["schemaVersion"] = payload["schemaVersion"]
-    return normalized
+    return apply_legacy_transform(payload)
 
 
 class KafkaContractValidator:

--- a/src/ume/events/contract.py
+++ b/src/ume/events/contract.py
@@ -5,6 +5,28 @@ from datetime import datetime
 from typing import Any, Dict, Mapping
 
 
+"""Event contract transformations.
+
+Authoritative ingress contract (external): flat producer payload with camelCase
+metadata keys and snake_case graph keys:
+
+    eventId, eventType, timestamp, schemaVersion, sourceService,
+    producerId, tenant, signature, correlationId, subjectEntity,
+    node_id, target_node_id, label, payload
+
+Authoritative internal contract (canonical):
+
+    {
+      "metadata": {...},
+      "graph": {...},
+      "payload": {...}
+    }
+
+Transform direction is strictly external -> canonical in this module.
+Legacy/backward shape upgrades must happen in ``ume.events.legacy_transform``.
+"""
+
+
 _CAMEL_TO_SNAKE = {
     "eventId": "event_id",
     "eventType": "event_type",
@@ -121,38 +143,38 @@ def _to_snake_keys(data: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def _to_external_contract(data: Mapping[str, Any]) -> Dict[str, Any]:
-    """Normalize adapter output to the single external producer contract."""
+    """Validate/normalize the single authoritative external producer contract."""
 
     if "event" in data:
-        raise ValueError("event envelope contract is not accepted; send flat event fields")
-
-    normalized = _to_snake_keys(data)
-    if "source" in normalized and "source_service" not in normalized:
-        normalized["source_service"] = normalized["source"]
-    if "signature" in normalized and "producer_signature" not in normalized:
-        normalized["producer_signature"] = normalized["signature"]
+        raise ValueError(
+            "event envelope contract is not accepted; run ume.events.legacy_transform first"
+        )
+    if "event_type" in data or "event_id" in data or "schema_version" in data:
+        raise ValueError(
+            "snake_case ingest fields are not accepted; run ume.events.legacy_transform first"
+        )
 
     external: Dict[str, Any] = {
-        "eventId": normalized.get("event_id"),
-        "eventType": normalized.get("event_type"),
-        "timestamp": normalized.get("timestamp"),
-        "payload": normalized.get("payload", {}),
-        "sourceService": normalized.get("source_service"),
-        "producerId": normalized.get("producer_id"),
-        "tenant": normalized.get("tenant"),
-        "signature": normalized.get("producer_signature"),
-        "schemaVersion": normalized.get("schema_version"),
-        "node_id": normalized.get("node_id"),
-        "target_node_id": normalized.get("target_node_id"),
-        "label": normalized.get("label"),
-        "correlationId": normalized.get("correlation_id"),
-        "subjectEntity": normalized.get("subject_entity"),
+        "eventId": data.get("eventId"),
+        "eventType": data.get("eventType"),
+        "timestamp": data.get("timestamp"),
+        "payload": data.get("payload", {}),
+        "sourceService": data.get("sourceService"),
+        "producerId": data.get("producerId"),
+        "tenant": data.get("tenant"),
+        "signature": data.get("signature"),
+        "schemaVersion": data.get("schemaVersion"),
+        "node_id": data.get("node_id"),
+        "target_node_id": data.get("target_node_id"),
+        "label": data.get("label"),
+        "correlationId": data.get("correlationId"),
+        "subjectEntity": data.get("subjectEntity"),
     }
     return {k: v for k, v in external.items() if v is not None}
 
 
 def canonicalize_event(data: Mapping[str, Any]) -> Dict[str, Any]:
-    """Normalize flat external producer event into the canonical envelope dict."""
+    """Transform authoritative external ingest payload into canonical envelope."""
 
     external_data = _to_external_contract(data)
     snake_data = _to_snake_keys(external_data)

--- a/src/ume/events/legacy_transform.py
+++ b/src/ume/events/legacy_transform.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+
+def apply_legacy_transform(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Upgrade legacy transport/event shapes to the authoritative external contract.
+
+    This is the *only* backward-compatibility transform entrypoint. All new ingress
+    code should provide already-compliant external payloads and skip this module.
+    """
+
+    normalized = dict(deepcopy(payload))
+
+    if "event" in normalized and isinstance(normalized["event"], Mapping):
+        nested = dict(deepcopy(normalized["event"]))
+        if "schemaVersion" in normalized and "schemaVersion" not in nested:
+            nested["schemaVersion"] = normalized["schemaVersion"]
+        if "schema_version" in normalized and "schemaVersion" not in nested:
+            nested["schemaVersion"] = normalized["schema_version"]
+        normalized = nested
+
+    # Promote snake_case historical fields to external camelCase contract keys.
+    if "event_id" in normalized and "eventId" not in normalized:
+        normalized["eventId"] = normalized["event_id"]
+    normalized.pop("event_id", None)
+    if "event_type" in normalized and "eventType" not in normalized:
+        normalized["eventType"] = normalized["event_type"]
+    normalized.pop("event_type", None)
+    if "schema_version" in normalized and "schemaVersion" not in normalized:
+        normalized["schemaVersion"] = normalized["schema_version"]
+    normalized.pop("schema_version", None)
+    if "source" in normalized and "sourceService" not in normalized:
+        normalized["sourceService"] = normalized["source"]
+    normalized.pop("source", None)
+    if "producer_signature" in normalized and "signature" not in normalized:
+        normalized["signature"] = normalized["producer_signature"]
+    normalized.pop("producer_signature", None)
+    if "correlation_id" in normalized and "correlationId" not in normalized:
+        normalized["correlationId"] = normalized["correlation_id"]
+    normalized.pop("correlation_id", None)
+    if "subject_entity" in normalized and "subjectEntity" not in normalized:
+        normalized["subjectEntity"] = normalized["subject_entity"]
+    normalized.pop("subject_entity", None)
+
+    # Promote graph aliases.
+    if "nodeId" in normalized and "node_id" not in normalized:
+        normalized["node_id"] = normalized["nodeId"]
+    if "targetNodeId" in normalized and "target_node_id" not in normalized:
+        normalized["target_node_id"] = normalized["targetNodeId"]
+
+    return normalized

--- a/tests/test_event_contract.py
+++ b/tests/test_event_contract.py
@@ -5,6 +5,7 @@ import pytest
 pytest.importorskip("google.protobuf.json_format")
 
 from ume.events.contract import canonical_to_camel_dict, canonicalize_event
+from ume.events.legacy_transform import apply_legacy_transform
 from ume.events.versioning import downgrade_event, upgrade_event
 from ume.schema_utils import validate_canonical_event, validate_event_dict
 from ume.schemas.contracts import load_bundle_schema, supported_contract_majors
@@ -30,21 +31,10 @@ def _canonical(version: str = "1.0.0") -> dict[str, object]:
     }
 
 
-def test_legacy_shapes_normalize_to_same_canonical_form() -> None:
+def test_legacy_shapes_require_explicit_transform_then_normalize() -> None:
     expected = _canonical()
 
     legacy_shapes = [
-        {
-            "eventId": "e-1",
-            "eventType": "CREATE_NODE",
-            "timestamp": 1,
-            "schema_version": "1.0.0",
-            "sourceService": "demo",
-            "correlationId": "c-1",
-            "subjectEntity": {"id": "u1", "type": "user"},
-            "node_id": "n1",
-            "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
-        },
         {
             "event_id": "e-1",
             "event_type": "CREATE_NODE",
@@ -72,7 +62,12 @@ def test_legacy_shapes_normalize_to_same_canonical_form() -> None:
     ]
 
     for shape in legacy_shapes:
-        assert canonicalize_event(shape) == expected
+        assert canonicalize_event(apply_legacy_transform(shape)) == expected
+
+
+def test_canonicalize_event_rejects_legacy_shapes_without_explicit_transform() -> None:
+    with pytest.raises(ValueError, match="legacy_transform"):
+        canonicalize_event({"event_type": "CREATE_NODE", "timestamp": 1})
 
 
 def test_contract_bundles_exist_and_can_be_loaded() -> None:
@@ -107,10 +102,10 @@ def test_upgrade_and_downgrade_transformers_support_replay_compatibility() -> No
 
 def test_json_schema_and_protobuf_converters_accept_canonicalized_shape() -> None:
     event = {
-        "event_type": "CREATE_EDGE",
-        "event_id": "e-2",
+        "eventType": "CREATE_EDGE",
+        "eventId": "e-2",
         "timestamp": 2,
-        "schema_version": "1.0.0",
+        "schemaVersion": "1.0.0",
         "node_id": "n1",
         "target_node_id": "n2",
         "label": "RELATES_TO",

--- a/tests/test_event_contract_normalization.py
+++ b/tests/test_event_contract_normalization.py
@@ -35,7 +35,7 @@ def test_external_contract_round_trip_edge_event() -> None:
 
 
 def test_event_envelope_is_rejected() -> None:
-    with pytest.raises(ValueError, match="event envelope contract"):
+    with pytest.raises(ValueError, match="legacy_transform"):
         canonicalize_event(
             {
                 "schemaVersion": "3.0.0",

--- a/tests/test_ingress_boundary_contract.py
+++ b/tests/test_ingress_boundary_contract.py
@@ -44,7 +44,7 @@ def test_ingress_paths_produce_identical_canonical_output() -> None:
     assert kafka_event == grpc_event == cli_event
 
 
-def test_ingress_accepts_legacy_nested_event_shape() -> None:
+def test_ingress_accepts_legacy_nested_event_shape_via_adapter_transform() -> None:
     legacy_payload = {
         "schemaVersion": "2.0.0",
         "event": {

--- a/tests/test_schema_resolution_parity.py
+++ b/tests/test_schema_resolution_parity.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from ume.event_ledger import EventLedger
+from ume.events.contract import canonicalize_event
+from ume.events.legacy_transform import apply_legacy_transform
 from ume.graph import MockGraph
 from ume.replay import replay_from_ledger
 from ume.services.event_processor import DEFAULT_EVENT_PROCESSOR
@@ -57,4 +59,38 @@ def test_mixed_version_replay_matches_live_ingestion_path(tmp_path) -> None:
     replay_from_ledger(replay_graph, ledger)
 
     assert replay_graph.dump() == live_graph.dump()
+    ledger.close()
+
+
+def test_historical_events_are_normalized_once_then_replayed_uniformly(tmp_path) -> None:
+    graph = MockGraph()
+    replay_graph = MockGraph()
+    ledger = EventLedger(str(tmp_path / "legacy-normalized.sqlite"))
+
+    historical = {
+        "schemaVersion": "1.0.0",
+        "event": {
+            "eventId": "evt-legacy-1",
+            "eventType": "CREATE_NODE",
+            "timestamp": 1,
+            "sourceService": "legacy",
+            "nodeId": "legacy-1",
+            "payload": {"node_id": "legacy-1", "attributes": {"kind": "legacy"}},
+        },
+    }
+
+    normalized_external = apply_legacy_transform(historical)
+    canonical = canonicalize_event(normalized_external)
+
+    DEFAULT_EVENT_PROCESSOR.mutate_graph(
+        normalized_external,
+        graph=graph,
+        source="service_ingest",
+        adapter="default",
+    )
+    ledger.append(0, normalized_external)
+    replay_from_ledger(replay_graph, ledger)
+
+    assert canonical["graph"]["node_id"] == "legacy-1"
+    assert replay_graph.dump() == graph.dump()
     ledger.close()


### PR DESCRIPTION
### Motivation

- Remove ambiguity between legacy/historical event shapes and the single authoritative ingest format so ingress stages and parsers operate on one clear contract. 
- Ensure backward-compatibility transforms are explicit and auditable rather than baked into multiple adapters or parser logic. 
- Prevent accidental dual-shape parsing in new code paths and block schema-breaking changes without an explicit migration transformer.

### Description

- Declare the authoritative external ingest contract and the internal canonical envelope and document strict transform direction (external -> canonical) in `src/ume/events/contract.py` and make legacy-shape rejection explicit. 
- Add `src/ume/events/legacy_transform.py` as the single migration entrypoint that normalizes nested `event` envelopes and snake_case metadata into the authoritative external camelCase shape. 
- Remove backward-shape parsing from ingress adapters by routing `cli`, `grpc`, and `kafka` adapters through `apply_legacy_transform(...)` and update `parse_event()` messaging to require canonical envelopes. 
- Add a CI migration gate in `scripts/check_schema_compatibility.py` that scans for forbidden dual-shape parsing markers outside the legacy transform module, update docs (`README.md`, `docs/API_REFERENCE.md`, `docs/GRAPH_MODEL.md`) to show canonical examples and a marked legacy migration section, and add/adjust tests to prove normalization + replay compatibility (including `tests/test_event_contract.py`, `tests/test_ingress_boundary_contract.py`, and `tests/test_schema_resolution_parity.py`).

### Testing

- Ran style checks with `ruff` against changed modules and they passed. 
- Compiled relevant modules with `python -m compileall` and compilation succeeded. 
- Executed unit tests with `pytest -q tests/test_event_contract.py tests/test_event_contract_normalization.py tests/test_ingress_boundary_contract.py tests/test_schema_resolution_parity.py` and they passed (`8 passed, 1 skipped`). 
- Ran the schema compatibility gate `python scripts/check_schema_compatibility.py` and it reported success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2c690910883269109054a5b65e031)