### PR TITLE
Require explicit capabilities for external graph adapter plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1467,6 +1467,22 @@ vector store.
 
 Use `ume-cli plugins` to inspect registered plugins across capabilities, or
 `ume-cli plugins --capability vector_backend` to filter by one capability.
+
+
+Graph backend plugins discovered through `ume.graph_adapters` must declare
+capabilities explicitly. Each entry point should load either a single backend
+spec:
+
+```python
+{
+    "constructor": YourGraphAdapter,
+    "capabilities": {"bulk_write", "transactional"},
+}
+```
+
+or a mapping of backend names to specs with the same shape. Discovery rejects
+registrations that omit `capabilities`, so plugin packages should treat the
+capability set as required metadata.
 ## Running Tests
 
 Install development dependencies before running tests:

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -135,7 +135,11 @@ path for graph backends:
 - Optional module discovery from `UME_GRAPH_ADAPTER_MODULES`
 
 This means graph backends can be contributed as plugins and discovered from
-Python package entry points, in addition to built-ins.
+Python package entry points, in addition to built-ins. External registrations
+must now provide explicit capability metadata; `ume.graph_adapters` entry
+points must resolve to either a single backend spec with `constructor` and
+`capabilities`, or a mapping of backend names to those specs. Registrations
+that omit `capabilities` are rejected during discovery.
 
 ## 2) Vector backend creation flow
 

--- a/src/ume/adapters/registry.py
+++ b/src/ume/adapters/registry.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Set as AbstractSet
 from importlib import import_module
-from typing import cast
+from typing import NotRequired, TypedDict, cast
 
 from ume.graph_adapter import IGraphAdapter
 from ume.plugins.registry import (
@@ -25,6 +25,14 @@ LazyConstructorLoader = Callable[[], GraphAdapterConstructor]
 
 GRAPH_BACKEND_CAPABILITY = "graph_backend"
 GRAPH_BACKEND_ENTRYPOINT_GROUP = "ume.graph_adapters"
+
+
+class ExternalGraphBackendSpec(TypedDict):
+    """Strict shape for externally discovered graph backend registrations."""
+
+    constructor: GraphAdapterConstructor
+    capabilities: AbstractSet[str]
+    name: NotRequired[str]
 
 
 class GraphAdapterRegistrationError(PluginRegistrationError):
@@ -121,8 +129,6 @@ def create_registered_graph_adapter(
     )
 
 
-
-
 def get_graph_backend_capabilities(name: str) -> frozenset[str]:
     """Return declared capabilities for backend ``name``."""
     metadata = get_plugin_metadata(GRAPH_BACKEND_CAPABILITY, name)
@@ -131,10 +137,7 @@ def get_graph_backend_capabilities(name: str) -> frozenset[str]:
 
 def available_graph_backends() -> list[str]:
     """Return all known graph backend keys."""
-    return [
-        item["name"]
-        for item in list_plugins(capability=GRAPH_BACKEND_CAPABILITY)
-    ]
+    return [item["name"] for item in list_plugins(capability=GRAPH_BACKEND_CAPABILITY)]
 
 
 def clear_graph_backend_registry() -> None:
@@ -142,20 +145,73 @@ def clear_graph_backend_registry() -> None:
     clear_plugins(capability=GRAPH_BACKEND_CAPABILITY)
 
 
+def _parse_external_backend_spec(
+    entry_name: str,
+    backend_name: str,
+    spec: object,
+) -> tuple[str, GraphAdapterConstructor, AbstractSet[str]]:
+    if not isinstance(spec, Mapping):
+        raise GraphAdapterRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' must provide a mapping "
+            "with constructor and capabilities"
+        )
+
+    constructor = spec.get("constructor")
+    if not callable(constructor):
+        raise GraphAdapterRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' must declare a callable constructor"
+        )
+
+    capabilities = spec.get("capabilities")
+    if capabilities is None:
+        raise GraphAdapterRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' must declare capabilities"
+        )
+    if not isinstance(capabilities, AbstractSet):
+        raise GraphAdapterRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' capabilities must be a set-like collection"
+        )
+
+    resolved_name = spec.get("name")
+    if resolved_name is not None and not isinstance(resolved_name, str):
+        raise GraphAdapterRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' name override must be a string"
+        )
+
+    return (
+        resolved_name or backend_name,
+        cast(GraphAdapterConstructor, constructor),
+        capabilities,
+    )
+
+
 def _register_external_loaded_object(name: str, loaded: object) -> None:
-    if callable(loaded):
-        register_graph_backend(name, loaded, capabilities=set())
-        return
     if isinstance(loaded, Mapping):
-        for backend_name, constructor in loaded.items():
-            if not callable(constructor):
-                raise GraphAdapterRegistrationError(
-                    f"Constructor for backend '{backend_name}' is not callable"
-                )
-            register_graph_backend(str(backend_name), constructor, capabilities=set())
+        if "constructor" in loaded or "capabilities" in loaded:
+            backend_name, constructor, capabilities = _parse_external_backend_spec(
+                name,
+                name,
+                loaded,
+            )
+            register_graph_backend(
+                backend_name, constructor, capabilities=set(capabilities)
+            )
+            return
+
+        for backend_name, spec in loaded.items():
+            resolved_name, constructor, capabilities = _parse_external_backend_spec(
+                name,
+                str(backend_name),
+                spec,
+            )
+            register_graph_backend(
+                resolved_name,
+                constructor,
+                capabilities=set(capabilities),
+            )
         return
     raise GraphAdapterRegistrationError(
-        f"Entry point '{name}' must load a constructor or backend mapping"
+        f"Entry point '{name}' must load a backend spec or backend-spec mapping"
     )
 
 
