### PR TITLE
Centralize deprecation registry, remove past-sunset shims, and add CI callsite guard

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -38,7 +38,39 @@ All mutation-capable ingress routes (API, CLI, Kafka, gRPC, and compatibility co
 - `ume.services.event_processor.EventProcessorService` is the service boundary used by integrations.
 - `ume.pipeline.core.EventPipelineOrchestrator` is the only stage orchestration runtime behind that service boundary.
 
-`ume.projection_engine` is maintained as a thin compatibility adapter that delegates to the same orchestrator path, and `ume.services.mutate.run_mutation*` is hard-deprecated compatibility surface retained only for migration support.
+`ume.projection_engine.run_projection_engine` and `ume.pipeline.graph_consumer.run_graph_consumer` were removed after sunset and replaced by orchestrator-native entrypoints. Remaining compatibility shims (`ume.services.mutate.run_mutation*`, `ume.stream_processor`, top-level `ume.__getattr__` fallback exports) are controlled by `ume.deprecations.DEPRECATION_REGISTRY` and a CI callsite guard (`scripts/check_deprecated_callsites.py`).
+
+
+
+### Deprecation migration snippets
+
+```python
+# old mutation path
+from ume.services.mutate import run_mutation_async
+result = await run_mutation_async(payload, source="kafka")
+
+# new service boundary
+from ume.services.event_processor import DEFAULT_EVENT_PROCESSOR
+result = await DEFAULT_EVENT_PROCESSOR.process_payload_async(payload, source="kafka")
+```
+
+```python
+# old projection consumer
+from ume.projection_engine import run_projection_engine
+run_projection_engine(graph)
+
+# new orchestrator worker
+from ume.services.projection_worker import run_projection_worker
+run_projection_worker(graph)
+```
+
+```python
+# old stream import
+from ume import stream_processor
+
+# new stream import
+from ume.pipeline import stream_processor
+```
 
 ## Architecture status
 

--- a/docs/PROJECTION_ENGINE.md
+++ b/docs/PROJECTION_ENGINE.md
@@ -12,7 +12,7 @@ The authoritative implementation is:
 - Transport adapters in `ume.events.adapters` + `ume.events.ingress` for ingress normalization.
 - `ume.services.event_processor.EventProcessorService` as the single service entrypoint used by CLI/API/consumer integrations (implemented as a thin facade over `EventPipelineOrchestrator`).
 
-Legacy entrypoints in `ume.projection_engine`, `ume.pipeline.graph_consumer`, and direct `ume.services.mutate.run_mutation*` calls are compatibility wrappers and are deprecated.
+Legacy entrypoints in `ume.projection_engine`, `ume.pipeline.graph_consumer`, and direct `ume.services.mutate.run_mutation*` calls are tracked in the central deprecation registry (`ume.deprecations.DEPRECATION_REGISTRY`). Past-sunset shims are removed; active shims emit registry-backed runtime warnings.
 
 Conformance is enforced by the mutation route parity matrix in `tests/test_mutation_entrypoint_parity.py`, which asserts equivalent `PipelineEnvelope` outcomes across Kafka/API/CLI/gRPC paths for identical payloads.
 
@@ -36,18 +36,47 @@ Outcomes are normalized as `applied`, `redacted`, `rejected`, or `quarantined`.
 
 ## Deprecation timeline
 
-Deprecated compatibility entrypoints:
+## Deprecated entrypoint inventory and migration map
 
-- `ume.projection_engine.run_projection_engine`
-- `ume.pipeline.graph_consumer.run_graph_consumer`
-- `ume.services.mutate.run_mutation`
-- `ume.services.mutate.run_mutation_async`
+| Legacy entrypoint | Status | Sunset | Replacement |
+| --- | --- | --- | --- |
+| `ume.projection_engine.run_projection_engine` | Removed (past sunset) | 2026-01-31 / 0.2.0 | `ume.services.projection_worker.run_projection_worker` |
+| `ume.pipeline.graph_consumer.run_graph_consumer` | Removed (past sunset) | 2026-01-31 / 0.2.0 | `ume.pipeline.graph_consumer.run_event_pipeline_consumer` |
+| `ume.services.mutate.run_mutation` | Active deprecation | 2026-07-01 / 0.3.0 | `DEFAULT_EVENT_PROCESSOR.process_payload(...)` |
+| `ume.services.mutate.run_mutation_async` | Active deprecation | 2026-07-01 / 0.3.0 | `DEFAULT_EVENT_PROCESSOR.process_payload_async(...)` |
+| `ume.stream_processor` | Active deprecation | 2026-07-01 / 0.3.0 | `ume.pipeline.stream_processor` |
 
-Timeline:
+### Migration snippets
 
-- Deprecated now (warnings emitted at runtime).
-- Removal target: **2026-01-31**.
-- Migration target: `ume.services.event_processor.DEFAULT_EVENT_PROCESSOR`.
+```python
+# old
+from ume.services.mutate import run_mutation
+envelope = run_mutation(payload, source="api")
+
+# new
+from ume.services.event_processor import DEFAULT_EVENT_PROCESSOR
+envelope = DEFAULT_EVENT_PROCESSOR.process_payload(payload, source="api")
+```
+
+```python
+# old
+from ume.pipeline.graph_consumer import run_graph_consumer
+run_graph_consumer(graph)
+
+# new
+from ume.pipeline.graph_consumer import run_event_pipeline_consumer
+run_event_pipeline_consumer(graph)
+```
+
+```python
+# explicit orchestrator wiring
+from ume.pipeline.core import EventPipelineOrchestrator
+from ume.services.event_processor import EventProcessorService
+
+orchestrator = EventPipelineOrchestrator()
+service = EventProcessorService(orchestrator=orchestrator)
+envelope = service.process_payload(payload, source="cli")
+```
 
 ## Configuration
 

--- a/scripts/check_deprecated_callsites.py
+++ b/scripts/check_deprecated_callsites.py
@@ -1,0 +1,62 @@
+"""Fail CI when deprecated shim callsites are introduced outside allowlisted files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TARGET_DIRS = ("src", "tests")
+
+PATTERNS: dict[str, tuple[re.Pattern[str], set[str]]] = {
+    "ume.services.mutate.run_mutation": (
+        re.compile(r"\brun_mutation\("),
+        {"src/ume/services/mutate.py"},
+    ),
+    "ume.services.mutate.run_mutation_async": (
+        re.compile(r"\brun_mutation_async\("),
+        {"src/ume/services/mutate.py"},
+    ),
+    "ume.stream_processor": (
+        re.compile(r"(?:from\s+ume\s+import\s+stream_processor|(?:from|import)\s+ume\.stream_processor\b)"),
+        {"src/ume/stream_processor.py"},
+    ),
+}
+
+
+def _iter_python_files(root: Path):
+    for dirname in TARGET_DIRS:
+        base = root / dirname
+        if not base.exists():
+            continue
+        for path in base.rglob("*.py"):
+            yield path
+
+
+def find_violations(root: Path = REPO_ROOT) -> list[str]:
+    violations: list[str] = []
+    for path in _iter_python_files(root):
+        rel_path = path.relative_to(root).as_posix()
+        text = path.read_text(encoding="utf-8")
+        for key, (pattern, allowlist) in PATTERNS.items():
+            if rel_path in allowlist:
+                continue
+            for match in pattern.finditer(text):
+                line = text.count("\n", 0, match.start()) + 1
+                violations.append(f"{rel_path}:{line}: deprecated callsite for {key}")
+    return violations
+
+
+def main() -> int:
+    violations = find_violations()
+    if violations:
+        print("Deprecated callsite check failed:")
+        for violation in violations:
+            print(f" - {violation}")
+        return 1
+    print("Deprecated callsite check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import warnings
 from importlib import import_module
 from typing import Any
 
 from .bootstrap.config import load_config
+from .deprecations import warn_deprecated
 from .event import Event, EventError, EventType, parse_event
 from .graph_adapter import IGraphAdapter
 
@@ -144,11 +144,12 @@ def __getattr__(name: str) -> object:
     if name in _RUNTIME_EXPORTS:
         from .bootstrap.runtime import bootstrap_runtime
 
-        warnings.warn(
-            f"ume.{name} now requires explicit runtime bootstrap; falling back to "
-            "compatibility shim. Call ume.bootstrap.runtime.bootstrap_runtime() "
-            "from service entry points.",
-            DeprecationWarning,
+        warn_deprecated(
+            "ume.__getattr__.runtime_export_fallback",
+            detail=(
+                f"Requested symbol ume.{name}. Falling back to compatibility shim. "
+                "Call ume.bootstrap.runtime.bootstrap_runtime() from service entry points."
+            ),
             stacklevel=2,
         )
         runtime_exports = bootstrap_runtime(__name__)
@@ -156,10 +157,9 @@ def __getattr__(name: str) -> object:
 
     if name in _COMPAT_EXPORTS:
         mod_name, attr = _COMPAT_EXPORTS[name]
-        warnings.warn(
-            f"ume.{name} is a compatibility export and will move to its module "
-            f"('{mod_name}.{attr}').",
-            DeprecationWarning,
+        warn_deprecated(
+            "ume.__getattr__.compat_exports",
+            detail=f"Requested symbol ume.{name} currently resolves to {mod_name}.{attr}.",
             stacklevel=2,
         )
         value: Any = getattr(import_module(mod_name), attr)

--- a/src/ume/deprecations.py
+++ b/src/ume/deprecations.py
@@ -1,0 +1,97 @@
+"""Central deprecation registry and runtime warning policy for UME."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+import warnings
+
+RUNTIME_WARNING_POLICY = {
+    "pre_sunset": "emit DeprecationWarning on each legacy shim access",
+    "post_sunset": "remove shim; if temporarily retained, emit DeprecationWarning with past-sunset marker",
+}
+
+
+@dataclass(frozen=True)
+class DeprecationSpec:
+    """Declarative metadata for one deprecated API entrypoint."""
+
+    key: str
+    replacement: str
+    sunset_version: str
+    sunset_date: date
+    status: str
+    removal_note: str | None = None
+
+
+DEPRECATION_REGISTRY: dict[str, DeprecationSpec] = {
+    "ume.projection_engine.run_projection_engine": DeprecationSpec(
+        key="ume.projection_engine.run_projection_engine",
+        replacement="ume.services.projection_worker.run_projection_worker",
+        sunset_version="0.2.0",
+        sunset_date=date(2026, 1, 31),
+        status="removed",
+        removal_note="Removed after sunset; use projection_worker entrypoint.",
+    ),
+    "ume.pipeline.graph_consumer.run_graph_consumer": DeprecationSpec(
+        key="ume.pipeline.graph_consumer.run_graph_consumer",
+        replacement="ume.pipeline.graph_consumer.run_event_pipeline_consumer",
+        sunset_version="0.2.0",
+        sunset_date=date(2026, 1, 31),
+        status="removed",
+        removal_note="Removed after sunset; renamed to explicit orchestrator consumer.",
+    ),
+    "ume.services.mutate.run_mutation": DeprecationSpec(
+        key="ume.services.mutate.run_mutation",
+        replacement="ume.services.event_processor.DEFAULT_EVENT_PROCESSOR.process_payload",
+        sunset_version="0.3.0",
+        sunset_date=date(2026, 7, 1),
+        status="active",
+    ),
+    "ume.services.mutate.run_mutation_async": DeprecationSpec(
+        key="ume.services.mutate.run_mutation_async",
+        replacement="ume.services.event_processor.DEFAULT_EVENT_PROCESSOR.process_payload_async",
+        sunset_version="0.3.0",
+        sunset_date=date(2026, 7, 1),
+        status="active",
+    ),
+    "ume.__getattr__.runtime_export_fallback": DeprecationSpec(
+        key="ume.__getattr__.runtime_export_fallback",
+        replacement="ume.bootstrap.runtime.bootstrap_runtime",
+        sunset_version="0.3.0",
+        sunset_date=date(2026, 7, 1),
+        status="active",
+    ),
+    "ume.__getattr__.compat_exports": DeprecationSpec(
+        key="ume.__getattr__.compat_exports",
+        replacement="Direct module imports from canonical module paths",
+        sunset_version="0.4.0",
+        sunset_date=date(2026, 10, 1),
+        status="active",
+    ),
+    "ume.stream_processor": DeprecationSpec(
+        key="ume.stream_processor",
+        replacement="ume.pipeline.stream_processor",
+        sunset_version="0.3.0",
+        sunset_date=date(2026, 7, 1),
+        status="active",
+    ),
+}
+
+
+def is_past_sunset(spec: DeprecationSpec, *, now: datetime | None = None) -> bool:
+    current = (now or datetime.now(tz=UTC)).date()
+    return current > spec.sunset_date
+
+
+def warn_deprecated(key: str, *, detail: str | None = None, stacklevel: int = 2) -> None:
+    spec = DEPRECATION_REGISTRY[key]
+    message = (
+        f"{spec.key} is deprecated; use {spec.replacement}. "
+        f"Sunset {spec.sunset_version} ({spec.sunset_date.isoformat()})."
+    )
+    if detail:
+        message = f"{message} {detail}"
+    if is_past_sunset(spec):
+        message = f"{message} [PAST_SUNSET]"
+    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)

