### PR TITLE
Add dashboard SSE stream, frontend stream subscription with REST fallback and docs

### DIFF
--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -27,8 +27,20 @@ This document describes UI architecture in a framework-neutral way, then records
 ### Real-time consumption pattern
 
 - Use a stream client abstraction for `GET /graph/digest/stream`.
+- Use a dashboard stream client abstraction for `GET /dashboard/stream` to drive high-churn panels (`stats`, `recent_events`, PII redaction count).
 - Persist last processed event ID per session to support reconnection.
 - Treat `control.backpressure` events as data-loss signals and trigger a catch-up flow.
+- Keep REST compatibility paths (`/dashboard/stats`, `/dashboard/recent_events`, `/pii/redactions`) for explicit refresh and stream fallback.
+
+### Transport feature flags
+
+The React SPA selects transport at runtime using Vite env flags:
+
+- `VITE_ENABLE_DASHBOARD_STREAM` (`true` by default): master switch for stream subscription.
+- `VITE_DASHBOARD_STREAM_TRANSPORT` (`sse` default): current transport selector.
+- `VITE_DASHBOARD_REST_FALLBACK` (`true` default): whether to fall back to REST when stream errors or backpressure occurs.
+
+Backend capability hints are available via `GET /dashboard/transport_features`.
 
 ### Testing strategy
 

--- a/docs/REALTIME_STREAMING.md
+++ b/docs/REALTIME_STREAMING.md
@@ -3,8 +3,10 @@
 UME exposes a server-side real-time projection feed over **SSE** at:
 
 - `GET /graph/digest/stream`
+- `GET /dashboard/stream`
 
 This endpoint is the canonical HTTP topic projection API for graph digest consumption.
+`/dashboard/stream` is a dashboard-focused projection that emits sanitized high-churn panel state.
 
 ## Authentication
 
@@ -60,6 +62,32 @@ Control channel payload follows `ume.realtime_contracts.GraphDigestControlEvent`
 }
 ```
 
+### `dashboard_digest`
+
+Dashboard payload follows `ume.realtime_contracts.DashboardDigestEvent`.
+
+```json
+{
+  "cursor_offset": 120,
+  "stats": {
+    "node_count": 32,
+    "edge_count": 71,
+    "vector_index_size": 32
+  },
+  "recent_events": [
+    {
+      "offset": 120,
+      "event_id": "evt-120",
+      "event_type": "UPDATE_NODE_ATTRIBUTES",
+      "payload_hash": "8f7d..."
+    }
+  ],
+  "redacted_count": 11
+}
+```
+
+`recent_events` contains graph digests only (event metadata + payload hash), never raw payload bodies.
+
 ## Backpressure behavior
 
 The stream uses a bounded in-memory queue. When the consumer cannot keep up:
@@ -69,6 +97,14 @@ The stream uses a bounded in-memory queue. When the consumer cannot keep up:
 3. a `control`/`backpressure` event reports how many were dropped.
 
 Clients should treat `backpressure` as a gap signal and resynchronize using the reported `cursor_offset`.
+
+## Reconnection and backfill semantics
+
+- Clients should persist the last consumed SSE `id` and reconnect with `Last-Event-ID`.
+- Server resumes from `Last-Event-ID + 1`.
+- If no reconnect marker is available, clients may use `cursor` for explicit backfill start.
+- If both are supplied, the greater offset wins.
+- On `control.kind=backpressure`, clients should treat local state as potentially stale and perform a REST catch-up (`/dashboard/stats`, `/dashboard/recent_events`, `/pii/redactions`) before continuing stream consumption.
 
 ## Transport notes
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,11 +10,10 @@ import GraphNetwork from './GraphNetwork';
 import NodeSearch from './NodeSearch';
 import EdgeList from './EdgeList';
 import LedgerHistory from './LedgerHistory';
+import { subscribeDashboardStream } from './realtimeStream';
 
 const POLICY_CONTENT = {
   'allow.rego': `package ume