@@ -197,7 +253,9 @@ def discover_external_graph_backends(*, module_paths: Iterable[str] = ()) -> Non
     discover_graph_backends_from_modules(module_paths)
 
 
-def ensure_external_graph_backends_discovered(*, module_paths: Iterable[str] = ()) -> None:
+def ensure_external_graph_backends_discovered(
+    *, module_paths: Iterable[str] = ()
+) -> None:
     """Run external discovery once per process."""
     ensure_plugins_discovered(
         capability=GRAPH_BACKEND_CAPABILITY,

--- a/tests/test_graph_adapter_registry.py
+++ b/tests/test_graph_adapter_registry.py
@@ -33,13 +33,17 @@ class _Adapter:
 def test_registry_default_backend_lookup() -> None:
     register_graph_backend("persistent", _Adapter, capabilities={"bulk_write"})
 
-    adapter = create_registered_graph_adapter("unknown", "graph.db", default="persistent")
+    adapter = create_registered_graph_adapter(
+        "unknown", "graph.db", default="persistent"
+    )
 
     assert isinstance(adapter, _Adapter)
     assert adapter.db_path == "graph.db"
 
 
-def test_factory_can_use_runtime_registered_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_factory_can_use_runtime_registered_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     register_graph_backend("custom", _Adapter, capabilities={"bulk_write"})
     monkeypatch.setattr(factories, "register_builtin_graph_backends", lambda: None)
     monkeypatch.setattr(
@@ -47,7 +51,9 @@ def test_factory_can_use_runtime_registered_backend(monkeypatch: pytest.MonkeyPa
         "ensure_external_graph_backends_discovered",
         lambda module_paths=(): None,
     )
-    monkeypatch.setattr(factories.settings, "UME_GRAPH_BACKEND", "custom", raising=False)
+    monkeypatch.setattr(
+        factories.settings, "UME_GRAPH_BACKEND", "custom", raising=False
+    )
     monkeypatch.setattr(factories.settings, "UME_ROLE", None, raising=False)
     monkeypatch.setattr(factories, "is_tracing_enabled", lambda: False)
 
@@ -76,13 +82,18 @@ def test_discover_graph_backends_from_modules() -> None:
     assert adapter.db_path == "from-module.db"
 
 
-def test_discover_graph_backends_from_entry_points(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_discover_graph_backends_from_entry_points(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class _FakeEntryPoint:
         name = "ep_custom"
 
         @staticmethod
         def load():
-            return _Adapter
+            return {
+                "constructor": _Adapter,
+                "capabilities": {"bulk_write", "transactional"},
+            }
 
     monkeypatch.setattr(
         "ume.plugins.registry.entry_points",
@@ -94,13 +105,34 @@ def test_discover_graph_backends_from_entry_points(monkeypatch: pytest.MonkeyPat
 
     assert isinstance(adapter, _Adapter)
     assert adapter.db_path == "from-ep.db"
+    assert get_graph_backend_capabilities("ep_custom") == frozenset(
+        {"bulk_write", "transactional"}
+    )
 
 
+def test_discover_graph_backends_from_entry_points_rejects_missing_capabilities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _FakeEntryPoint:
+        name = "ep_missing_caps"
+
+        @staticmethod
+        def load():
+            return {"constructor": _Adapter}
+
+    monkeypatch.setattr(
+        "ume.plugins.registry.entry_points",
+        lambda group: [_FakeEntryPoint()] if group == "ume.graph_adapters" else [],
+    )
+
+    with pytest.raises(ValueError, match="must declare capabilities"):
+        discover_graph_backends_from_entry_points()
 
 
 def test_register_graph_backend_requires_capabilities() -> None:
     with pytest.raises(ValueError, match="must declare capabilities"):
         register_graph_backend("missing", _Adapter)
+
 
 def test_registry_exposes_backend_capabilities() -> None:
     register_graph_backend("postgres", _Adapter, capabilities={"transactional"})


### PR DESCRIPTION
### Motivation
- Ensure external graph backend plugins declare their capabilities so the system can build accurate capability schemas and avoid implicit or ambiguous registrations.
- Introduce a strict plugin shape for entry points and module mappings to make plugin discovery predictable and safer.

### Description
- Enforce a required external plugin spec by adding `ExternalGraphBackendSpec` (`constructor`, required `capabilities`, optional `name`) and a `_parse_external_backend_spec` helper used by `_register_external_loaded_object` to validate entry-point or mapping values in `src/ume/adapters/registry.py`.
- Make `_register_external_loaded_object` reject registrations that omit `capabilities` and require that each mapping item provide a callable `constructor` and a set-like `capabilities` collection.
- Add unit tests in `tests/test_graph_adapter_registry.py` to cover successful discovery when `capabilities` are provided and failure when `capabilities` are missing, and adjust the entry-point test to assert capability propagation.
- Update plugin author documentation in `docs/ARCHITECTURE_OVERVIEW.md` and `README.md` to document the required capability declaration and show an example spec for `ume.graph_adapters` entry points.

### Testing
- Ran `pytest -q tests/test_graph_adapter_registry.py`, which completed successfully (`7 passed`).
- Ran linters with `python -m ruff check src/ume/adapters/registry.py tests/test_graph_adapter_registry.py`, which passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa8d014ec83269895294352e542bd)