### PR TITLE
Tighten CI quality gates and align contributor docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           npm ci
           npm run build
 
-  schema-compatibility:
+  event-schema-regression-required:
     runs-on: ubuntu-latest
     needs: lint-and-install
     if: needs.lint-and-install.outputs.run == 'true'
@@ -58,7 +58,7 @@ jobs:
 
   architecture-tests-required:
     runs-on: ubuntu-latest
-    needs: [lint-and-install, schema-compatibility]
+    needs: [lint-and-install, event-schema-regression-required]
     if: needs.lint-and-install.outputs.run == 'true'
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +72,7 @@ jobs:
 
   unit-tests-required:
     runs-on: ubuntu-latest
-    needs: [lint-and-install, schema-compatibility]
+    needs: [lint-and-install, event-schema-regression-required]
     if: needs.lint-and-install.outputs.run == 'true'
     env:
       UME_AUDIT_SIGNING_KEY: test-key
@@ -97,8 +97,8 @@ jobs:
         run: |
           poetry run pytest --cov=ume --cov-report xml -m "not integration"
           poetry run pytest tests/test_dossier_migration.py
-      - name: Coverage stage 1 (fail under 50%)
-        run: poetry run coverage report --fail-under=50
+      - name: Coverage stage 2 (fail under 70%)
+        run: poetry run coverage report --fail-under=70
       - name: Upload unit coverage artifact
         uses: actions/upload-artifact@v4
         with:
@@ -133,7 +133,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11']
-        coverage-threshold: [65, 75]
+        coverage-threshold: [80, 85]
     env:
       UME_AUDIT_SIGNING_KEY: test-key
       UME_ENCRYPTION_ENABLED: 'true'
@@ -151,7 +151,22 @@ jobs:
         run: poetry run coverage report --fail-under=${{ matrix.coverage-threshold }}
 
 
-  replay-regression:
+  policy-outcomes-regression-required:
+    runs-on: ubuntu-latest
+    needs: lint-and-install
+    if: needs.lint-and-install.outputs.run == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-poetry
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: poetry install --with dev --extras vector --extras embedding
+      - name: Run policy outcomes regression suite
+        run: poetry run pytest tests/test_policy_pipeline_parity.py tests/test_security_controls.py
+
+
+  replay-determinism-required:
     runs-on: ubuntu-latest
     needs: lint-and-install
     if: needs.lint-and-install.outputs.run == 'true'
@@ -183,7 +198,7 @@ jobs:
 
   compose-smoke:
     runs-on: ubuntu-latest
-    needs: [architecture-tests-required, unit-tests-required, changed-lines-coverage-required, integration-tests-required]
+    needs: [architecture-tests-required, unit-tests-required, changed-lines-coverage-required, policy-outcomes-regression-required, replay-determinism-required, integration-tests-required]
     steps:
       - uses: actions/checkout@v4
       - name: Start stack

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,16 +93,16 @@ pre-commit run detect-secrets --files path/to/file
 The CI suite is split into explicit required and optional quality gates:
 
 - **Required gates (must pass to merge):**
-  - Lint/install bootstrap and schema-compatibility checks.
-  - Architecture suite (`tests/architecture`) on Python 3.12.
-  - Unit suite on Python 3.12 with staged total coverage gate at **50%**.
+  - Lint/install bootstrap, event-schema regression checks, and architecture suite (`tests/architecture`) on Python 3.12.
+  - Unit suite on Python 3.12 with staged total coverage gate at **70%**.
   - Changed-lines coverage enforcement with `diff-cover` at **85%** against `origin/main`.
+  - Policy outcomes regression suite (`tests/test_policy_pipeline_parity.py` and `tests/test_security_controls.py`) and replay determinism regression suite (`tests/test_replay_regression.py`) on Python 3.12.
   - Integration suite on Python 3.12.
   - Docker compose smoke checks.
 - **Optional gates (informational, non-blocking):**
-  - Additional unit matrix runs on Python 3.10/3.11 with staged aspirational coverage gates at **65%** and **75%**.
+  - Additional unit matrix runs on Python 3.10/3.11 with staged aspirational coverage gates at **80%** and **85%**.
 
-The staged thresholds are designed to ratchet quality progressively (`30 → 50 → 65 → 75`) while avoiding sudden contributor disruption.
+The staged thresholds are designed to ratchet quality progressively (`30 → 50 → 70 → 80+`) while avoiding sudden contributor disruption.
 
 ### Test depth rubric by feature risk
 

--- a/README.md
+++ b/README.md
@@ -484,14 +484,23 @@ Strive for clear, concise tests that verify specific behaviors and edge cases.
 
 ## CI Workflow
 
-This project uses GitHub Actions to run linting, type checks, unit tests, and
-coverage reporting. The `coverage` job executes on a self-hosted runner as
-described in [docs/SELF_HOSTED_RUNNER.md](docs/SELF_HOSTED_RUNNER.md). It uses
-`concurrency` with `cancel-in-progress` to terminate earlier runs on the same
-branch. Steps are skipped when only documentation or comments change, so tests
-and linters run only for code modifications. CI validates multiple Python
-versions via a matrix (`3.10`, `3.11`, and `3.12`) in
-[.github/workflows/ci.yml](.github/workflows/ci.yml).
+This project uses GitHub Actions to run required and optional quality gates in
+[.github/workflows/ci.yml](.github/workflows/ci.yml). Steps are skipped when a
+pull request changes only documentation or comments; mutation/code changes must
+pass all required jobs.
+
+Required CI gates include:
+- event schema regression compatibility checks;
+- architecture tests (`tests/architecture`);
+- unit tests on Python 3.12 with total coverage `--fail-under=70`;
+- changed-lines coverage enforcement with `diff-cover --fail-under=85`;
+- policy outcomes regression checks (`tests/test_policy_pipeline_parity.py` and
+  `tests/test_security_controls.py`);
+- replay determinism regression checks (`tests/test_replay_regression.py`);
+- integration tests and compose smoke checks.
+
+Optional CI matrix runs on Python 3.10/3.11 and currently reports aspirational
+coverage thresholds staged at 80% and 85%.
 
 ## Access Control
 


### PR DESCRIPTION
### Motivation
- Raise enforced coverage and aspirational matrix thresholds so CI gradually ratchets quality toward target coverage levels. 
- Make explicit regression gates for event schema, policy outcomes, and replay determinism so these important regressions are required rather than implicit. 
- Keep the changed-lines coverage gate strict for mutation/code PRs so incremental changes remain well-covered. 

### Description
- Updated CI workflow in ` .github/workflows/ci.yml` to raise the required unit coverage gate to `--fail-under=70`, change the optional matrix thresholds to `80/85`, and preserve `diff-cover --fail-under=85` for changed-lines enforcement. 
- Added explicit required jobs: `event-schema-regression-required`, `policy-outcomes-regression-required`, and `replay-determinism-required`, and wired them into downstream `needs` (including `compose-smoke`). 
- Synced contributor guidance by updating `README.md` and `CONTRIBUTING.md` to reflect the new required gates and the real enforced thresholds. 

### Testing
- Ran `pre-commit` against the modified files (`.github/workflows/ci.yml`, `README.md`, `CONTRIBUTING.md`) and the hooks completed successfully for the changed files. 
- Executed the targeted regression suites used by the new CI gates with `poetry run pytest tests/test_policy_pipeline_parity.py tests/test_security_controls.py tests/test_replay_regression.py`. 
- The targeted pytest run completed with `2` tests passing and `6` failing (automated test failures present in the current branch state).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ce5987048326aa3698b05e855efa)