-
-# Allow an event only when no deny rules match
 
 default allow = false
 
@@ -26,16 +25,12 @@ allow {
 `,
   'deny_admin_role.rego': `package ume
 
-# Deny updating a node role to "admin"
-
 admin_role_update {
     input.event_type == "UPDATE_NODE_ATTRIBUTES"
     input.payload.attributes.role == "admin"
 }
 `,
   'deny_forbidden_node.rego': `package ume
-
-# Deny creating a node with id "forbidden"
 
 forbidden_node {
     input.event_type == "CREATE_NODE"
@@ -44,8 +39,6 @@ forbidden_node {
 `,
   'extra/deny_admin_edge.rego': `package ume
 
-# Deny creating an edge from the admin node
-
 admin_edge {
     input.event_type == "CREATE_EDGE"
     input.node_id == "admin"
@@ -53,14 +46,22 @@ admin_edge {
 `,
 };
 
+const STREAM_ENABLED = import.meta.env.VITE_ENABLE_DASHBOARD_STREAM !== 'false';
+const STREAM_TRANSPORT = import.meta.env.VITE_DASHBOARD_STREAM_TRANSPORT || 'sse';
+const REST_FALLBACK = import.meta.env.VITE_DASHBOARD_REST_FALLBACK !== 'false';
+
 function App() {
   const [token, setToken] = useState('');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [stats, setStats] = useState(null);
   const [events, setEvents] = useState([]);
+  const [redactedCount, setRedactedCount] = useState(0);
+  const [streamStatus, setStreamStatus] = useState('rest');
   const [policies, setPolicies] = useState([]);
   const [editingPolicy, setEditingPolicy] = useState('');
+
+  const authHeaders = { Authorization: 'Bearer ' + token };
 
   const login = async (e) => {
     e.preventDefault();
@@ -73,16 +74,6 @@ function App() {
     setToken(data.access_token);
   };
 
-  useEffect(() => {
-    if (token) {
-      loadStats();
-      loadEvents();
-      loadPolicies();
-    }
-  }, [token]);
-
-  const authHeaders = { Authorization: 'Bearer ' + token };
-
   const loadStats = async () => {
     const res = await fetch('/dashboard/stats', { headers: authHeaders });
     if (res.ok) setStats(await res.json());
@@ -93,16 +84,66 @@ function App() {
     if (res.ok) setEvents(await res.json());
   };
 
+  const loadRedactions = async () => {
+    const res = await fetch('/pii/redactions', { headers: authHeaders });
+    if (res.ok) {
+      const data = await res.json();
+      setRedactedCount(data.redacted || 0);
+    }
+  };
+
   const loadPolicies = async () => {
     const res = await fetch('/policies', { headers: authHeaders });
     if (res.ok) {
       const data = await res.json();
       const active = new Set(data.policies);
-      setPolicies(
-        Object.keys(POLICY_CONTENT).map((name) => ({ name, enabled: active.has(name) }))
-      );
+      setPolicies(Object.keys(POLICY_CONTENT).map((name) => ({ name, enabled: active.has(name) })));
     }
   };
+
+  useEffect(() => {
+    if (!token) return;
+
+    loadPolicies();
+
+    const canStream = STREAM_ENABLED && STREAM_TRANSPORT === 'sse';
+    if (!canStream) {
+      setStreamStatus('rest');
+      void loadStats();
+      void loadEvents();
+      void loadRedactions();
+      return;
+    }
+
+    setStreamStatus('connecting');
+    const unsubscribe = subscribeDashboardStream({
+      token,
+      onDigest: (digest) => {
+        setStats(digest.stats);
+        setEvents(digest.recent_events);
+        setRedactedCount(digest.redacted_count);
+        setStreamStatus('connected');
+      },
+      onControl: (control) => {
+        if (control.kind === 'backpressure' && REST_FALLBACK) {
+          void loadStats();
+          void loadEvents();
+          void loadRedactions();
+        }
+      },
+      onError: () => {
+        if (REST_FALLBACK) {
+          setStreamStatus('rest-fallback');
+          void loadStats();
+          void loadEvents();
+          void loadRedactions();
+        }
+      },
+      onReconnect: () => setStreamStatus('reconnecting'),
+    });
+
+    return () => unsubscribe();
+  }, [token]);
 
   const togglePolicy = async (name) => {
     const p = policies.find((x) => x.name === name);
@@ -118,10 +159,6 @@ function App() {
     loadPolicies();
   };
 
-  const editPolicy = (name) => {
-    setEditingPolicy(name);
-  };
-
   const Dashboard = () => (
     <div style={{ padding: '20px', fontFamily: 'sans-serif' }}>
       <button onClick={loadStats}>Refresh Stats</button>
@@ -131,13 +168,12 @@ function App() {
       <button onClick={loadPolicies} style={{ marginLeft: '4px' }}>
         Refresh Policies
       </button>
-      {stats && (
-        <pre style={{ background: '#eee', padding: '8px' }}>{JSON.stringify(stats, null, 2)}</pre>
-      )}
-      {events.length > 0 && (
-        <pre style={{ background: '#eee', padding: '8px' }}>{JSON.stringify(events, null, 2)}</pre>
-      )}
-      <PiiStatus token={token} />
+      <div style={{ marginTop: '8px', fontSize: '12px', color: '#555' }}>
+        Dashboard transport: {streamStatus}
+      </div>
+      {stats && <pre style={{ background: '#eee', padding: '8px' }}>{JSON.stringify(stats, null, 2)}</pre>}
+      {events.length > 0 && <pre style={{ background: '#eee', padding: '8px' }}>{JSON.stringify(events, null, 2)}</pre>}
+      <PiiStatus count={redactedCount} />
       <Recommendations token={token} />
       <ConsentLedger token={token} />
       <Recall token={token} />
@@ -150,12 +186,8 @@ function App() {
         {policies.map((p) => (
           <li key={p.name}>
             <label>
-              <input
-                type="checkbox"
-                checked={p.enabled}
-                onChange={() => togglePolicy(p.name)}
-              />
-              <span onClick={() => editPolicy(p.name)} style={{ cursor: 'pointer' }}>
+              <input type="checkbox" checked={p.enabled} onChange={() => togglePolicy(p.name)} />
+              <span onClick={() => setEditingPolicy(p.name)} style={{ cursor: 'pointer' }}>
                 {p.name}
               </span>
             </label>

--- a/frontend/src/PiiStatus.jsx
+++ b/frontend/src/PiiStatus.jsx
@@ -1,21 +1,3 @@
-import { useEffect, useState } from 'react';
-
-export default function PiiStatus({ token }) {
-  const [count, setCount] = useState(0);
-
-  useEffect(() => {
-    if (!token) return;
-    const id = setInterval(async () => {
-      const res = await fetch('/pii/redactions', {
-        headers: { Authorization: 'Bearer ' + token },
-      });
-      if (res.ok) {
-        const data = await res.json();
-        setCount(data.redacted);
-      }
-    }, 1000);
-    return () => clearInterval(id);
-  }, [token]);
-
+export default function PiiStatus({ count }) {
   return <div>Redacted events: {count}</div>;
 }

--- a/frontend/src/PiiStatus.test.jsx
+++ b/frontend/src/PiiStatus.test.jsx
@@ -1,39 +1,19 @@
-import { render, screen, waitFor, cleanup } from '@testing-library/react';
-import { vi, describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
 import PiiStatus from './PiiStatus';
-
-function mockFetch(data) {
-  global.fetch = vi.fn(() =>
-    Promise.resolve({
-      ok: true,
-      json: () => Promise.resolve(data),
-    }),
-  );
-}
 
 describe('PiiStatus', () => {
   afterEach(() => {
     cleanup();
-    vi.useRealTimers();
-    vi.restoreAllMocks();
   });
 
-  it('polls and displays redaction count', async () => {
-    const intervals = [];
-    vi.spyOn(global, 'setInterval').mockImplementation((fn) => {
-      intervals.push(fn);
-      return 1;
-    });
-    mockFetch({ redacted: 3 });
-    render(<PiiStatus token="t" />);
-    await intervals[0]();
-    await waitFor(() => screen.getByText('Redacted events: 3'));
-    expect(fetch).toHaveBeenCalledWith('/pii/redactions', expect.any(Object));
+  it('renders redaction count', () => {
+    render(<PiiStatus count={3} />);
+    expect(screen.getByText('Redacted events: 3')).toBeTruthy();
   });
 
-  it('does not poll without a token', () => {
-    mockFetch({ redacted: 1 });
-    render(<PiiStatus />);
-    expect(fetch).not.toHaveBeenCalled();
+  it('defaults to zero-ish display via provided value', () => {
+    render(<PiiStatus count={0} />);
+    expect(screen.getByText('Redacted events: 0')).toBeTruthy();
   });
 });

--- a/frontend/src/realtimeStream.js
+++ b/frontend/src/realtimeStream.js
@@ -1,0 +1,72 @@
+const DEFAULT_RECONNECT_MS = 1000;
+const MAX_RECONNECT_MS = 8000;
+
+function parseSseChunk(state, chunk, onFrame) {
+  state.buffer += chunk;
+  const frames = state.buffer.split('\n\n');
+  state.buffer = frames.pop() || '';
+
+  for (const rawFrame of frames) {
+    const lines = rawFrame.split('\n');
+    const frame = { event: 'message', data: '', id: undefined };
+    for (const line of lines) {
+      if (line.startsWith('event:')) frame.event = line.slice(6).trim();
+      if (line.startsWith('data:')) frame.data += `${line.slice(5).trim()}\n`;
+      if (line.startsWith('id:')) frame.id = line.slice(3).trim();
+    }
+    frame.data = frame.data.trim();
+    if (frame.data) onFrame(frame);
+  }
+}
+
+export function subscribeDashboardStream({ token, onDigest, onControl, onError, onReconnect }) {
+  const state = { active: true, buffer: '', reconnectMs: DEFAULT_RECONNECT_MS, lastEventId: null };
+  const decoder = new TextDecoder();
+
+  const connect = async () => {
+    while (state.active) {
+      const params = new URLSearchParams();
+      if (state.lastEventId !== null) params.set('lastEventId', state.lastEventId);
+      const url = `/dashboard/stream${params.size ? `?${params}` : ''}`;
+
+      try {
+        const response = await fetch(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'text/event-stream',
+          },
+        });
+
+        if (!response.ok || !response.body) {
+          throw new Error(`dashboard_stream_http_${response.status}`);
+        }
+
+        state.reconnectMs = DEFAULT_RECONNECT_MS;
+        const reader = response.body.getReader();
+
+        while (state.active) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          parseSseChunk(state, decoder.decode(value, { stream: true }), (frame) => {
+            if (frame.id !== undefined) state.lastEventId = frame.id;
+            if (frame.event === 'dashboard_digest') onDigest(JSON.parse(frame.data));
+            if (frame.event === 'control') onControl(JSON.parse(frame.data));
+          });
+        }
+      } catch (error) {
+        onError(error);
+      }
+
+      if (!state.active) break;
+      onReconnect(state.reconnectMs);
+      await new Promise((resolve) => setTimeout(resolve, state.reconnectMs));
+      state.reconnectMs = Math.min(state.reconnectMs * 2, MAX_RECONNECT_MS);
+    }
+  };
+
+  void connect();
+
+  return () => {
+    state.active = false;
+  };
+}

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -46,6 +46,9 @@ class Settings(BaseSettings):  # type: ignore[misc]
     WATCH_PATHS: list[str] = ["."]
     DAG_RESOURCES: dict[str, int] = {"cpu": 1, "io": 1}
     UME_VALUE_STORE_PATH: str | None = None
+    UME_ENABLE_DASHBOARD_STREAM: bool = True
+    UME_DASHBOARD_STREAM_TRANSPORT: str = "sse"
+    UME_DASHBOARD_REST_FALLBACK: bool = True
 
     # Vector store
     UME_VECTOR_BACKEND: str = "faiss"  # faiss, chroma, or plugin name

--- a/src/ume/dashboard_routes.py
+++ b/src/ume/dashboard_routes.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List
+import asyncio
+import contextlib
+import time
+from typing import Any, AsyncGenerator, Dict, List
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header, Query
+from sse_starlette.sse import EventSourceResponse
 
 from .audit import get_audit_entries
 from .graph_adapter import IGraphAdapter
 from .api_deps import get_current_role, get_graph, get_vector_store
+from .event_ledger import event_ledger
+from .realtime_contracts import DashboardDigestEvent, GraphDigestControlEvent
+from .realtime_digest import to_graph_digest
 from .vector_store import VectorStore
+from .config import settings
 
 router = APIRouter(prefix="/dashboard")
 
@@ -35,3 +43,121 @@ def dashboard_recent_events(
 ) -> List[Dict[str, Any]]:
     entries = get_audit_entries()
     return list(reversed(entries[-limit:]))
+
+
+@router.get("/transport_features")
+def dashboard_transport_features(_: str = Depends(get_current_role)) -> Dict[str, Any]:
+    return {
+        "realtime_dashboard_stream": settings.UME_ENABLE_DASHBOARD_STREAM,
+        "dashboard_stream_transport": settings.UME_DASHBOARD_STREAM_TRANSPORT,
+        "rest_fallback_enabled": settings.UME_DASHBOARD_REST_FALLBACK,
+    }
+
+
+def _redaction_count() -> int:
+    entries = get_audit_entries()
+    return sum(1 for e in entries if "payload_redacted" in str(e.get("reason", "")))
+
+
+def _dashboard_snapshot(cursor_offset: int) -> DashboardDigestEvent:
+    node_count = len(get_graph().get_all_node_ids())
+    edge_count = len(get_graph().get_all_edges())
+    index_size = len(getattr(get_vector_store(), "idx_to_id", []))
+    recent_batch = event_ledger.range(start=max(cursor_offset - 9, 0), end=cursor_offset, limit=10)
+    recent_events = [to_graph_digest(offset, event) for offset, event in recent_batch]
+    return DashboardDigestEvent(
+        cursor_offset=cursor_offset,
+        stats={
+            "node_count": node_count,
+            "edge_count": edge_count,
+            "vector_index_size": index_size,
+        },
+        recent_events=recent_events,
+        redacted_count=_redaction_count(),
+    )
+
+
+@router.get("/stream")
+async def dashboard_stream(
+    cursor: int | None = Query(None, ge=0, description="Start streaming from this ledger offset"),
+    last_event_id: int | None = Query(None, ge=0, alias="lastEventId"),
+    last_event_id_header: int | None = Header(None, alias="Last-Event-ID"),
+    max_events: int | None = Query(None, ge=1, description="Optional cap for emitted digest events"),
+    _: str = Depends(get_current_role),
+) -> EventSourceResponse:
+    queue: asyncio.Queue[dict[str, str]] = asyncio.Queue(maxsize=64)
+    dropped_events = 0
+    stop_event = asyncio.Event()
+
+    resume_from = last_event_id_header if last_event_id_header is not None else last_event_id
+    start_offset = max((cursor if cursor is not None else 0), (resume_from + 1) if resume_from is not None else 0)
+
+    async def _producer() -> None:
+        nonlocal dropped_events
+        next_offset = start_offset
+        emitted = 0
+        heartbeat_interval_s = 5.0
+        last_heartbeat = time.monotonic()
+
+        while not stop_event.is_set():
+            batch = event_ledger.range(start=next_offset, limit=100)
+            if batch:
+                for offset, _ in batch:
+                    frame = {
+                        "event": "dashboard_digest",
+                        "id": str(offset),
+                        "data": _dashboard_snapshot(offset).model_dump_json(),
+                    }
+                    if queue.full():
+                        try:
+                            queue.get_nowait()
+                            dropped_events += 1
+                        except asyncio.QueueEmpty:
+                            pass
+                    await queue.put(frame)
+                    next_offset = offset + 1
+                    emitted += 1
+                    if max_events is not None and emitted >= max_events:
+                        stop_event.set()
+                        break
+                if dropped_events > 0:
+                    ctrl = GraphDigestControlEvent(
+                        kind="backpressure",
+                        cursor_offset=next_offset - 1,
+                        dropped_events=dropped_events,
+                    )
+                    await queue.put({"event": "control", "data": ctrl.model_dump_json()})
+                    dropped_events = 0
+                last_heartbeat = time.monotonic()
+            else:
+                now = time.monotonic()
+                if now - last_heartbeat >= heartbeat_interval_s:
+                    heartbeat = GraphDigestControlEvent(
+                        kind="heartbeat",
+                        cursor_offset=max(next_offset - 1, -1),
+                    )
+                    await queue.put({"event": "control", "data": heartbeat.model_dump_json()})
+                    last_heartbeat = now
+                await asyncio.sleep(0.1)
+
+    async def _gen() -> AsyncGenerator[dict[str, str], None]:
+        producer_task = asyncio.create_task(_producer())
+        try:
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=0.2)
+                except asyncio.TimeoutError:
+                    if stop_event.is_set() and queue.empty():
+                        break
+                    continue
+                yield event
+                await asyncio.sleep(0)
+                if stop_event.is_set() and queue.empty():
+                    break
+        finally:
+            stop_event.set()
+            producer_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await producer_task
+
+    return EventSourceResponse(_gen())

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import hashlib
-import json
 import time
 from typing import Any, AsyncGenerator, Dict, List
 from uuid import uuid4
@@ -34,7 +32,8 @@ from .event import EventError
 from .processing import ProcessingError
 from .graph_schema import DEFAULT_SCHEMA
 from .event_ledger import event_ledger
-from .realtime_contracts import GraphDigestControlEvent, GraphDigestEvent
+from .realtime_contracts import GraphDigestControlEvent
+from .realtime_digest import to_graph_digest
 from .rbac_adapter import AccessDeniedError
 from ume.services.ingest import ingest_event, ingest_events_batch
 
@@ -234,25 +233,6 @@ class EventRequest(BaseModel):
         }
     
 
-def _event_payload_hash(payload: Dict[str, Any] | None) -> str:
-    serialized = json.dumps(payload or {}, sort_keys=True, separators=(",", ":"))
-    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
-
-
-def _to_graph_digest(offset: int, event: Dict[str, Any]) -> GraphDigestEvent:
-    return GraphDigestEvent(
-        offset=offset,
-        event_id=event.get("event_id") or event.get("eventId"),
-        event_type=str(event.get("event_type") or event.get("eventType") or "UNKNOWN"),
-        source_service=event.get("source") or event.get("sourceService"),
-        schema_version=event.get("schema_version") or event.get("schemaVersion"),
-        timestamp=event.get("timestamp"),
-        node_id=event.get("node_id"),
-        target_node_id=event.get("target_node_id") or event.get("targetNodeId"),
-        label=event.get("label"),
-        payload_hash=_event_payload_hash(event.get("payload")),
-    )
-
 
 @router.get("/query")
 def run_cypher(
@@ -365,7 +345,7 @@ async def api_graph_digest_stream(
             batch = event_ledger.range(start=next_offset, limit=100)
             if batch:
                 for offset, event in batch:
-                    digest = _to_graph_digest(offset, event)
+                    digest = to_graph_digest(offset, event)
                     frame = {"event": "graph_digest", "id": str(offset), "data": digest.model_dump_json()}
                     if queue.full():
                         try:

--- a/src/ume/realtime_contracts.py
+++ b/src/ume/realtime_contracts.py
@@ -29,3 +29,11 @@ class GraphDigestControlEvent(BaseModel):
     cursor_offset: int
     dropped_events: int = 0
 
+
+class DashboardDigestEvent(BaseModel):
+    """Sanitized dashboard state emitted for real-time UI updates."""
+
+    cursor_offset: int
+    stats: dict[str, int]
+    recent_events: list[GraphDigestEvent]
+    redacted_count: int

--- a/src/ume/realtime_digest.py
+++ b/src/ume/realtime_digest.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any, Dict
+
+from .realtime_contracts import GraphDigestEvent
+
+
+def event_payload_hash(payload: Dict[str, Any] | None) -> str:
+    serialized = json.dumps(payload or {}, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def to_graph_digest(offset: int, event: Dict[str, Any]) -> GraphDigestEvent:
+    return GraphDigestEvent(
+        offset=offset,
+        event_id=event.get("event_id") or event.get("eventId"),
+        event_type=str(event.get("event_type") or event.get("eventType") or "UNKNOWN"),
+        source_service=event.get("source") or event.get("sourceService"),
+        schema_version=event.get("schema_version") or event.get("schemaVersion"),
+        timestamp=event.get("timestamp"),
+        node_id=event.get("node_id"),
+        target_node_id=event.get("target_node_id") or event.get("targetNodeId"),
+        label=event.get("label"),
+        payload_hash=event_payload_hash(event.get("payload")),
+    )
+

--- a/tests/integration/test_dashboard_stream.py
+++ b/tests/integration/test_dashboard_stream.py
@@ -1,0 +1,112 @@
+import json
+
+from fastapi.testclient import TestClient
+
+from ume.api import app, configure_graph
+from ume.config import settings
+from ume.event_ledger import EventLedger
+from ume.graph import MockGraph
+import ume.dashboard_routes as dashboard_routes
+
+
+class _VectorStoreStub:
+    def __init__(self) -> None:
+        self.idx_to_id = ["n0", "n1"]
+
+    def close(self) -> None:
+        return None
+
+
+def _token(client: TestClient) -> str:
+    response = client.post(
+        "/auth/token",
+        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
+    )
+    return response.json()["access_token"]
+
+
+def _seed_ledger(ledger: EventLedger, count: int) -> None:
+    for offset in range(count):
+        ledger.append(
+            offset,
+            {
+                "eventType": "CREATE_NODE",
+                "eventId": f"evt-{offset}",
+                "timestamp": offset + 1,
+                "sourceService": "test",
+                "node_id": f"n{offset}",
+                "payload": {"node_id": f"n{offset}", "attributes": {"name": f"N{offset}"}},
+            },
+        )
+
+
+def _read_dashboard_digest_payloads(
+    client: TestClient,
+    *,
+    token: str,
+    expected: int,
+    headers: dict[str, str] | None = None,
+) -> list[dict[str, object]]:
+    payloads: list[dict[str, object]] = []
+    req_headers = {"Authorization": f"Bearer {token}", "Accept": "text/event-stream"}
+    if headers:
+        req_headers.update(headers)
+
+    with client.stream("GET", f"/dashboard/stream?max_events={expected}", headers=req_headers) as response:
+        assert response.status_code == 200
+        pending = False
+        for line in response.iter_lines():
+            if not line:
+                continue
+            if line.startswith("event: dashboard_digest"):
+                pending = True
+                continue
+            if pending and line.startswith("data: "):
+                payloads.append(json.loads(line[len("data: ") :]))
+                pending = False
+                if len(payloads) >= expected:
+                    break
+    return payloads
+
+
+def test_dashboard_stream_emits_sanitized_updates(tmp_path, monkeypatch) -> None:
+    graph = MockGraph()
+    graph.add_node("n0", {})
+    graph.add_node("n1", {})
+    graph.add_edge("n0", "n1", "L")
+    configure_graph(graph)
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+    app.state.vector_store = _VectorStoreStub()
+
+    ledger = EventLedger(str(tmp_path / "dashboard_stream.db"))
+    _seed_ledger(ledger, 2)
+    monkeypatch.setattr(dashboard_routes, "event_ledger", ledger)
+
+    with TestClient(app) as client:
+        payloads = _read_dashboard_digest_payloads(client, token=_token(client), expected=2)
+
+    assert [item["cursor_offset"] for item in payloads] == [0, 1]
+    latest = payloads[-1]
+    assert latest["stats"] == {"node_count": 2, "edge_count": 1, "vector_index_size": 2}
+    assert isinstance(latest["recent_events"], list)
+    assert "payload_hash" in latest["recent_events"][0]
+
+
+def test_dashboard_stream_resumes_with_last_event_id(tmp_path, monkeypatch) -> None:
+    configure_graph(MockGraph())
+    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
+    app.state.vector_store = _VectorStoreStub()
+
+    ledger = EventLedger(str(tmp_path / "dashboard_stream_resume.db"))
+    _seed_ledger(ledger, 4)
+    monkeypatch.setattr(dashboard_routes, "event_ledger", ledger)
+
+    with TestClient(app) as client:
+        resumed = _read_dashboard_digest_payloads(
+            client,
+            token=_token(client),
+            expected=2,
+            headers={"Last-Event-ID": "1"},
+        )
+
+    assert [item["cursor_offset"] for item in resumed] == [2, 3]


### PR DESCRIPTION
### Motivation
- Provide a low-latency, replay-safe channel for high-churn dashboard panels by exposing a sanitized digest stream instead of frequent polling. 
- Reuse existing pipeline/ledger outputs to avoid exposing raw payloads while preserving privacy and detection of data-loss/backpressure. 
- Keep REST compatibility and allow runtime selection of transport with feature flags so deployments can opt-in or fall back safely.

### Description
- Added a dashboard-focused SSE endpoint `GET /dashboard/stream` that emits `dashboard_digest` updates and `control` (heartbeat/backpressure) events, with `Last-Event-ID` / `lastEventId` resume semantics in `src/ume/dashboard_routes.py` and uses `event_ledger` for backfill. 
- Introduced reusable digest helpers in `src/ume/realtime_digest.py` and extended `src/ume/realtime_contracts.py` with `DashboardDigestEvent`, and refactored `src/ume/graph_routes.py` to reuse the mapper. 
- Added backend config flags `UME_ENABLE_DASHBOARD_STREAM`, `UME_DASHBOARD_STREAM_TRANSPORT`, and `UME_DASHBOARD_REST_FALLBACK` in `src/ume/config/__init__.py` and a capability route `GET /dashboard/transport_features`. 
- Refactored the React dashboard to subscribe to the stream (`frontend/src/App.jsx`), added a small SSE client `frontend/src/realtimeStream.js` with reconnect/backoff and last-id backfill, simplified `PiiStatus` to a presentational component, and preserved REST refresh endpoints as fallbacks. 
- Added integration tests for emission and resume behavior in `tests/integration/test_dashboard_stream.py` and updated docs in `docs/REALTIME_STREAMING.md` and `docs/FRONTEND_ARCHITECTURE.md` to document transport contract and reconnection/backfill semantics.

### Testing
- Ran linter: `poetry run ruff check ...` against modified Python files and the new tests and the check passed. 
- Ran Python integration tests: `poetry run pytest tests/integration/test_dashboard_stream.py tests/integration/test_realtime_stream.py`, which failed in this environment during test collection due to the runtime lacking `fastapi.testclient` (import environment limitation). 
- Frontend tests: installed deps and ran `npm --prefix frontend test` (Vitest), and the SPA unit tests passed (`11 files, 17 tests passed`). 
- Manual smoke/dev run: started the Vite dev server and captured a dashboard screenshot to validate the UI subscription flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2d3690c848326b631928656589ca4)