### PR TITLE
Add versioned capability schema, emit capability metadata and canonical /capabilities manifest

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -108,6 +108,7 @@ _COMPAT_EXPORTS: dict[str, tuple[str, str]] = {
     "create_graph": ("ume.resources", "create_graph"),
     "graph_factory": ("ume.resources", "graph_factory"),
     "vector_store_factory": ("ume.resources", "vector_store_factory"),
+    "get_capability_manifest": ("ume.factories", "get_capability_manifest"),
     "start_dossier_snapshot_scheduler": (
         "ume.dossier.scheduler",
         "start_dossier_snapshot_scheduler",

--- a/src/ume/adapters/registry.py
+++ b/src/ume/adapters/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from importlib import import_module
+from typing import cast
 
 from ume.graph_adapter import IGraphAdapter
 from ume.plugins.registry import (
@@ -17,6 +18,7 @@ from ume.plugins.registry import (
     register_lazy_plugin,
     register_plugin,
 )
+from ume.capability_schema import build_capability_schema
 
 GraphAdapterConstructor = Callable[[str | None], IGraphAdapter]
 LazyConstructorLoader = Callable[[], GraphAdapterConstructor]
@@ -36,11 +38,25 @@ def register_graph_backend(
     capabilities: set[str] | frozenset[str] | None = None,
 ) -> None:
     """Register a graph backend constructor under ``name``."""
+    if capabilities is None:
+        raise GraphAdapterRegistrationError(
+            f"Graph backend '{name}' must declare capabilities"
+        )
+    declared = frozenset(capabilities)
     register_plugin(
         GRAPH_BACKEND_CAPABILITY,
         name,
         constructor,
-        metadata=ConstructorMetadata(capabilities=frozenset(capabilities or set())),
+        metadata=ConstructorMetadata(
+            capabilities=declared,
+            details={
+                "capability_schema": build_capability_schema(
+                    domain="graph",
+                    backend=name,
+                    declared=declared,
+                ).as_dict()
+            },
+        ),
     )
 
 
@@ -51,11 +67,26 @@ def register_lazy_graph_backend(
     capabilities: set[str] | frozenset[str] | None = None,
 ) -> None:
     """Register a deferred loader for backend ``name``."""
+    if capabilities is None:
+        raise GraphAdapterRegistrationError(
+            f"Graph backend '{name}' must declare capabilities"
+        )
+    declared = frozenset(capabilities)
     register_lazy_plugin(
         GRAPH_BACKEND_CAPABILITY,
         name,
         loader,
-        metadata=ConstructorMetadata(lazy=True, capabilities=frozenset(capabilities or set())),
+        metadata=ConstructorMetadata(
+            lazy=True,
+            capabilities=declared,
+            details={
+                "capability_schema": build_capability_schema(
+                    domain="graph",
+                    backend=name,
+                    declared=declared,
+                ).as_dict()
+            },
+        ),
     )
 
 
@@ -79,11 +110,14 @@ def create_registered_graph_adapter(
     default: str | None = None,
 ) -> IGraphAdapter:
     """Instantiate backend ``name`` using the registration table."""
-    return create_plugin(
-        GRAPH_BACKEND_CAPABILITY,
-        name,
-        db_path,
-        default=default,
+    return cast(
+        IGraphAdapter,
+        create_plugin(
+            GRAPH_BACKEND_CAPABILITY,
+            name,
+            db_path,
+            default=default,
+        ),
     )
 
 
@@ -110,7 +144,7 @@ def clear_graph_backend_registry() -> None:
 
 def _register_external_loaded_object(name: str, loaded: object) -> None:
     if callable(loaded):
-        register_graph_backend(name, loaded)
+        register_graph_backend(name, loaded, capabilities=set())
         return
     if isinstance(loaded, Mapping):
         for backend_name, constructor in loaded.items():
@@ -118,7 +152,7 @@ def _register_external_loaded_object(name: str, loaded: object) -> None:
                 raise GraphAdapterRegistrationError(
                     f"Constructor for backend '{backend_name}' is not callable"
                 )
-            register_graph_backend(str(backend_name), constructor)
+            register_graph_backend(str(backend_name), constructor, capabilities=set())
         return
     raise GraphAdapterRegistrationError(
         f"Entry point '{name}' must load a constructor or backend mapping"

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -52,7 +52,7 @@ from .rbac_adapter import AccessDeniedError
 from .graph_adapter import IGraphAdapter  # noqa: F401
 from .vector_store import VectorStoreListener
 from .vector_outbox import VectorOutboxDispatcher
-from .factories import create_vector_store, graph_capability_negotiation, vector_capability_negotiation
+from .factories import create_vector_store, get_capability_manifest
 from ._internal.listeners import register_listener, unregister_listener
 
 
@@ -354,14 +354,13 @@ async def validation_error_handler(
 
 
 
+@app.get("/capabilities")
+def capabilities() -> dict[str, Any]:
+    """Canonical capability negotiation endpoint for all backend domains."""
+    return get_capability_manifest()
+
+
 @app.get("/health/capabilities")
 def health_capabilities() -> dict[str, Any]:
-    """Expose backend capability support and active fallbacks."""
-    graph_backend = settings.UME_GRAPH_BACKEND.lower()
-    vector_backend = settings.UME_VECTOR_BACKEND.lower()
-    return {
-        "graph_backend": graph_backend,
-        "vector_backend": vector_backend,
-        "graph": graph_capability_negotiation(graph_backend).as_dict(),
-        "vector": vector_capability_negotiation(vector_backend).as_dict(),
-    }
+    """Backwards-compatible alias for the canonical capability endpoint."""
+    return capabilities()

--- a/src/ume/capability_schema.py
+++ b/src/ume/capability_schema.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+CAPABILITY_SCHEMA_VERSION = "1.0"
+
+
+@dataclass(frozen=True)
+class CapabilitySchema:
+    """Versioned capability declaration and negotiation payload."""
+
+    domain: Literal["graph", "vector", "integration"]
+    backend: str
+    declared: tuple[str, ...]
+    supported: tuple[str, ...]
+    fallbacks: dict[str, str] = field(default_factory=dict)
+    schema_version: str = CAPABILITY_SCHEMA_VERSION
+    field_versions: dict[str, str] = field(
+        default_factory=lambda: {
+            "domain": "1.0",
+            "backend": "1.0",
+            "declared": "1.0",
+            "supported": "1.0",
+            "fallbacks": "1.0",
+        }
+    )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "field_versions": dict(self.field_versions),
+            "domain": self.domain,
+            "backend": self.backend,
+            "declared": list(self.declared),
+            "supported": list(self.supported),
+            "fallbacks": dict(self.fallbacks),
+        }
+
+
+def build_capability_schema(
+    *,
+    domain: Literal["graph", "vector", "integration"],
+    backend: str,
+    declared: frozenset[str],
+    supported: frozenset[str] | None = None,
+    fallbacks: dict[str, str] | None = None,
+) -> CapabilitySchema:
+    supported_capabilities = declared if supported is None else supported
+    return CapabilitySchema(
+        domain=domain,
+        backend=backend.lower(),
+        declared=tuple(sorted(declared)),
+        supported=tuple(sorted(supported_capabilities)),
+        fallbacks=dict(fallbacks or {}),
+    )

--- a/src/ume/factories.py
+++ b/src/ume/factories.py
@@ -11,11 +11,17 @@ from .rbac_adapter import RoleBasedGraphAdapter
 from .vector_store import VectorBackend, create_vector_store as _create_vector_store
 from .plugins.registry import get_plugin_metadata
 from .vector_backends import VECTOR_BACKEND_CAPABILITY
+from .integrations.registry import (
+    available_adapters,
+    get_adapter_capabilities,
+    register_builtin_adapters,
+)
 from .capabilities import (
     CapabilityNegotiation,
     NATIVE_ACL_CAPABILITY,
     VECTOR_SIMILARITY_CAPABILITY,
 )
+from .capability_schema import build_capability_schema
 from .memory import EpisodicMemory, SemanticMemory
 
 from .graph_adapter import IGraphAdapter
@@ -57,6 +63,61 @@ def vector_capability_negotiation(backend: str | None = None) -> CapabilityNegot
         fallbacks[VECTOR_SIMILARITY_CAPABILITY] = "semantic_search_disabled"
     return CapabilityNegotiation(supported=supported, fallbacks=fallbacks)
 
+
+
+
+def integration_capability_negotiation(backend: str) -> CapabilityNegotiation:
+    """Return integration adapter capability support metadata."""
+    register_builtin_adapters()
+    supported = get_adapter_capabilities(backend)
+    return CapabilityNegotiation(supported=supported, fallbacks={})
+
+
+def get_capability_manifest(
+    *,
+    graph_backend: str | None = None,
+    vector_backend: str | None = None,
+    integration_backends: list[str] | None = None,
+) -> dict[str, object]:
+    """Return canonical backend capability negotiation metadata."""
+    graph_name = (graph_backend or settings.UME_GRAPH_BACKEND).lower()
+    vector_name = (vector_backend or settings.UME_VECTOR_BACKEND).lower()
+
+    graph_negotiation = graph_capability_negotiation(graph_name)
+    vector_negotiation = vector_capability_negotiation(vector_name)
+
+    register_builtin_adapters()
+    adapter_names = integration_backends or sorted(available_adapters())
+    integration_payload: dict[str, dict[str, object]] = {}
+    for adapter_name in adapter_names:
+        negotiation = integration_capability_negotiation(adapter_name)
+        integration_payload[adapter_name] = build_capability_schema(
+            domain="integration",
+            backend=adapter_name,
+            declared=negotiation.supported,
+            supported=negotiation.supported,
+            fallbacks=negotiation.fallbacks,
+        ).as_dict()
+
+    return {
+        "graph_backend": graph_name,
+        "vector_backend": vector_name,
+        "graph": build_capability_schema(
+            domain="graph",
+            backend=graph_name,
+            declared=graph_negotiation.supported,
+            supported=graph_negotiation.supported,
+            fallbacks=graph_negotiation.fallbacks,
+        ).as_dict(),
+        "vector": build_capability_schema(
+            domain="vector",
+            backend=vector_name,
+            declared=vector_negotiation.supported,
+            supported=vector_negotiation.supported,
+            fallbacks=vector_negotiation.fallbacks,
+        ).as_dict(),
+        "integrations": integration_payload,
+    }
 
 def create_graph_adapter(
     db_path: str | None = None,

--- a/src/ume/integrations/registry.py
+++ b/src/ume/integrations/registry.py
@@ -1,21 +1,51 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, cast
 
-from ume.plugins.registry import get_plugin_constructor, list_plugins, register_plugin
+from ume.plugins.registry import (
+    ConstructorMetadata,
+    get_plugin_constructor,
+    get_plugin_metadata,
+    list_plugins,
+    register_plugin,
+)
+
+from ume.capability_schema import build_capability_schema
 
 
 INTEGRATION_CAPABILITY = "integration_adapter"
 
 
-def register_adapter(name: str, cls: type) -> None:
+def register_adapter(
+    name: str,
+    cls: type,
+    *,
+    capabilities: set[str] | frozenset[str] | None = None,
+) -> None:
     """Register an integration adapter class under ``name``."""
-    register_plugin(INTEGRATION_CAPABILITY, name, cls)
+    if capabilities is None:
+        raise ValueError(f"Integration adapter '{name}' must declare capabilities")
+    declared = frozenset(capabilities)
+    register_plugin(
+        INTEGRATION_CAPABILITY,
+        name,
+        cls,
+        metadata=ConstructorMetadata(
+            capabilities=declared,
+            details={
+                "capability_schema": build_capability_schema(
+                    domain="integration",
+                    backend=name,
+                    declared=declared,
+                ).as_dict()
+            },
+        ),
+    )
 
 
 def get_adapter(name: str) -> type:
     """Return the adapter class registered under ``name``."""
-    return get_plugin_constructor(INTEGRATION_CAPABILITY, name)
+    return cast(type, get_plugin_constructor(INTEGRATION_CAPABILITY, name))
 
 
 def available_adapters() -> Iterable[str]:
@@ -32,9 +62,15 @@ def register_builtin_adapters() -> None:
     from .crewai import CrewAI
     from .autogen import AutoGen
 
-    register_adapter("langgraph", LangGraph)
-    register_adapter("letta", Letta)
-    register_adapter("memgpt", MemGPT)
-    register_adapter("supermemory", SuperMemory)
-    register_adapter("crewai", CrewAI)
-    register_adapter("autogen", AutoGen)
+    register_adapter("langgraph", LangGraph, capabilities={"workflow_orchestration"})
+    register_adapter("letta", Letta, capabilities={"agent_memory_sync"})
+    register_adapter("memgpt", MemGPT, capabilities={"agent_memory_sync"})
+    register_adapter("supermemory", SuperMemory, capabilities={"memory_indexing"})
+    register_adapter("crewai", CrewAI, capabilities={"multi_agent_orchestration"})
+    register_adapter("autogen", AutoGen, capabilities={"multi_agent_orchestration"})
+
+
+def get_adapter_capabilities(name: str) -> frozenset[str]:
+    """Return declared capabilities for an integration adapter."""
+    metadata = get_plugin_metadata(INTEGRATION_CAPABILITY, name)
+    return metadata.capabilities

--- a/src/ume/vector_backends/__init__.py
+++ b/src/ume/vector_backends/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Iterable
+from typing import Dict, Iterable, cast
 from types import TracebackType
 import json
 import logging
@@ -25,6 +25,7 @@ from ..plugins.registry import (
     list_plugins,
     register_plugin,
 )
+from ..capability_schema import build_capability_schema
 
 faiss: Any
 try:  # optional dependency
@@ -68,16 +69,28 @@ def register_backend(
     capabilities: set[str] | frozenset[str] | None = None,
 ) -> None:
     """Register a vector backend class under ``name``."""
+    if capabilities is None:
+        raise ValueError(f"Vector backend '{name}' must declare capabilities")
+    declared = frozenset(capabilities)
     register_plugin(
         VECTOR_BACKEND_CAPABILITY,
         name,
         cls,
-        metadata=ConstructorMetadata(capabilities=frozenset(capabilities or set())),
+        metadata=ConstructorMetadata(
+            capabilities=declared,
+            details={
+                "capability_schema": build_capability_schema(
+                    domain="vector",
+                    backend=name,
+                    declared=declared,
+                ).as_dict()
+            },
+        ),
     )
 
 def get_backend(name: str) -> type[VectorBackend]:
     """Return the backend class registered under ``name``."""
-    return get_plugin_constructor(VECTOR_BACKEND_CAPABILITY, name)
+    return cast(type[VectorBackend], get_plugin_constructor(VECTOR_BACKEND_CAPABILITY, name))
 
 def available_backends() -> Iterable[str]:
     """Return names of all registered backends."""
@@ -96,6 +109,14 @@ def load_entrypoints() -> None:
             metadata=ConstructorMetadata(
                 source="entry_point",
                 entry_point_group=ENTRYPOINT_GROUP,
+                capabilities=frozenset(),
+                details={
+                    "capability_schema": build_capability_schema(
+                        domain="vector",
+                        backend=name,
+                        declared=frozenset(),
+                    ).as_dict()
+                },
             ),
         )
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -198,3 +198,40 @@ def test_vector_capability_negotiation(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert negotiation.supports("vector_similarity")
     assert negotiation.fallbacks == {}
+
+
+def test_get_capability_manifest_includes_versioned_domains(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        factories,
+        "graph_capability_negotiation",
+        lambda backend=None: factories.CapabilityNegotiation(
+            supported=frozenset({"transactional"}),
+            fallbacks={"native_acl": "application_side_acl_filtering"},
+        ),
+    )
+    monkeypatch.setattr(
+        factories,
+        "vector_capability_negotiation",
+        lambda backend=None: factories.CapabilityNegotiation(
+            supported=frozenset({"vector_similarity"}),
+        ),
+    )
+    monkeypatch.setattr(factories, "register_builtin_adapters", lambda: None)
+    monkeypatch.setattr(factories, "available_adapters", lambda: ["langgraph"])
+    monkeypatch.setattr(
+        factories,
+        "integration_capability_negotiation",
+        lambda backend: factories.CapabilityNegotiation(
+            supported=frozenset({"workflow_orchestration"}),
+        ),
+    )
+
+    payload = factories.get_capability_manifest(
+        graph_backend="postgres",
+        vector_backend="faiss",
+    )
+
+    assert payload["graph"]["schema_version"] == "1.0"
+    assert payload["graph"]["domain"] == "graph"
+    assert payload["vector"]["domain"] == "vector"
+    assert payload["integrations"]["langgraph"]["domain"] == "integration"

--- a/tests/test_graph_adapter_registry.py
+++ b/tests/test_graph_adapter_registry.py
@@ -31,7 +31,7 @@ class _Adapter:
 
 
 def test_registry_default_backend_lookup() -> None:
-    register_graph_backend("persistent", _Adapter)
+    register_graph_backend("persistent", _Adapter, capabilities={"bulk_write"})
 
     adapter = create_registered_graph_adapter("unknown", "graph.db", default="persistent")
 
@@ -40,7 +40,7 @@ def test_registry_default_backend_lookup() -> None:
 
 
 def test_factory_can_use_runtime_registered_backend(monkeypatch: pytest.MonkeyPatch) -> None:
-    register_graph_backend("custom", _Adapter)
+    register_graph_backend("custom", _Adapter, capabilities={"bulk_write"})
     monkeypatch.setattr(factories, "register_builtin_graph_backends", lambda: None)
     monkeypatch.setattr(
         factories,
@@ -62,7 +62,7 @@ def test_discover_graph_backends_from_modules() -> None:
 
     def _register(register, register_lazy) -> None:  # noqa: ANN001
         del register_lazy
-        register("module_custom", _Adapter)
+        register("module_custom", _Adapter, capabilities={"bulk_write"})
 
     module.register_graph_backends = _register  # type: ignore[attr-defined]
     sys.modules[module.__name__] = module
@@ -95,6 +95,12 @@ def test_discover_graph_backends_from_entry_points(monkeypatch: pytest.MonkeyPat
     assert isinstance(adapter, _Adapter)
     assert adapter.db_path == "from-ep.db"
 
+
+
+
+def test_register_graph_backend_requires_capabilities() -> None:
+    with pytest.raises(ValueError, match="must declare capabilities"):
+        register_graph_backend("missing", _Adapter)
 
 def test_registry_exposes_backend_capabilities() -> None:
     register_graph_backend("postgres", _Adapter, capabilities={"transactional"})

--- a/tests/test_integration_registry.py
+++ b/tests/test_integration_registry.py
@@ -4,6 +4,7 @@ from ume.integrations.registry import (
     INTEGRATION_CAPABILITY,
     register_adapter,
     get_adapter,
+    get_adapter_capabilities,
     register_builtin_adapters,
 )
 from ume.integrations.langgraph import LangGraph
@@ -21,7 +22,7 @@ def _reset_registry() -> None:
 
 
 def test_register_and_retrieve() -> None:
-    register_adapter("dummy", DummyAdapter)
+    register_adapter("dummy", DummyAdapter, capabilities={"test_capability"})
     assert get_adapter("dummy") is DummyAdapter
 
 
@@ -32,3 +33,12 @@ def test_builtin_registered() -> None:
 def test_register_builtin_function() -> None:
     register_builtin_adapters()
     assert get_adapter("langgraph") is LangGraph
+
+
+def test_register_requires_capabilities() -> None:
+    with pytest.raises(ValueError, match="must declare capabilities"):
+        register_adapter("missing", DummyAdapter)
+
+
+def test_builtin_adapters_declare_capabilities() -> None:
+    assert "workflow_orchestration" in get_adapter_capabilities("langgraph")

--- a/tests/test_vector_backend_plugins.py
+++ b/tests/test_vector_backend_plugins.py
@@ -1,8 +1,9 @@
+import pytest
 import types
 import importlib
 from types import SimpleNamespace
 
-from ume.vector_backends import get_backend, available_backends, load_entrypoints
+from ume.vector_backends import get_backend, available_backends, load_entrypoints, register_backend
 from ume.vector_store import VectorBackend
 from ume.plugins.registry import clear_plugins
 
@@ -70,3 +71,8 @@ def test_backend_loaded_on_import(monkeypatch):
 
     assert "dummy_imp" in reloaded.available_backends()
     assert reloaded.get_backend("dummy_imp") is DummyBackend
+
+
+def test_register_backend_requires_capabilities() -> None:
+    with pytest.raises(ValueError, match="must declare capabilities"):
+        register_backend("invalid", DummyBackend)


### PR DESCRIPTION
### Motivation
- Provide a single, versioned shape for backend capability declarations and negotiation for graph, vector and integration domains. 
- Ensure all backend registration surfaces consistently declare and expose capability metadata so capability negotiation is reliable. 
- Expose a canonical capability negotiation endpoint and Python entrypoint to simplify clients and health checks.

### Description
- Introduce `src/ume/capability_schema.py` with a versioned `CapabilitySchema` dataclass and `build_capability_schema()` helper to normalize payloads. 
- Require explicit capability declarations on registries and attach schema metadata: graph registry (`src/ume/adapters/registry.py`), vector registry (`src/ume/vector_backends/__init__.py`), and integration registry (`src/ume/integrations/registry.py`) now add `capability_schema` into constructor metadata and raise if `capabilities` is omitted. 
- Add a canonical Python API `ume.get_capability_manifest()` in `src/ume/factories.py` and expose HTTP `GET /capabilities` (with `GET /health/capabilities` kept as a backward-compatible alias) returning versioned domain payloads. 
- Add conformance/tests that fail when registrations omit capabilities and validate manifest shape: updates to `tests/test_graph_adapter_registry.py`, `tests/test_vector_backend_plugins.py`, `tests/test_integration_registry.py`, and `tests/test_factories.py`.

### Testing
- Ran unit tests: `pytest -q tests/test_factories.py tests/test_graph_adapter_registry.py tests/test_integration_registry.py tests/test_vector_backend_plugins.py` and all targeted tests passed (`21 passed`).
- Ran linter: `ruff check ...` on modified files and the check passed for the change set.
- Type check: `mypy` on the focused files was executed and the failures encountered are pre-existing repository-wide typing issues outside this change set (reported but unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7eb98737c832680228d4a22199cc3)