### PR TITLE
Prune deprecated top-level export shims and add CI guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         run: python scripts/check_arch_terms.py
 
+      - name: Check deprecated internal callsites
+        if: steps.changes.outputs.run == 'true'
+        run: poetry run python scripts/check_deprecated_callsites.py
+
       - name: Set up Node.js
         if: steps.changes.outputs.run == 'true'
         uses: actions/setup-node@v3

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -76,6 +76,91 @@ from ume import stream_processor
 from ume.pipeline import stream_processor
 ```
 
+## Deprecated top-level export migration matrix
+
+`src/ume/__init__.py` now keeps only the top-level compatibility exports still exercised by external-facing tests or runtime bootstrap compatibility paths. First-party source modules should import canonical modules directly.
+
+### `_RUNTIME_EXPORTS` audit
+
+| Symbol | Disposition | Replacement import / action | Target removal | Notes |
+| --- | --- | --- | --- | --- |
+| `Neo4jGraph` | keep | Call `ume.bootstrap.runtime.bootstrap_runtime("ume")`, then use `ume.Neo4jGraph` only on the bootstrapped package or import `ume.neo4j_graph.Neo4jGraph` directly where appropriate. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+| `VectorBackend` | keep | `ume.bootstrap.runtime.bootstrap_runtime("ume")` or `ume.vector_store.VectorBackend`. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+| `VectorStore` | keep | `ume.bootstrap.runtime.bootstrap_runtime("ume")` or `ume.vector_store.VectorStore`. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+| `VectorStoreListener` | keep | `ume.bootstrap.runtime.bootstrap_runtime("ume")` or `ume._internal.listeners.VectorStoreListener`. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+| `create_default_store` | keep | `ume.bootstrap.runtime.bootstrap_runtime("ume")` or `ume.vector_store.create_default_store`. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+| `FaissBackend` | keep | `ume.bootstrap.runtime.bootstrap_runtime("ume")` or `ume.faiss_backend.FaissBackend`. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+| `ChromaBackend` | keep | `ume.bootstrap.runtime.bootstrap_runtime("ume")` or `ume.chroma_backend.ChromaBackend`. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+| `generate_embedding` | keep | `ume.bootstrap.runtime.bootstrap_runtime("ume")` or `ume.embedding.generate_embedding`. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+| `OntologyListener` | keep | `ume.bootstrap.runtime.bootstrap_runtime("ume")` or `ume.embedding.OntologyListener`. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+| `configure_ontology_graph` | keep | `ume.bootstrap.runtime.bootstrap_runtime("ume")` or `ume.ontology.configure_ontology_graph`. | `0.3.0` | Runtime bootstrap fallback retained for external callers only. |
+
+### `_COMPAT_EXPORTS` audit
+
+| Symbol | Disposition | Replacement import | Target removal | Notes |
+| --- | --- | --- | --- | --- |
+| `MockGraph` | keep | `from ume.graph import MockGraph` | `0.4.0` | Retained for external/tests compatibility. |
+| `PersistentGraph` | keep | `from ume.persistent_graph import PersistentGraph` | `0.4.0` | Retained for external/tests compatibility. |
+| `PostgresGraph` | remove | `from ume.postgres_graph import PostgresGraph` | removed now | No first-party top-level import callsites remain. |
+| `RedisGraphAdapter` | remove | `from ume.redis_graph_adapter import RedisGraphAdapter` | removed now | No first-party top-level import callsites remain. |
+| `ArangoGraph` | remove | `from ume.arango_graph import ArangoGraph` | removed now | No first-party top-level import callsites remain. |
+| `enable_periodic_snapshot` | remove | `from ume.auto_snapshot import enable_periodic_snapshot` | removed now | Internal callers already use module imports. |
+| `disable_periodic_snapshot` | remove | `from ume.auto_snapshot import disable_periodic_snapshot` | removed now | Internal callers already use module imports. |
+| `enable_snapshot_autosave_and_restore` | remove | `from ume.auto_snapshot import enable_snapshot_autosave_and_restore` | removed now | `ume.cli.prompt` now imports the canonical module directly. |
+| `start_retention_scheduler` | remove | `from ume.retention import start_retention_scheduler` | removed now | Internal callers already use module imports. |
+| `stop_retention_scheduler` | remove | `from ume.retention import stop_retention_scheduler` | removed now | Internal callers already use module imports. |
+| `start_ledger_compaction_scheduler` | remove | `from ume.retention import start_ledger_compaction_scheduler` | removed now | Internal callers already use module imports. |
+| `stop_ledger_compaction_scheduler` | remove | `from ume.retention import stop_ledger_compaction_scheduler` | removed now | Internal callers already use module imports. |
+| `start_memory_aging_scheduler` | remove | `from ume.memory_aging import start_memory_aging_scheduler` | removed now | Internal callers already use module imports. |
+| `stop_memory_aging_scheduler` | remove | `from ume.memory_aging import stop_memory_aging_scheduler` | removed now | Internal callers already use module imports. |
+| `start_vector_age_scheduler` | remove | `from ume.memory_aging import start_vector_age_scheduler` | removed now | Internal callers already use module imports. |
+| `stop_vector_age_scheduler` | remove | `from ume.memory_aging import stop_vector_age_scheduler` | removed now | Internal callers already use module imports. |
+| `RoleBasedGraphAdapter` | keep | `from ume.rbac_adapter import RoleBasedGraphAdapter` | `0.4.0` | Retained for external/tests compatibility. |
+| `AccessDeniedError` | keep | `from ume.rbac_adapter import AccessDeniedError` | `0.4.0` | Retained for external/tests compatibility. |
+| `PermissionsGraphAdapter` | keep | `from ume.permissions_adapter import PermissionsGraphAdapter` | `0.4.0` | Retained for external/tests compatibility. |
+| `PolicyViolationError` | keep | `from ume.plugins.alignment import PolicyViolationError` | `0.4.0` | Retained for external/tests compatibility. |
+| `apply_event_to_graph` | keep | `from ume.processing import apply_event_to_graph` | `0.4.0` | Retained for external/tests compatibility. |
+| `ProcessingError` | keep | `from ume.processing import ProcessingError` | `0.4.0` | Retained for external/tests compatibility. |
+| `log_audit_entry` | remove | `from ume.audit import log_audit_entry` | removed now | `ume.cli.prompt` now imports the canonical module directly. |
+| `get_audit_entries` | keep | `from ume.audit import get_audit_entries` | `0.4.0` | Retained for external/tests compatibility. |
+| `snapshot_graph_to_file` | keep | `from ume.snapshot import snapshot_graph_to_file` | `0.4.0` | Retained for external/tests compatibility. |
+| `load_graph_from_file` | keep | `from ume.snapshot import load_graph_from_file` | `0.4.0` | Retained for external/tests compatibility. |
+| `load_graph_into_existing` | remove | `from ume.snapshot import load_graph_into_existing` | removed now | `ume.cli.prompt` now imports the canonical module directly. |
+| `SnapshotError` | keep | `from ume.snapshot import SnapshotError` | `0.4.0` | Retained for external/tests compatibility. |
+| `validate_event_dict` | remove | `from ume.schema_utils import validate_event_dict` | removed now | Internal callers already use module imports. |
+| `GraphSchema` | remove | `from ume.graph_schema import GraphSchema` | removed now | Internal callers already use module imports. |
+| `load_default_schema` | remove | `from ume.graph_schema import load_default_schema` | removed now | Internal callers already use module imports. |
+| `GraphSchemaManager` | remove | `from ume.schema_manager import GraphSchemaManager` | removed now | Internal callers already use module imports. |
+| `DEFAULT_SCHEMA_MANAGER` | keep | `from ume.schema_manager import DEFAULT_SCHEMA_MANAGER` | `0.4.0` | Internal callers migrated; shim remains for external/tests compatibility. |
+| `ssl_config` | remove | `from ume.utils import ssl_config` | removed now | Internal callers already use module imports. |
+| `EpisodicMemory` | remove | `from ume.memory import EpisodicMemory` | removed now | Internal callers already use package/module imports. |
+| `SemanticMemory` | remove | `from ume.memory import SemanticMemory` | removed now | Internal callers already use package/module imports. |
+| `ColdMemory` | remove | `from ume.memory import ColdMemory` | removed now | Internal callers already use package/module imports. |
+| `LLMFerry` | remove | `from ume.llm_ferry import LLMFerry` | removed now | No first-party top-level import callsites remain. |
+| `score_text` | remove | `from ume.reliability import score_text` | removed now | Internal callers already use module imports. |
+| `filter_low_confidence` | remove | `from ume.reliability import filter_low_confidence` | removed now | Internal callers already use module imports. |
+| `AgentTask` | remove | `from ume.agent_orchestrator import AgentTask` | removed now | No first-party top-level import callsites remain. |
+| `AgentOrchestrator` | remove | `from ume.agent_orchestrator import AgentOrchestrator` | removed now | No first-party top-level import callsites remain. |
+| `Supervisor` | remove | `from ume.agent_orchestrator import Supervisor` | removed now | No first-party top-level import callsites remain. |
+| `Critic` | remove | `from ume.agent_orchestrator import Critic` | removed now | No first-party top-level import callsites remain. |
+| `MessageEnvelope` | remove | `from ume.message_bus import MessageEnvelope` | removed now | No first-party top-level import callsites remain. |
+| `ReflectionAgent` | remove | `from ume.agent_orchestrator import ReflectionAgent` | removed now | No first-party top-level import callsites remain. |
+| `Task` | keep | `from ume.dag_executor import Task` | `0.4.0` | Retained for external/tests compatibility. |
+| `DAGExecutor` | keep | `from ume.dag_executor import DAGExecutor` | `0.4.0` | Retained for external/tests compatibility. |
+| `DAGService` | remove | `from ume.dag_service import DAGService` | removed now | No first-party top-level import callsites remain. |
+| `ResourceScheduler` | remove | `from ume.resource_scheduler import ResourceScheduler` | removed now | No first-party top-level import callsites remain. |
+| `ScheduledTask` | remove | `from ume.resource_scheduler import ScheduledTask` | removed now | No first-party top-level import callsites remain. |
+| `Dossier` | remove | `from ume.dossier import Dossier` | removed now | No first-party top-level import callsites remain. |
+| `tokenize` | remove | `from ume.tokenization import tokenize` | removed now | Internal callers already use module imports. |
+| `create_graph_adapter` | migrate | `from ume.factories import create_graph_adapter` | migrated in-tree, removed now | `ume.cli.prompt` now imports the canonical factory directly. |
+| `create_vector_store` | remove | `from ume.factories import create_vector_store` | removed now | Internal callers already use module imports. |
+| `create_graph` | remove | `from ume.resources import create_graph` | removed now | Internal callers already use module imports. |
+| `graph_factory` | remove | `from ume.resources import graph_factory` | removed now | No first-party top-level import callsites remain. |
+| `vector_store_factory` | remove | `from ume.resources import vector_store_factory` | removed now | No first-party top-level import callsites remain. |
+| `get_capability_manifest` | remove | `from ume.factories import get_capability_manifest` | removed now | Internal callers already use module imports. |
+| `start_dossier_snapshot_scheduler` | remove | `from ume.dossier.scheduler import start_dossier_snapshot_scheduler` | removed now | Internal callers already use module imports. |
+| `stop_dossier_snapshot_scheduler` | remove | `from ume.dossier.scheduler import stop_dossier_snapshot_scheduler` | removed now | Internal callers already use module imports. |
+
 ## Architecture status
 
 ### Implemented components

--- a/scripts/check_deprecated_callsites.py
+++ b/scripts/check_deprecated_callsites.py
@@ -8,6 +8,92 @@ import re
 REPO_ROOT = Path(__file__).resolve().parents[1]
 TARGET_DIRS = ("src", "tests")
 
+DEPRECATED_TOP_LEVEL_EXPORTS = {
+    "MockGraph",
+    "PersistentGraph",
+    "RoleBasedGraphAdapter",
+    "AccessDeniedError",
+    "PermissionsGraphAdapter",
+    "PolicyViolationError",
+    "apply_event_to_graph",
+    "ProcessingError",
+    "snapshot_graph_to_file",
+    "load_graph_from_file",
+    "SnapshotError",
+    "DEFAULT_SCHEMA_MANAGER",
+    "get_audit_entries",
+    "Task",
+    "DAGExecutor",
+    "Neo4jGraph",
+    "VectorBackend",
+    "VectorStore",
+    "VectorStoreListener",
+    "create_default_store",
+    "FaissBackend",
+    "ChromaBackend",
+    "generate_embedding",
+    "OntologyListener",
+    "configure_ontology_graph",
+}
+
+LEGACY_TOP_LEVEL_ALLOWLIST = {
+    "tests/test_alignment_plugins.py",
+    "tests/test_analytics.py",
+    "tests/test_api.py",
+    "tests/test_api_events.py",
+    "tests/test_api_mutations.py",
+    "tests/test_api_rbac.py",
+    "tests/test_api_redact_endpoints.py",
+    "tests/test_api_snapshot.py",
+    "tests/test_audit_logging.py",
+    "tests/test_auto_snapshot.py",
+    "tests/test_calendar_decision_api.py",
+    "tests/test_calendar_event_rollback.py",
+    "tests/test_calendar_event_validation.py",
+    "tests/test_calendar_invites.py",
+    "tests/test_calendar_layer_routes.py",
+    "tests/test_dag_executor.py",
+    "tests/test_decision_group.py",
+    "tests/test_decisions_routes.py",
+    "tests/test_financial_account_routes.py",
+    "tests/test_dossier_telemetry_rbac.py",
+    "tests/test_graph_consumer.py",
+    "tests/test_graph_retention.py",
+    "tests/test_graph_serialization.py",
+    "tests/test_graphql.py",
+    "tests/test_graphql_advanced.py",
+    "tests/test_import_safety.py",
+    "tests/test_listeners.py",
+    "tests/test_live_integrations.py",
+    "tests/test_llm_ferry.py",
+    "tests/test_mixed_access_api.py",
+    "tests/test_ontology.py",
+    "tests/test_permissioned_client_flows.py",
+    "tests/test_permissions_adapter.py",
+    "tests/test_permissions_routes.py",
+    "tests/test_processing.py",
+    "tests/test_projection_engine_event_types.py",
+    "tests/test_projection_worker.py",
+    "tests/test_query_helpers.py",
+    "tests/test_rbac_adapter.py",
+    "tests/test_schema_versioning.py",
+    "tests/test_snapshot_roundtrip.py",
+    "tests/test_sse.py",
+    "tests/test_traversal_methods.py",
+    "tests/test_users_routes.py",
+    "tests/test_vector_api.py",
+    "tests/test_vector_store.py",
+    "tests/test_deprecated_callsites.py",
+    "src/ume_client/ume_pb2.py",
+    "src/ume/proto/ume_pb2.py",
+}
+
+TOP_LEVEL_IMPORT_PATTERN = re.compile(
+    r"from\s+ume\s+import\s+(?P<imports>[^\n]+)|(?P<module>\bume\.(?P<attr>{attrs})\b)|getattr\(\s*ume\s*,\s*['\"](?P<getattr>{attrs})['\"]".format(
+        attrs="|".join(sorted(DEPRECATED_TOP_LEVEL_EXPORTS))
+    )
+)
+
 PATTERNS: dict[str, tuple[re.Pattern[str], set[str]]] = {
     "ume.services.mutate.run_mutation": (
         re.compile(r"\brun_mutation\("),
@@ -33,11 +119,39 @@ def _iter_python_files(root: Path):
             yield path
 
 
+def _top_level_export_violations(text: str, rel_path: str) -> list[str]:
+    if rel_path in LEGACY_TOP_LEVEL_ALLOWLIST:
+        return []
+
+    violations: list[str] = []
+    for match in TOP_LEVEL_IMPORT_PATTERN.finditer(text):
+        imports = match.group("imports")
+        names: set[str] = set()
+        if imports:
+            for part in imports.split(","):
+                candidate = part.strip().split(" as ", 1)[0].strip()
+                if candidate in DEPRECATED_TOP_LEVEL_EXPORTS:
+                    names.add(candidate)
+        else:
+            candidate = match.group("attr") or match.group("getattr")
+            if candidate:
+                names.add(candidate)
+
+        if not names:
+            continue
+
+        line = text.count("\n", 0, match.start()) + 1
+        for name in sorted(names):
+            violations.append(f"{rel_path}:{line}: deprecated callsite for ume.{name}")
+    return violations
+
+
 def find_violations(root: Path = REPO_ROOT) -> list[str]:
     violations: list[str] = []
     for path in _iter_python_files(root):
         rel_path = path.relative_to(root).as_posix()
         text = path.read_text(encoding="utf-8")
+        violations.extend(_top_level_export_violations(text, rel_path))
         for key, (pattern, allowlist) in PATTERNS.items():
             if rel_path in allowlist:
                 continue

--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from importlib import import_module
 from typing import Any
 
@@ -24,98 +25,142 @@ __all__ = [
     "parse_event",
 ]
 
-_RUNTIME_EXPORTS = {
-    "Neo4jGraph",
-    "VectorBackend",
-    "VectorStore",
-    "VectorStoreListener",
-    "create_default_store",
-    "FaissBackend",
-    "ChromaBackend",
-    "generate_embedding",
-    "OntologyListener",
-    "configure_ontology_graph",
+
+@dataclass(frozen=True)
+class _ShimExport:
+    module: str
+    attr: str
+    deprecation_key: str
+
+
+_RUNTIME_EXPORTS: dict[str, _ShimExport] = {
+    "Neo4jGraph": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.Neo4jGraph",
+    ),
+    "VectorBackend": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.VectorBackend",
+    ),
+    "VectorStore": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.VectorStore",
+    ),
+    "VectorStoreListener": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.VectorStoreListener",
+    ),
+    "create_default_store": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.create_default_store",
+    ),
+    "FaissBackend": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.FaissBackend",
+    ),
+    "ChromaBackend": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.ChromaBackend",
+    ),
+    "generate_embedding": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.generate_embedding",
+    ),
+    "OntologyListener": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.OntologyListener",
+    ),
+    "configure_ontology_graph": _ShimExport(
+        module="ume.bootstrap.runtime",
+        attr="bootstrap_runtime",
+        deprecation_key="ume.__getattr__.runtime_export_fallback.configure_ontology_graph",
+    ),
 }
 
-_COMPAT_EXPORTS: dict[str, tuple[str, str]] = {
-    "MockGraph": ("ume.graph", "MockGraph"),
-    "PersistentGraph": ("ume.persistent_graph", "PersistentGraph"),
-    "PostgresGraph": ("ume.postgres_graph", "PostgresGraph"),
-    "RedisGraphAdapter": ("ume.redis_graph_adapter", "RedisGraphAdapter"),
-    "ArangoGraph": ("ume.arango_graph", "ArangoGraph"),
-    "enable_periodic_snapshot": ("ume.auto_snapshot", "enable_periodic_snapshot"),
-    "disable_periodic_snapshot": ("ume.auto_snapshot", "disable_periodic_snapshot"),
-    "enable_snapshot_autosave_and_restore": (
-        "ume.auto_snapshot",
-        "enable_snapshot_autosave_and_restore",
+_COMPAT_EXPORTS: dict[str, _ShimExport] = {
+    "MockGraph": _ShimExport(
+        module="ume.graph",
+        attr="MockGraph",
+        deprecation_key="ume.__getattr__.compat_exports.MockGraph",
     ),
-    "start_retention_scheduler": ("ume.retention", "start_retention_scheduler"),
-    "stop_retention_scheduler": ("ume.retention", "stop_retention_scheduler"),
-    "start_ledger_compaction_scheduler": (
-        "ume.retention",
-        "start_ledger_compaction_scheduler",
+    "PersistentGraph": _ShimExport(
+        module="ume.persistent_graph",
+        attr="PersistentGraph",
+        deprecation_key="ume.__getattr__.compat_exports.PersistentGraph",
     ),
-    "stop_ledger_compaction_scheduler": (
-        "ume.retention",
-        "stop_ledger_compaction_scheduler",
+    "RoleBasedGraphAdapter": _ShimExport(
+        module="ume.rbac_adapter",
+        attr="RoleBasedGraphAdapter",
+        deprecation_key="ume.__getattr__.compat_exports.RoleBasedGraphAdapter",
     ),
-    "start_memory_aging_scheduler": (
-        "ume.memory_aging",
-        "start_memory_aging_scheduler",
+    "AccessDeniedError": _ShimExport(
+        module="ume.rbac_adapter",
+        attr="AccessDeniedError",
+        deprecation_key="ume.__getattr__.compat_exports.AccessDeniedError",
     ),
-    "stop_memory_aging_scheduler": ("ume.memory_aging", "stop_memory_aging_scheduler"),
-    "start_vector_age_scheduler": ("ume.memory_aging", "start_vector_age_scheduler"),
-    "stop_vector_age_scheduler": ("ume.memory_aging", "stop_vector_age_scheduler"),
-    "RoleBasedGraphAdapter": ("ume.rbac_adapter", "RoleBasedGraphAdapter"),
-    "AccessDeniedError": ("ume.rbac_adapter", "AccessDeniedError"),
-    "PermissionsGraphAdapter": ("ume.permissions_adapter", "PermissionsGraphAdapter"),
-    "PolicyViolationError": ("ume.plugins.alignment", "PolicyViolationError"),
-    "apply_event_to_graph": ("ume.processing", "apply_event_to_graph"),
-    "ProcessingError": ("ume.processing", "ProcessingError"),
-    "log_audit_entry": ("ume.audit", "log_audit_entry"),
-    "get_audit_entries": ("ume.audit", "get_audit_entries"),
-    "snapshot_graph_to_file": ("ume.snapshot", "snapshot_graph_to_file"),
-    "load_graph_from_file": ("ume.snapshot", "load_graph_from_file"),
-    "load_graph_into_existing": ("ume.snapshot", "load_graph_into_existing"),
-    "SnapshotError": ("ume.snapshot", "SnapshotError"),
-    "validate_event_dict": ("ume.schema_utils", "validate_event_dict"),
-    "GraphSchema": ("ume.graph_schema", "GraphSchema"),
-    "load_default_schema": ("ume.graph_schema", "load_default_schema"),
-    "GraphSchemaManager": ("ume.schema_manager", "GraphSchemaManager"),
-    "DEFAULT_SCHEMA_MANAGER": ("ume.schema_manager", "DEFAULT_SCHEMA_MANAGER"),
-    "ssl_config": ("ume.utils", "ssl_config"),
-    "EpisodicMemory": ("ume.memory", "EpisodicMemory"),
-    "SemanticMemory": ("ume.memory", "SemanticMemory"),
-    "ColdMemory": ("ume.memory", "ColdMemory"),
-    "LLMFerry": ("ume.llm_ferry", "LLMFerry"),
-    "score_text": ("ume.reliability", "score_text"),
-    "filter_low_confidence": ("ume.reliability", "filter_low_confidence"),
-    "AgentTask": ("ume.agent_orchestrator", "AgentTask"),
-    "AgentOrchestrator": ("ume.agent_orchestrator", "AgentOrchestrator"),
-    "Supervisor": ("ume.agent_orchestrator", "Supervisor"),
-    "Critic": ("ume.agent_orchestrator", "Critic"),
-    "MessageEnvelope": ("ume.message_bus", "MessageEnvelope"),
-    "ReflectionAgent": ("ume.agent_orchestrator", "ReflectionAgent"),
-    "Task": ("ume.dag_executor", "Task"),
-    "DAGExecutor": ("ume.dag_executor", "DAGExecutor"),
-    "DAGService": ("ume.dag_service", "DAGService"),
-    "ResourceScheduler": ("ume.resource_scheduler", "ResourceScheduler"),
-    "ScheduledTask": ("ume.resource_scheduler", "ScheduledTask"),
-    "Dossier": ("ume.dossier", "Dossier"),
-    "tokenize": ("ume.tokenization", "tokenize"),
-    "create_graph_adapter": ("ume.factories", "create_graph_adapter"),
-    "create_vector_store": ("ume.factories", "create_vector_store"),
-    "create_graph": ("ume.resources", "create_graph"),
-    "graph_factory": ("ume.resources", "graph_factory"),
-    "vector_store_factory": ("ume.resources", "vector_store_factory"),
-    "get_capability_manifest": ("ume.factories", "get_capability_manifest"),
-    "start_dossier_snapshot_scheduler": (
-        "ume.dossier.scheduler",
-        "start_dossier_snapshot_scheduler",
+    "PermissionsGraphAdapter": _ShimExport(
+        module="ume.permissions_adapter",
+        attr="PermissionsGraphAdapter",
+        deprecation_key="ume.__getattr__.compat_exports.PermissionsGraphAdapter",
     ),
-    "stop_dossier_snapshot_scheduler": (
-        "ume.dossier.scheduler",
-        "stop_dossier_snapshot_scheduler",
+    "PolicyViolationError": _ShimExport(
+        module="ume.plugins.alignment",
+        attr="PolicyViolationError",
+        deprecation_key="ume.__getattr__.compat_exports.PolicyViolationError",
+    ),
+    "apply_event_to_graph": _ShimExport(
+        module="ume.processing",
+        attr="apply_event_to_graph",
+        deprecation_key="ume.__getattr__.compat_exports.apply_event_to_graph",
+    ),
+    "ProcessingError": _ShimExport(
+        module="ume.processing",
+        attr="ProcessingError",
+        deprecation_key="ume.__getattr__.compat_exports.ProcessingError",
+    ),
+    "snapshot_graph_to_file": _ShimExport(
+        module="ume.snapshot",
+        attr="snapshot_graph_to_file",
+        deprecation_key="ume.__getattr__.compat_exports.snapshot_graph_to_file",
+    ),
+    "load_graph_from_file": _ShimExport(
+        module="ume.snapshot",
+        attr="load_graph_from_file",
+        deprecation_key="ume.__getattr__.compat_exports.load_graph_from_file",
+    ),
+    "SnapshotError": _ShimExport(
+        module="ume.snapshot",
+        attr="SnapshotError",
+        deprecation_key="ume.__getattr__.compat_exports.SnapshotError",
+    ),
+    "DEFAULT_SCHEMA_MANAGER": _ShimExport(
+        module="ume.schema_manager",
+        attr="DEFAULT_SCHEMA_MANAGER",
+        deprecation_key="ume.__getattr__.compat_exports.DEFAULT_SCHEMA_MANAGER",
+    ),
+    "get_audit_entries": _ShimExport(
+        module="ume.audit",
+        attr="get_audit_entries",
+        deprecation_key="ume.__getattr__.compat_exports.get_audit_entries",
+    ),
+    "Task": _ShimExport(
+        module="ume.dag_executor",
+        attr="Task",
+        deprecation_key="ume.__getattr__.compat_exports.Task",
+    ),
+    "DAGExecutor": _ShimExport(
+        module="ume.dag_executor",
+        attr="DAGExecutor",
+        deprecation_key="ume.__getattr__.compat_exports.DAGExecutor",
     ),
 }
 
@@ -145,8 +190,9 @@ def __getattr__(name: str) -> object:
     if name in _RUNTIME_EXPORTS:
         from .bootstrap.runtime import bootstrap_runtime
 
+        spec = _RUNTIME_EXPORTS[name]
         warn_deprecated(
-            "ume.__getattr__.runtime_export_fallback",
+            spec.deprecation_key,
             detail=(
                 f"Requested symbol ume.{name}. Falling back to compatibility shim. "
                 "Call ume.bootstrap.runtime.bootstrap_runtime() from service entry points."
@@ -157,13 +203,13 @@ def __getattr__(name: str) -> object:
         return runtime_exports[name]
 
     if name in _COMPAT_EXPORTS:
-        mod_name, attr = _COMPAT_EXPORTS[name]
+        spec = _COMPAT_EXPORTS[name]
         warn_deprecated(
-            "ume.__getattr__.compat_exports",
-            detail=f"Requested symbol ume.{name} currently resolves to {mod_name}.{attr}.",
+            spec.deprecation_key,
+            detail=f"Requested symbol ume.{name} currently resolves to {spec.module}.{spec.attr}.",
             stacklevel=2,
         )
-        value: Any = getattr(import_module(mod_name), attr)
+        value: Any = getattr(import_module(spec.module), spec.attr)
         globals()[name] = value
         return value
 

--- a/src/ume/cli/prompt.py
+++ b/src/ume/cli/prompt.py
@@ -17,33 +17,24 @@ if _src_path.exists() and str(_src_path) not in sys.path:
     sys.path.insert(0, str(_src_path))
 
 from ume.config import settings
-import ume
 from ume.events.contract import canonicalize_event
-from ume.services.mutate import MutationError
-from ume.services.event_processor import DEFAULT_EVENT_PROCESSOR
-
-# Support tests that provide a lightweight ``ume`` stub without all attributes.
-load_graph_into_existing = getattr(ume, "load_graph_into_existing", lambda *_args, **_kw: None)
-snapshot_graph_to_file = getattr(ume, "snapshot_graph_to_file", lambda *_args, **_kw: None)
-create_graph_adapter = getattr(ume, "create_graph_adapter", lambda *_args, **_kw: None)
-RoleBasedGraphAdapter = getattr(ume, "RoleBasedGraphAdapter", object)
-enable_snapshot_autosave_and_restore = getattr(
-    ume, "enable_snapshot_autosave_and_restore", lambda *_args, **_kw: None
-)
-ProcessingError = getattr(ume, "ProcessingError", Exception)
-EventError = getattr(ume, "EventError", Exception)
-SnapshotError = getattr(ume, "SnapshotError", Exception)
-IGraphAdapter = getattr(ume, "IGraphAdapter", object)
-log_audit_entry = getattr(ume, "log_audit_entry", lambda *_args, **_kw: None)
-get_audit_entries = getattr(ume, "get_audit_entries", lambda *_args, **_kw: [])
+from ume.audit import get_audit_entries, log_audit_entry
+from ume.auto_snapshot import enable_snapshot_autosave_and_restore
 from ume.benchmarks import benchmark_vector_store
+from ume.event import EventError
+from ume.factories import create_graph_adapter
+from ume.graph_adapter import IGraphAdapter
+from ume.rbac_adapter import RoleBasedGraphAdapter
+from ume.schema_manager import DEFAULT_SCHEMA_MANAGER
+from ume.services.event_processor import DEFAULT_EVENT_PROCESSOR
+from ume.services.mutate import MutationError
+from ume.snapshot import SnapshotError, load_graph_into_existing, snapshot_graph_to_file
+from ume.processing import ProcessingError
 
 try:  # optional dependency for federation features
     from ume.federation import MirrorMakerDriver
 except Exception:  # pragma: no cover - federation optional
     MirrorMakerDriver = None  # type: ignore[misc]
-from ume import DEFAULT_SCHEMA_MANAGER
-
 
 class UMEPrompt(Cmd):
     intro = "Welcome to UME CLI. Type help or ? to list commands.\n"

--- a/src/ume/deprecations.py
+++ b/src/ume/deprecations.py
@@ -55,20 +55,6 @@ DEPRECATION_REGISTRY: dict[str, DeprecationSpec] = {
         sunset_date=date(2026, 7, 1),
         status="active",
     ),
-    "ume.__getattr__.runtime_export_fallback": DeprecationSpec(
-        key="ume.__getattr__.runtime_export_fallback",
-        replacement="ume.bootstrap.runtime.bootstrap_runtime",
-        sunset_version="0.3.0",
-        sunset_date=date(2026, 7, 1),
-        status="active",
-    ),
-    "ume.__getattr__.compat_exports": DeprecationSpec(
-        key="ume.__getattr__.compat_exports",
-        replacement="Direct module imports from canonical module paths",
-        sunset_version="0.4.0",
-        sunset_date=date(2026, 10, 1),
-        status="active",
-    ),
     "ume.stream_processor": DeprecationSpec(
         key="ume.stream_processor",
         replacement="ume.pipeline.stream_processor",
@@ -77,6 +63,55 @@ DEPRECATION_REGISTRY: dict[str, DeprecationSpec] = {
         status="active",
     ),
 }
+
+for symbol in (
+    "Neo4jGraph",
+    "VectorBackend",
+    "VectorStore",
+    "VectorStoreListener",
+    "create_default_store",
+    "FaissBackend",
+    "ChromaBackend",
+    "generate_embedding",
+    "OntologyListener",
+    "configure_ontology_graph",
+):
+    DEPRECATION_REGISTRY[f"ume.__getattr__.runtime_export_fallback.{symbol}"] = DeprecationSpec(
+        key=f"ume.{symbol}",
+        replacement="ume.bootstrap.runtime.bootstrap_runtime",
+        sunset_version="0.3.0",
+        sunset_date=date(2026, 7, 1),
+        status="active",
+        removal_note="Top-level runtime export fallback retained for external callers only.",
+    )
+
+_COMPAT_REPLACEMENTS = {
+    "MockGraph": "ume.graph.MockGraph",
+    "PersistentGraph": "ume.persistent_graph.PersistentGraph",
+    "RoleBasedGraphAdapter": "ume.rbac_adapter.RoleBasedGraphAdapter",
+    "AccessDeniedError": "ume.rbac_adapter.AccessDeniedError",
+    "PermissionsGraphAdapter": "ume.permissions_adapter.PermissionsGraphAdapter",
+    "PolicyViolationError": "ume.plugins.alignment.PolicyViolationError",
+    "apply_event_to_graph": "ume.processing.apply_event_to_graph",
+    "ProcessingError": "ume.processing.ProcessingError",
+    "snapshot_graph_to_file": "ume.snapshot.snapshot_graph_to_file",
+    "load_graph_from_file": "ume.snapshot.load_graph_from_file",
+    "SnapshotError": "ume.snapshot.SnapshotError",
+    "DEFAULT_SCHEMA_MANAGER": "ume.schema_manager.DEFAULT_SCHEMA_MANAGER",
+    "get_audit_entries": "ume.audit.get_audit_entries",
+    "Task": "ume.dag_executor.Task",
+    "DAGExecutor": "ume.dag_executor.DAGExecutor",
+}
+
+for symbol, replacement in _COMPAT_REPLACEMENTS.items():
+    DEPRECATION_REGISTRY[f"ume.__getattr__.compat_exports.{symbol}"] = DeprecationSpec(
+        key=f"ume.{symbol}",
+        replacement=replacement,
+        sunset_version="0.4.0",
+        sunset_date=date(2026, 10, 1),
+        status="active",
+        removal_note="Top-level compatibility export retained for external callers only.",
+    )
 
 
 def is_past_sunset(spec: DeprecationSpec, *, now: datetime | None = None) -> bool:

--- a/tests/test_deprecated_callsites.py
+++ b/tests/test_deprecated_callsites.py
@@ -1,5 +1,17 @@
+from pathlib import Path
+
 from scripts.check_deprecated_callsites import find_violations
 
 
 def test_no_new_deprecated_callsites() -> None:
     assert find_violations() == []
+
+
+def test_detects_new_top_level_compat_import(tmp_path: Path) -> None:
+    sample = tmp_path / "src" / "demo.py"
+    sample.parent.mkdir(parents=True)
+    sample.write_text("from ume import MockGraph\n", encoding="utf-8")
+
+    assert find_violations(tmp_path) == [
+        "src/demo.py:1: deprecated callsite for ume.MockGraph"
+    ]


### PR DESCRIPTION
### Motivation

- Reduce the implicit top-level compatibility/runtime shims in `src/ume/__init__.py` so first-party code imports canonical modules directly and only externally required shims remain with explicit sunset metadata.
- Remove in-tree fallback usage where possible (migrate `ume` internal callsites) to avoid accidental new internal dependencies on deprecated top-level exports.
- Fail CI fast on new internal references to deprecated top-level exports by adding a static checker and an allowlist for legacy test surfaces.

### Description

- Replace the ad-hoc `_RUNTIME_EXPORTS`/`_COMPAT_EXPORTS` maps with a per-symbol `_ShimExport` dataclass and prune the compatibility map to only retain externally-justified shims in `src/ume/__init__.py`.
- Migrate first-party callsites to canonical imports (notably `src/ume/cli/prompt.py` now imports `create_graph_adapter`, `DEFAULT_SCHEMA_MANAGER`, snapshot/audit helpers, and other symbols from their canonical modules instead of through `ume`).
- Expand `src/ume/deprecations.py` to declare per-symbol deprecation keys, replacement imports, target sunset versions/dates, and removal notes for runtime and compat shims.
- Add a stricter `scripts/check_deprecated_callsites.py` that detects forbidden top-level `from ume import ...` usages (with a legacy allowlist) and extend CI (`.github/workflows/ci.yml`) to run this check; also add `tests/test_deprecated_callsites.py` to cover the checker.
- Publish a migration matrix in `docs/ARCHITECTURE_OVERVIEW.md` documenting keep/remove/migrate decisions, replacement imports, and target removal versions for `_RUNTIME_EXPORTS` and `_COMPAT_EXPORTS`.

### Testing

- Ran `python scripts/check_deprecated_callsites.py` and it completed with no violations for the repository state (passed).
- Ran `pytest tests/test_deprecated_callsites.py` and the new regression tests passed (2 passed).
- Ran `pytest tests/test_import_safety.py` to verify import safety after migrating callsites and it passed.
- Ran `ruff` on the modified files (`src/ume/__init__.py`, `src/ume/cli/prompt.py`, `src/ume/deprecations.py`, `scripts/check_deprecated_callsites.py`, `tests/test_deprecated_callsites.py`) and the linter checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab9ae60b08326a0065070ba5ddf21)