--- a/src/ume/pipeline/graph_consumer.py
+++ b/src/ume/pipeline/graph_consumer.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import logging
-import warnings
 
 from confluent_kafka import Consumer, KafkaException, KafkaError
 
@@ -29,7 +28,7 @@ DEFAULT_GROUP_ID = settings.KAFKA_GROUP_ID
 VALID_EVENT_TYPES = {e.value for e in EventType}
 
 
-def run_graph_consumer(
+def run_event_pipeline_consumer(
     graph: IGraphAdapter,
     *,
     group_id: str | None = None,
@@ -59,11 +58,6 @@ def run_graph_consumer(
             return
         owns_consumer = True
 
-    warnings.warn(
-        "ume.pipeline.graph_consumer.run_graph_consumer is deprecated; use ume.services.event_processor.EventProcessorService in integrations by 2026-01-31",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     processor = EventProcessorService()
 
     def _record_invalid_event(*, offset: int, envelope: PipelineEnvelope) -> None:

--- a/src/ume/projection_engine.py
+++ b/src/ume/projection_engine.py
@@ -1,110 +1,15 @@
-"""Kafka consumer that projects sanitized events into the graph."""
+"""Projection worker entrypoint.
+
+This module previously exposed ``run_projection_engine`` as a compatibility shim.
+The shim was removed after its deprecation sunset; use
+``ume.services.projection_worker.run_projection_worker`` directly.
+"""
 
 from __future__ import annotations
 
-import json
-import logging
-import warnings
+from .services.projection_worker import main, run_projection_worker
 
-from confluent_kafka import Consumer, KafkaError, KafkaException
-
-from .config import settings
-from .utils import ssl_config
-from .event import EventError
-from .events.types import EventType
-from .services.mutate import (
-    MutationError,
-    build_graph_projector as _build_graph_projector,
-    raise_for_rejected_outcome,
-)
-from .services.event_processor import DEFAULT_EVENT_PROCESSOR
-from .graph_adapter import IGraphAdapter
-from .logging_utils import configure_logging
-
-
-configure_logging()
-logger = logging.getLogger(__name__)
-
-BOOTSTRAP_SERVERS = settings.KAFKA_BOOTSTRAP_SERVERS
-TOPIC = settings.KAFKA_CLEAN_EVENTS_TOPIC
-GROUP_ID = settings.KAFKA_GROUP_ID
-
-VALID_EVENT_TYPES = {e.value for e in EventType}
-
-# compatibility export retained for legacy tests/integrations
-build_graph_projector = _build_graph_projector
-
-
-def run_projection_engine(
-    graph: IGraphAdapter,
-    *,
-    group_id: str | None = None,
-    consumer: Consumer | None = None,
-) -> None:
-    """Consume sanitized events and update ``graph`` accordingly."""
-    warnings.warn(
-        "ume.projection_engine.run_projection_engine is deprecated; use ume.services.event_processor.EventProcessorService-based consumers by 2026-01-31",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    gid = group_id or GROUP_ID
-    owns_consumer = False
-    if consumer is None:
-        conf = {
-            "bootstrap.servers": BOOTSTRAP_SERVERS,
-            "group.id": gid,
-            "auto.offset.reset": "earliest",
-        }
-        conf.update(ssl_config())
-        try:
-            consumer = Consumer(conf)
-            consumer.subscribe([TOPIC])
-        except KafkaException as exc:  # pragma: no cover - network errors
-            logger.error("Failed to start projection consumer: %s", exc)
-            return
-        owns_consumer = True
-
-    projector = build_graph_projector(graph, classify=False)
-    logger.info("Projection engine started with group_id %s", gid)
-    try:
-        while True:
-            try:
-                msg = consumer.poll(1.0)
-            except KafkaException as exc:  # pragma: no cover - network errors
-                logger.error("Poll failed: %s", exc)
-                continue
-            if msg is None:
-                continue
-            if msg.error():
-                if msg.error().code() != KafkaError._PARTITION_EOF:
-                    logger.error("Kafka error: %s", msg.error())
-                continue
-
-            try:
-                data = json.loads(msg.value().decode("utf-8"))
-                envelope = DEFAULT_EVENT_PROCESSOR.process_payload(
-                    data,
-                    source="projection_engine",
-                    adapter="kafka",
-                    raw_payload=msg.value(),
-                    projector=projector,
-                )
-                if envelope.event and envelope.event.event_type not in VALID_EVENT_TYPES:
-                    raise EventError(f"unknown_event_type:{envelope.event.event_type}")
-                raise_for_rejected_outcome(envelope)
-            except (json.JSONDecodeError, EventError, MutationError) as exc:
-                logger.error("Invalid event skipped: %s", exc)
-    except KeyboardInterrupt:  # pragma: no cover - manual interrupt
-        logger.info("Projection engine shutting down")
-    finally:
-        if owns_consumer:
-            consumer.close()
-
-def main() -> None:
-    from .resources import create_graph
-
-    graph = create_graph()
-    run_projection_engine(graph)
+__all__ = ["main", "run_projection_worker"]
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution

--- a/src/ume/services/mutate.py
+++ b/src/ume/services/mutate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import warnings
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable
@@ -24,6 +23,7 @@ from ..policy.pipeline import PolicyDecision
 from ..policy.graph_view import build_graph_read_view
 from ..processing import DEFAULT_VERSION, apply_event_to_graph
 from ..vector_outbox import enqueue_vector_outbox_event
+from ..deprecations import warn_deprecated
 
 
 class MutationErrorCategory(str, Enum):
@@ -84,15 +84,11 @@ def run_mutation(
     projector: Callable[[Any], dict[str, Any] | None] | None = None,
     orchestrator: Any | None = None,
 ) -> PipelineEnvelope:
-    warnings.warn(
-        "ume.services.mutate.run_mutation is hard-deprecated; use ume.services.event_processor.DEFAULT_EVENT_PROCESSOR.process_payload",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    warn_deprecated("ume.services.mutate.run_mutation", stacklevel=2)
     if orchestrator is not None:
-        warnings.warn(
-            "orchestrator parameter is ignored; use EventProcessorService directly if you need orchestrator injection",
-            DeprecationWarning,
+        warn_deprecated(
+            "ume.services.mutate.run_mutation",
+            detail="The orchestrator parameter is ignored; use EventProcessorService directly for orchestrator injection.",
             stacklevel=2,
         )
     from .event_processor import DEFAULT_EVENT_PROCESSOR
@@ -116,15 +112,11 @@ async def run_mutation_async(
     projector: Callable[[Any], Any] | None = None,
     orchestrator: Any | None = None,
 ) -> PipelineEnvelope:
-    warnings.warn(
-        "ume.services.mutate.run_mutation_async is hard-deprecated; use ume.services.event_processor.DEFAULT_EVENT_PROCESSOR.process_payload_async",
-        DeprecationWarning,
-        stacklevel=2,
-    )
+    warn_deprecated("ume.services.mutate.run_mutation_async", stacklevel=2)
     if orchestrator is not None:
-        warnings.warn(
-            "orchestrator parameter is ignored; use EventProcessorService directly if you need orchestrator injection",
-            DeprecationWarning,
+        warn_deprecated(
+            "ume.services.mutate.run_mutation_async",
+            detail="The orchestrator parameter is ignored; use EventProcessorService directly for orchestrator injection.",
             stacklevel=2,
         )
     from .event_processor import DEFAULT_EVENT_PROCESSOR

--- a/src/ume/stream_processor.py
+++ b/src/ume/stream_processor.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from .deprecations import warn_deprecated
 from .pipeline.stream_processor import app, build_app, main
+
+warn_deprecated("ume.stream_processor", stacklevel=2)
 
 __all__ = ["app", "build_app", "main"]

--- a/tests/integration/test_api_kafka_golden_path.py
+++ b/tests/integration/test_api_kafka_golden_path.py
@@ -92,7 +92,7 @@ def test_golden_path_api_and_kafka_are_equivalent(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(graph_consumer, "event_ledger", ledger)
 
-    graph_consumer.run_graph_consumer(kafka_graph, consumer=consumer)
+    graph_consumer.run_event_pipeline_consumer(kafka_graph, consumer=consumer)
 
     assert api_graph.dump() == kafka_graph.dump()
     assert ledger.last_processed_offset == len(events) - 1

--- a/tests/integration/test_pipeline_end_to_end.py
+++ b/tests/integration/test_pipeline_end_to_end.py
@@ -127,7 +127,7 @@ def test_pipeline_end_to_end(tmp_path, monkeypatch):
     register_listener(listener)
 
     consumer_thread = threading.Thread(
-        target=graph_consumer.run_graph_consumer,
+        target=graph_consumer.run_event_pipeline_consumer,
         args=(graph,),
         kwargs={"group_id": "pipeline_group"},
     )
@@ -171,7 +171,7 @@ def test_generic_events_go_to_ledger(tmp_path, monkeypatch, caplog):
 
     graph = MockGraph()
     with caplog.at_level("WARNING"):
-        graph_consumer.run_graph_consumer(graph, group_id="g")
+        graph_consumer.run_event_pipeline_consumer(graph, group_id="g")
 
     assert ledger.range() == [
         (0, {"eventType": "CUSTOM", "timestamp": 1, "payload": {"foo": "bar"}})
@@ -200,7 +200,7 @@ def test_generic_enveloped_events_go_to_ledger(tmp_path, monkeypatch, caplog):
 
     graph = MockGraph()
     with caplog.at_level("WARNING"):
-        graph_consumer.run_graph_consumer(graph, group_id="g")
+        graph_consumer.run_event_pipeline_consumer(graph, group_id="g")
 
     assert ledger.range() == [
         (0, {"eventType": "CUSTOM", "timestamp": 1, "payload": {"foo": "bar"}})

--- a/tests/integration/test_projection_engine_kafka.py
+++ b/tests/integration/test_projection_engine_kafka.py
@@ -57,7 +57,7 @@ def test_projection_engine_kafka() -> None:
         consumer.subscribe([topic])
 
         graph = MockGraph()
-        projection_engine.run_projection_engine(graph, consumer=consumer)
+        projection_engine.run_projection_worker(graph, consumer=consumer)
         consumer.close()
 
         assert graph.get_node("n1") == {"type": "User"}

--- a/tests/test_deprecated_callsites.py
+++ b/tests/test_deprecated_callsites.py
@@ -1,0 +1,5 @@
+from scripts.check_deprecated_callsites import find_violations
+
+
+def test_no_new_deprecated_callsites() -> None:
+    assert find_violations() == []

--- a/tests/test_graph_consumer.py
+++ b/tests/test_graph_consumer.py
@@ -56,14 +56,18 @@ def test_graph_consumer_applies_events(tmp_path, monkeypatch: pytest.MonkeyPatch
             "eventId": "evt-1",
             "timestamp": 1,
             "nodeId": "n1",
-            "payload": {"node_id": "n1"},
+            "producerId": "p1",
+            "tenant": "t1",
+            "payload": {"node_id": "n1", "acl": {"t1": ["p1"]}},
         },
         {
             "eventType": "CREATE_NODE",
             "eventId": "evt-2",
             "timestamp": 1,
             "nodeId": "n2",
-            "payload": {"node_id": "n2"},
+            "producerId": "p1",
+            "tenant": "t1",
+            "payload": {"node_id": "n2", "acl": {"t1": ["p1"]}},
         },
         {
             "eventType": "CREATE_EDGE",
@@ -72,7 +76,9 @@ def test_graph_consumer_applies_events(tmp_path, monkeypatch: pytest.MonkeyPatch
             "nodeId": "n1",
             "targetNodeId": "n2",
             "label": "TAGGED_AS",
-            "payload": {},
+            "producerId": "p1",
+            "tenant": "t1",
+            "payload": {"acl": {"t1": ["p1"]}},
         },
     ]
     msgs = [DummyMessage(json.dumps(e).encode("utf-8"), i) for i, e in enumerate(events)]
@@ -80,7 +86,7 @@ def test_graph_consumer_applies_events(tmp_path, monkeypatch: pytest.MonkeyPatch
     _patch_modules(monkeypatch, consumer, ledger)
 
     graph = MockGraph()
-    graph_consumer.run_graph_consumer(graph)
+    graph_consumer.run_event_pipeline_consumer(graph)
 
     assert graph.node_exists("n1")
     assert graph.node_exists("n2")
@@ -97,7 +103,9 @@ def test_graph_consumer_replay_is_deterministic_for_rejections(
             "eventId": "det-1",
             "timestamp": 1,
             "nodeId": "n1",
-            "payload": {"node_id": "n1"},
+            "producerId": "p1",
+            "tenant": "t1",
+            "payload": {"node_id": "n1", "acl": {"t1": ["p1"]}},
         },
         {
             "eventType": "CREATE_EDGE",
@@ -106,13 +114,17 @@ def test_graph_consumer_replay_is_deterministic_for_rejections(
             "nodeId": "n1",
             "targetNodeId": "n2",
             "label": "UNKNOWN_LABEL",
-            "payload": {},
+            "producerId": "p1",
+            "tenant": "t1",
+            "payload": {"acl": {"t1": ["p1"]}},
         },
         {
             "eventType": "NOT_A_REAL_EVENT",
             "eventId": "det-3",
             "timestamp": 1,
-            "payload": {},
+            "producerId": "p1",
+            "tenant": "t1",
+            "payload": {"acl": {"t1": ["p1"]}},
         },
     ]
 
@@ -123,7 +135,7 @@ def test_graph_consumer_replay_is_deterministic_for_rejections(
         _patch_modules(monkeypatch, consumer, ledger)
 
         graph = MockGraph()
-        graph_consumer.run_graph_consumer(graph)
+        graph_consumer.run_event_pipeline_consumer(graph)
         rejected = [item for item in ledger.range() if item[1].get("eventType") == "REJECTED_EVENT"]
         return graph.dump(), rejected
 

--- a/tests/test_projection_engine_event_types.py
+++ b/tests/test_projection_engine_event_types.py
@@ -1,7 +1,7 @@
 import json
 
 from ume import MockGraph
-from ume import projection_engine
+from ume.services import projection_worker
 
 
 class DummyMessage:
@@ -43,7 +43,7 @@ def test_projection_engine_event_type_contract_import_path(monkeypatch) -> None:
 
         return _project
 
-    monkeypatch.setattr(projection_engine, "build_graph_projector", _capture_projector)
+    monkeypatch.setattr(projection_worker, "build_graph_projector", _capture_projector)
 
     consumer = DummyConsumer(
         [
@@ -52,11 +52,13 @@ def test_projection_engine_event_type_contract_import_path(monkeypatch) -> None:
                 "eventId": "evt-1",
                 "timestamp": 1,
                 "nodeId": "n1",
-                "payload": {"node_id": "n1", "type": "User"},
+                "producerId": "p1",
+                "tenant": "t1",
+                "payload": {"node_id": "n1", "type": "User", "acl": {"t1": ["p1"]}},
             }
         ]
     )
 
-    projection_engine.run_projection_engine(MockGraph(), consumer=consumer)
+    projection_worker.run_projection_worker(MockGraph(), consumer=consumer)
 
     assert captured_event_types == ["CREATE_NODE"]


### PR DESCRIPTION
### Motivation
- Consolidate scattered ad-hoc deprecation warnings into a single registry so sunset metadata, replacement guidance, and runtime behaviour are consistent across the codebase.
- Remove compatibility shims that are past their sunset date to simplify the public surface and encourage migration to orchestrator-native entrypoints.
- Prevent accidental re-introduction of deprecated callsites by adding an automated CI check that fails on new uses of tracked shims.

### Description
- Added a central deprecation registry and helper `src/ume/deprecations.py` containing per-entrypoint `DeprecationSpec` metadata and `warn_deprecated(...)` to standardize runtime warnings.
- Replaced module-local `warnings.warn(...)` calls with `warn_deprecated(...)` calls in `src/ume/services/mutate.py` and `src/ume/__init__.py`, and added registry-backed warnings for `src/ume/stream_processor.py`.
- Removed past-sunset compatibility shims by turning `src/ume/projection_engine.py` into a thin re-export of `run_projection_worker`/`main`, and renamed the pipeline consumer to `run_event_pipeline_consumer` in `src/ume/pipeline/graph_consumer.py` (removed its local shim warning).
- Added a CI guard script `scripts/check_deprecated_callsites.py` and test `tests/test_deprecated_callsites.py` to detect newly introduced callsites for remaining active shims (allowlist-driven), and updated docs (`docs/PROJECTION_ENGINE.md`, `docs/ARCHITECTURE_OVERVIEW.md`) with an inventory and migration snippets mapping legacy APIs to `EventProcessorService` / `EventPipelineOrchestrator` paths.
- Updated tests and integration callsites to the new entrypoint names and adjusted test payloads where necessary so behaviour remains deterministic under current policy stages.

### Testing
- Ran lint checks with `python -m ruff check ...` against changed modules, and the linter reported no failures after fixes.
- Executed the deprecated callsite guard with `python scripts/check_deprecated_callsites.py`, which reported no violations.
- Ran focused unit tests with `pytest -q tests/test_deprecated_callsites.py tests/test_graph_consumer.py tests/test_projection_engine_event_types.py tests/test_import_safety.py`, and all selected tests passed (6 passed, 1 DeprecationWarning observed for a compat export during import).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2caada48083268196d61a1d12fe2f)