### PR TITLE
Harden Docker secrets handling: remove tracked secret files, add bootstrap scripts and CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
           python-version: '3.12'
           run: ${{ steps.changes.outputs.run }}
 
+      - name: Enforce docker secrets guard
+        if: steps.changes.outputs.run == 'true'
+        run: bash scripts/check_docker_secrets_guard.sh
+
       - name: Run pre-commit
         if: steps.changes.outputs.run == 'true'
         run: poetry run pre-commit run --all-files --show-diff-on-failure --color always

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,8 @@ feedback.db
 event_ledger.db
 vectors.faiss
 vectors.faiss.json
+# Docker runtime secret files (generated locally)
+docker/secrets/*.txt
+!docker/secrets/*.example
+!docker/secrets/README.md
+

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -27,12 +27,22 @@ This quickstart shows how to run a simple producer and consumer locally.
    docker run -d -p 9092:9092 -p 9644:9644 --name redpanda docker.redpanda.com/vectorized/redpanda:latest redpanda start
    ```
 
-4. In one terminal, start the demo consumer:
+
+4. If you plan to run the Docker Compose stack, bootstrap runtime secrets first:
+   ```
+   export NEO4J_PASSWORD=<your-neo4j-password>
+   export UME_API_TOKEN=<your-api-token>
+   export UME_OAUTH_PASSWORD=<your-oauth-password>
+   # Optional when using SASL: export KAFKA_SASL_PASSWORD=<your-kafka-password>
+   ./scripts/bootstrap_docker_secrets.sh
+   ```
+
+5. In one terminal, start the demo consumer:
    ```
    python -m ume.consumer_demo
    ```
 
-5. In another terminal, publish a typed demo event:
+6. In another terminal, publish a typed demo event:
    ```
    python -m ume.producer_demo
    ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -65,7 +65,7 @@ services:
   neo4j:
     image: neo4j:5
     environment:
-      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:-change-me}
+      NEO4J_AUTH: neo4j/${NEO4J_PASSWORD:?Set NEO4J_PASSWORD before starting compose}
     ports:
       - "7687:7687"
     volumes:
@@ -73,7 +73,7 @@ services:
     secrets:
       - neo4j_password
     healthcheck:
-      test: ["CMD-SHELL", "cypher-shell -u neo4j -p \"$$(cat /run/secrets/neo4j_password 2>/dev/null || printf '%s' '${NEO4J_PASSWORD:-change-me}')\" 'RETURN 1' || exit 1"]
+      test: ["CMD-SHELL", "cypher-shell -u neo4j -p \"$$(cat /run/secrets/neo4j_password)\" 'RETURN 1' || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -99,9 +99,7 @@ services:
       NEO4J_URI: "bolt://neo4j:7687"
       NEO4J_USER: ${NEO4J_USER:-neo4j}
       NEO4J_PASSWORD_FILE: /run/secrets/neo4j_password
-      UME_API_TOKEN: ${UME_API_TOKEN:-change-me}
       UME_API_TOKEN_FILE: /run/secrets/ume_api_token
-      UME_OAUTH_PASSWORD: ${UME_OAUTH_PASSWORD:-change-me}
       UME_OAUTH_PASSWORD_FILE: /run/secrets/ume_oauth_password
     ports:
       - "8000:8000"
@@ -237,13 +235,13 @@ services:
 
 secrets:
   neo4j_password:
-    file: ./secrets/neo4j_password.txt
+    file: ${NEO4J_PASSWORD_SECRET_FILE:-./secrets/neo4j_password.txt}
   kafka_sasl_password:
-    file: ./secrets/kafka_sasl_password.txt
+    file: ${KAFKA_SASL_PASSWORD_SECRET_FILE:-./secrets/kafka_sasl_password.txt}
   ume_api_token:
-    file: ./secrets/ume_api_token.txt
+    file: ${UME_API_TOKEN_SECRET_FILE:-./secrets/ume_api_token.txt}
   ume_oauth_password:
-    file: ./secrets/ume_oauth_password.txt
+    file: ${UME_OAUTH_PASSWORD_SECRET_FILE:-./secrets/ume_oauth_password.txt}
 
 volumes:
   ume-db:

--- a/docker/secrets/README.md
+++ b/docker/secrets/README.md
@@ -1,0 +1,32 @@
+# Docker secrets
+
+This directory is intentionally committed with **templates only**.
+
+## Version-controlled files
+
+- `README.md`
+- `*.example` secret templates
+
+## Local secret bootstrap
+
+Create runtime secret files (`*.txt`) from environment variables before running Docker Compose:
+
+```bash
+./scripts/bootstrap_docker_secrets.sh
+```
+
+By default, the script writes:
+
+- `docker/secrets/neo4j_password.txt`
+- `docker/secrets/kafka_sasl_password.txt`
+- `docker/secrets/ume_api_token.txt`
+- `docker/secrets/ume_oauth_password.txt`
+
+You can override values with environment variables:
+
+- `NEO4J_PASSWORD`
+- `KAFKA_SASL_PASSWORD`
+- `UME_API_TOKEN`
+- `UME_OAUTH_PASSWORD`
+
+> Never commit generated `docker/secrets/*.txt` files.

--- a/docker/secrets/kafka_sasl_password.example
+++ b/docker/secrets/kafka_sasl_password.example
@@ -1,0 +1,1 @@
+<set-kafka-sasl-password-before-bootstrap>

--- a/docker/secrets/kafka_sasl_password.txt
+++ b/docker/secrets/kafka_sasl_password.txt
@@ -1,1 +1,0 @@
-change-me

--- a/docker/secrets/neo4j_password.example
+++ b/docker/secrets/neo4j_password.example
@@ -1,0 +1,1 @@
+<set-neo4j-password-before-bootstrap>

--- a/docker/secrets/neo4j_password.txt
+++ b/docker/secrets/neo4j_password.txt
@@ -1,1 +1,0 @@
-change-me

--- a/docker/secrets/ume_api_token.example
+++ b/docker/secrets/ume_api_token.example
@@ -1,0 +1,1 @@
+<set-ume-api-token-before-bootstrap>

--- a/docker/secrets/ume_api_token.txt
+++ b/docker/secrets/ume_api_token.txt
@@ -1,1 +1,0 @@
-change-me

--- a/docker/secrets/ume_oauth_password.example
+++ b/docker/secrets/ume_oauth_password.example
@@ -1,0 +1,1 @@
+<set-ume-oauth-password-before-bootstrap>

--- a/docker/secrets/ume_oauth_password.txt
+++ b/docker/secrets/ume_oauth_password.txt
@@ -1,1 +1,0 @@
-change-me

--- a/docs/ENV_EXAMPLE.md
+++ b/docs/ENV_EXAMPLE.md
@@ -6,6 +6,8 @@ The `.env` file allows you to override default settings defined in `src/ume/conf
 
 An `env.example` file with the following contents is included at the project root.
 
+For Docker Compose, secrets must be supplied via environment variables and generated into `docker/secrets/*.txt` at bootstrap (`./scripts/bootstrap_docker_secrets.sh`), or by pointing compose to externally mounted files with `NEO4J_PASSWORD_SECRET_FILE`, `KAFKA_SASL_PASSWORD_SECRET_FILE`, `UME_API_TOKEN_SECRET_FILE`, and `UME_OAUTH_PASSWORD_SECRET_FILE`.
+
 ```bash
 # Path where the CLI stores its SQLite database
 UME_CLI_DB=./ume.db

--- a/docs/SECURITY_NOTES.md
+++ b/docs/SECURITY_NOTES.md
@@ -90,3 +90,5 @@ Use these settings as the minimum baseline for staging/production environments:
 - If Kafka uses SASL (`SASL_SSL` or `SASL_PLAINTEXT`), set `KAFKA_SASL_USERNAME` and `KAFKA_SASL_PASSWORD` (or `KAFKA_SASL_PASSWORD_FILE`).
 
 The Docker Compose file includes optional profiles (`secure-kafka`, `secure-api`) and secret-file mounts to support this baseline in local and self-hosted deployments.
+
+For local Compose usage, generate secret files at bootstrap time with `./scripts/bootstrap_docker_secrets.sh` (or mount external files by setting `*_SECRET_FILE` compose variables). Do not commit generated `docker/secrets/*.txt` files.

--- a/scripts/bootstrap_docker_secrets.sh
+++ b/scripts/bootstrap_docker_secrets.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+secrets_dir="docker/secrets"
+mkdir -p "$secrets_dir"
+
+write_secret() {
+  local out_file="$1"
+  local value="$2"
+  if [ -z "$value" ]; then
+    echo "Missing required secret value for $out_file" >&2
+    exit 1
+  fi
+  printf '%s\n' "$value" > "$out_file"
+}
+
+write_secret "$secrets_dir/neo4j_password.txt" "${NEO4J_PASSWORD:-change-me-in-local-dev}"
+write_secret "$secrets_dir/kafka_sasl_password.txt" "${KAFKA_SASL_PASSWORD:-change-me-in-local-dev}"
+write_secret "$secrets_dir/ume_api_token.txt" "${UME_API_TOKEN:-change-me-in-local-dev}"
+write_secret "$secrets_dir/ume_oauth_password.txt" "${UME_OAUTH_PASSWORD:-change-me-in-local-dev}"
+
+echo "Docker secret files generated in $secrets_dir"

--- a/scripts/check_docker_secrets_guard.sh
+++ b/scripts/check_docker_secrets_guard.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tracked_disallowed=$(git ls-files 'docker/secrets/*' \
+  | rg -v '^docker/secrets/README\.md$|^docker/secrets/[^/]+\.example$' || true)
+
+if [ -n "$tracked_disallowed" ]; then
+  echo "Disallowed tracked files detected in docker/secrets/:"
+  echo "$tracked_disallowed"
+  echo "Only README.md and *.example files may be committed."
+  exit 1
+fi
+
+echo "docker/secrets guard passed"


### PR DESCRIPTION
### Motivation

- Prevent committing runtime secret values and enforce a template-first workflow for `docker/secrets/` to reduce accidental leakage of credentials.
- Require secrets to be provided at runtime (via env vars or mounted secret files) and make local bootstrap reproducible and documented.
- Add an automated CI guard so PRs fail if non-example secret files are tracked under `docker/secrets/`.

### Description

- Removed tracked concrete secret files `docker/secrets/*.txt` and added non-sensitive `*.example` templates plus `docker/secrets/README.md` explaining the workflow.
- Updated `.gitignore` to ignore generated `docker/secrets/*.txt` while explicitly allowing `README.md` and `*.example` files to remain version-controlled.
- Adjusted `docker/docker-compose.yml` to require explicit Neo4j credentials and to read API/OAuth/Kafka secret file paths via optional `*_SECRET_FILE` environment variables instead of committing defaults.
- Added `scripts/bootstrap_docker_secrets.sh` to generate runtime secret files from environment variables and `scripts/check_docker_secrets_guard.sh` to fail CI when disallowed files are tracked, and wired the guard into `.github/workflows/ci.yml`.

### Testing

- Ran `bash scripts/check_docker_secrets_guard.sh` which passed and correctly detects tracked disallowed files when present.
- Performed a shell syntax check with `bash -n scripts/bootstrap_docker_secrets.sh` and verified the guard script invocation in CI, both succeeding in this environment.
- Attempted `docker compose -f docker/docker-compose.yml config` but `docker` is not available in the current environment so the compose rendering could not be validated.
- Attempted `poetry run pre-commit run ...` but `pre-commit` is not installed in this environment so lint/pre-commit hooks were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80e8a45a48326a21c0db7d154281c)