### PR TITLE
Add dashboard stream transport abstraction, formal contract docs, and conformance tests

### DIFF
--- a/docs/FRONTEND_ARCHITECTURE.md
+++ b/docs/FRONTEND_ARCHITECTURE.md
@@ -19,7 +19,7 @@ This document describes UI architecture in a framework-neutral way, then records
    - Stores session/auth state and view model state.
    - Exposes deterministic update functions.
 3. **Data access layer**
-   - Encapsulates HTTP + SSE calls to UME backend.
+   - Encapsulates HTTP + streaming transport calls to UME backend.
    - Handles token attachment, retries, and stream resume policy.
 4. **Domain utilities**
    - Pure helpers for shaping backend payloads into view models.
@@ -32,12 +32,75 @@ This document describes UI architecture in a framework-neutral way, then records
 - Treat `control.backpressure` events as data-loss signals and trigger a catch-up flow.
 - Keep REST compatibility paths (`/dashboard/stats`, `/dashboard/recent_events`, `/pii/redactions`) for explicit refresh and stream fallback.
 
+### Formal transport contract
+
+The canonical dashboard real-time contract is transport-neutral even though the currently deployed backend endpoint is SSE-first.
+Any future transport, including WebSocket, must preserve the same auth, replay, and payload semantics.
+
+#### Supported transports
+
+- **SSE (canonical production transport):** `GET /dashboard/stream` with `Accept: text/event-stream`.
+- **WebSocket (migration/reference transport):** clients may bind the same event envelope to a WebSocket endpoint when the backend advertises one. Transport swaps must not require view-layer rewrites.
+
+#### Authentication model
+
+- Every transport uses the same bearer token obtained from `POST /auth/token`.
+- SSE clients send `Authorization: Bearer <token>`.
+- WebSocket clients must forward the same bearer token during the handshake using a negotiated subprotocol, header, or equivalent server-approved handshake mechanism.
+- Auth failures are terminal for the current connection attempt and should not mutate the replay cursor.
+
+#### Replay semantics
+
+- `lastEventId` is the canonical replay cursor and always represents the most recently processed stream event ID.
+- For SSE, clients send the cursor using the standard `Last-Event-ID` header; the query parameter `lastEventId` is a compatibility fallback.
+- When both are supplied, `Last-Event-ID` takes precedence.
+- Server replay resumes at `lastEventId + 1`.
+- If both `cursor` and a replay cursor are provided, the server starts at the greater offset.
+- Clients must persist the last acknowledged event ID only after a digest or control event has been parsed successfully.
+- `control.kind=backpressure` indicates a gap; clients must refresh via REST before treating the stream as current again.
+
+#### Event envelope schema
+
+All transports must emit the same logical envelope before framework-specific mapping:
+
+```json
+{
+  "event": "dashboard_digest",
+  "id": "42",
+  "data": {
+    "cursor_offset": 42,
+    "stats": {
+      "node_count": 32,
+      "edge_count": 71,
+      "vector_index_size": 32
+    },
+    "recent_events": [
+      {
+        "offset": 42,
+        "event_id": "evt-42",
+        "event_type": "UPDATE_NODE_ATTRIBUTES",
+        "payload_hash": "8f7d..."
+      }
+    ],
+    "redacted_count": 11
+  }
+}
+```
+
+Envelope requirements:
+
+- `event`: string event discriminator. Supported values today are `dashboard_digest` and `control`.
+- `id`: stringified ledger offset used for replay and ordering.
+- `data`: JSON object matching the backend contract models.
+- Ordering is monotonic by ledger offset.
+- `dashboard_digest.data.recent_events` must remain sanitized metadata only; raw payload bodies must not be emitted.
+
 ### Transport feature flags
 
 The React SPA selects transport at runtime using Vite env flags:
 
 - `VITE_ENABLE_DASHBOARD_STREAM` (`true` by default): master switch for stream subscription.
-- `VITE_DASHBOARD_STREAM_TRANSPORT` (`sse` default): current transport selector.
+- `VITE_DASHBOARD_STREAM_TRANSPORT` (`sse` default): transport selector (`sse` or `websocket`).
 - `VITE_DASHBOARD_REST_FALLBACK` (`true` default): whether to fall back to REST when stream errors or backpressure occurs.
 
 Backend capability hints are available via `GET /dashboard/transport_features`.
@@ -46,6 +109,7 @@ Backend capability hints are available via `GET /dashboard/transport_features`.
 
 - Unit test view/state/domain logic in isolation.
 - Integration test data-access adapters with mocked transport.
+- Conformance test `/dashboard/stream` envelope, auth, and replay behavior so future framework migrations inherit the same contract.
 - End-to-end test authenticated real-time subscription and reconnect behavior.
 
 ## Concrete framework decision
@@ -57,3 +121,8 @@ Rationale:
 - Existing codebase and tests are already built around React components.
 - The dashboard deployment model is static assets served alongside the API.
 - Current build/test tooling (`vite`, `vitest`) is already integrated in repository workflows.
+
+## Next.js migration note
+
+Next.js remains a valid roadmap target only if it consumes the same canonical transport contract.
+To keep that migration low-risk, the repository includes a parallel reference client module at `frontend/src/next/dashboardStreamClient.js` that reuses the shared transport abstraction instead of redefining stream semantics.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@ import GraphNetwork from './GraphNetwork';
 import NodeSearch from './NodeSearch';
 import EdgeList from './EdgeList';
 import LedgerHistory from './LedgerHistory';
-import { subscribeDashboardStream } from './realtimeStream';
+import { createDashboardStreamClient } from './realtimeStream';
 
 const POLICY_CONTENT = {
   'allow.rego': `package ume
@@ -106,8 +106,7 @@ function App() {
 
     loadPolicies();
 
-    const canStream = STREAM_ENABLED && STREAM_TRANSPORT === 'sse';
-    if (!canStream) {
+    if (!STREAM_ENABLED) {
       setStreamStatus('rest');
       void loadStats();
       void loadEvents();
@@ -115,14 +114,15 @@ function App() {
       return;
     }
 
-    setStreamStatus('connecting');
-    const unsubscribe = subscribeDashboardStream({
+    const streamClient = createDashboardStreamClient({ transport: STREAM_TRANSPORT });
+    setStreamStatus(`connecting:${STREAM_TRANSPORT}`);
+    const unsubscribe = streamClient.subscribe({
       token,
       onDigest: (digest) => {
         setStats(digest.stats);
         setEvents(digest.recent_events);
         setRedactedCount(digest.redacted_count);
-        setStreamStatus('connected');
+        setStreamStatus(`connected:${STREAM_TRANSPORT}`);
       },
       onControl: (control) => {
         if (control.kind === 'backpressure' && REST_FALLBACK) {
@@ -133,13 +133,15 @@ function App() {
       },
       onError: () => {
         if (REST_FALLBACK) {
-          setStreamStatus('rest-fallback');
+          setStreamStatus(`rest-fallback:${STREAM_TRANSPORT}`);
           void loadStats();
           void loadEvents();
           void loadRedactions();
+          return;
         }
+        setStreamStatus(`error:${STREAM_TRANSPORT}`);
       },
-      onReconnect: () => setStreamStatus('reconnecting'),
+      onReconnect: () => setStreamStatus(`reconnecting:${STREAM_TRANSPORT}`),
     });
 
     return () => unsubscribe();

--- a/frontend/src/next/dashboardStreamClient.js
+++ b/frontend/src/next/dashboardStreamClient.js
@@ -1,0 +1,9 @@
+import { createDashboardStreamClient } from '../realtimeStream';
+
+export function createNextDashboardStreamClient(config = {}) {
+  return createDashboardStreamClient(config);
+}
+
+export function connectDashboardStream(config) {
+  return createNextDashboardStreamClient(config.client).subscribe(config.subscription);
+}

--- a/frontend/src/realtimeStream.js
+++ b/frontend/src/realtimeStream.js
@@ -1,5 +1,7 @@
 const DEFAULT_RECONNECT_MS = 1000;
 const MAX_RECONNECT_MS = 8000;
+const DEFAULT_SSE_PATH = '/dashboard/stream';
+const DEFAULT_WS_PATH = '/dashboard/ws';
 
 function parseSseChunk(state, chunk, onFrame) {
   state.buffer += chunk;
@@ -19,54 +21,153 @@ function parseSseChunk(state, chunk, onFrame) {
   }
 }
 
-export function subscribeDashboardStream({ token, onDigest, onControl, onError, onReconnect }) {
-  const state = { active: true, buffer: '', reconnectMs: DEFAULT_RECONNECT_MS, lastEventId: null };
-  const decoder = new TextDecoder();
-
-  const connect = async () => {
-    while (state.active) {
-      const params = new URLSearchParams();
-      if (state.lastEventId !== null) params.set('lastEventId', state.lastEventId);
-      const url = `/dashboard/stream${params.size ? `?${params}` : ''}`;
-
-      try {
-        const response = await fetch(url, {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: 'text/event-stream',
-          },
-        });
-
-        if (!response.ok || !response.body) {
-          throw new Error(`dashboard_stream_http_${response.status}`);
-        }
-
-        state.reconnectMs = DEFAULT_RECONNECT_MS;
-        const reader = response.body.getReader();
-
-        while (state.active) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          parseSseChunk(state, decoder.decode(value, { stream: true }), (frame) => {
-            if (frame.id !== undefined) state.lastEventId = frame.id;
-            if (frame.event === 'dashboard_digest') onDigest(JSON.parse(frame.data));
-            if (frame.event === 'control') onControl(JSON.parse(frame.data));
-          });
-        }
-      } catch (error) {
-        onError(error);
-      }
-
-      if (!state.active) break;
-      onReconnect(state.reconnectMs);
-      await new Promise((resolve) => setTimeout(resolve, state.reconnectMs));
-      state.reconnectMs = Math.min(state.reconnectMs * 2, MAX_RECONNECT_MS);
-    }
-  };
-
-  void connect();
-
-  return () => {
-    state.active = false;
+function createStreamState() {
+  return {
+    active: true,
+    buffer: '',
+    reconnectMs: DEFAULT_RECONNECT_MS,
+    lastEventId: null,
   };
 }
+
+function appendReplayMarker(url, lastEventId, queryParam = 'lastEventId') {
+  if (lastEventId === null || lastEventId === undefined) return url;
+  const nextUrl = new URL(url, window.location.origin);
+  nextUrl.searchParams.set(queryParam, lastEventId);
+  return `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`;
+}
+
+function dispatchEnvelope(frame, handlers, state) {
+  if (frame.id !== undefined) state.lastEventId = frame.id;
+  const payload = JSON.parse(frame.data);
+  if (frame.event === 'dashboard_digest') handlers.onDigest(payload);
+  if (frame.event === 'control') handlers.onControl(payload);
+}
+
+async function runSseSubscription({ token, state, handlers, endpoint = DEFAULT_SSE_PATH }) {
+  const decoder = new TextDecoder();
+
+  while (state.active) {
+    const url = appendReplayMarker(endpoint, state.lastEventId);
+
+    try {
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'text/event-stream',
+        },
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error(`dashboard_stream_http_${response.status}`);
+      }
+
+      state.reconnectMs = DEFAULT_RECONNECT_MS;
+      const reader = response.body.getReader();
+
+      while (state.active) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        parseSseChunk(state, decoder.decode(value, { stream: true }), (frame) =>
+          dispatchEnvelope(frame, handlers, state),
+        );
+      }
+    } catch (error) {
+      handlers.onError(error);
+    }
+
+    if (!state.active) break;
+    handlers.onReconnect(state.reconnectMs);
+    await new Promise((resolve) => setTimeout(resolve, state.reconnectMs));
+    state.reconnectMs = Math.min(state.reconnectMs * 2, MAX_RECONNECT_MS);
+  }
+}
+
+function toWebSocketUrl(path, lastEventId) {
+  const url = new URL(path, window.location.origin);
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  if (lastEventId !== null && lastEventId !== undefined) {
+    url.searchParams.set('lastEventId', lastEventId);
+  }
+  return url.toString();
+}
+
+async function runWebSocketSubscription({ token, state, handlers, endpoint = DEFAULT_WS_PATH }) {
+  while (state.active) {
+    let settled = false;
+
+    try {
+      await new Promise((resolve) => {
+        const socket = new WebSocket(toWebSocketUrl(endpoint, state.lastEventId), [token]);
+
+        socket.onopen = () => {
+          settled = true;
+          state.reconnectMs = DEFAULT_RECONNECT_MS;
+        };
+
+        socket.onmessage = (message) => {
+          const frame = JSON.parse(message.data);
+          dispatchEnvelope(frame, handlers, state);
+        };
+
+        socket.onerror = () => {
+          handlers.onError(new Error('dashboard_stream_websocket_error'));
+        };
+
+        socket.onclose = () => {
+          resolve();
+        };
+
+        if (!state.active) {
+          socket.close();
+          resolve();
+        }
+      });
+    } catch (error) {
+      handlers.onError(error);
+    }
+
+    if (!state.active) break;
+    if (!settled) {
+      handlers.onError(new Error('dashboard_stream_websocket_unavailable'));
+    }
+    handlers.onReconnect(state.reconnectMs);
+    await new Promise((resolve) => setTimeout(resolve, state.reconnectMs));
+    state.reconnectMs = Math.min(state.reconnectMs * 2, MAX_RECONNECT_MS);
+  }
+}
+
+export function createDashboardStreamClient({
+  transport = 'sse',
+  sseEndpoint = DEFAULT_SSE_PATH,
+  webSocketEndpoint = DEFAULT_WS_PATH,
+} = {}) {
+  return {
+    subscribe({ token, onDigest, onControl, onError, onReconnect }) {
+      const state = createStreamState();
+      const handlers = {
+        onDigest: onDigest ?? (() => {}),
+        onControl: onControl ?? (() => {}),
+        onError: onError ?? (() => {}),
+        onReconnect: onReconnect ?? (() => {}),
+      };
+
+      if (transport === 'websocket') {
+        void runWebSocketSubscription({ token, state, handlers, endpoint: webSocketEndpoint });
+      } else {
+        void runSseSubscription({ token, state, handlers, endpoint: sseEndpoint });
+      }
+
+      return () => {
+        state.active = false;
+      };
+    },
+  };
+}
+
+export function subscribeDashboardStream(options) {
+  const { transport = 'sse', ...rest } = options;
+  return createDashboardStreamClient({ transport }).subscribe(rest);
+}
+
+export { appendReplayMarker, dispatchEnvelope, parseSseChunk, toWebSocketUrl };

--- a/frontend/src/realtimeStream.test.js
+++ b/frontend/src/realtimeStream.test.js
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { appendReplayMarker, createDashboardStreamClient, toWebSocketUrl } from './realtimeStream';
+
+describe('realtimeStream transport abstraction', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete global.fetch;
+    delete global.WebSocket;
+  });
+
+  it('appends replay markers for SSE reconnects', () => {
+    expect(appendReplayMarker('/dashboard/stream', '12')).toBe('/dashboard/stream?lastEventId=12');
+  });
+
+  it('delivers dashboard digest frames over SSE', async () => {
+    const encoder = new TextEncoder();
+    const frames = [
+      'id: 7\nevent: dashboard_digest\ndata: {"cursor_offset":7,"stats":{"node_count":1,"edge_count":0,"vector_index_size":1},"recent_events":[],"redacted_count":0}\n\n',
+    ];
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      body: {
+        getReader() {
+          let index = 0;
+          return {
+            read: vi.fn().mockImplementation(async () => {
+              if (index >= frames.length) {
+                return { done: true, value: undefined };
+              }
+              const value = encoder.encode(frames[index]);
+              index += 1;
+              return { done: false, value };
+            }),
+          };
+        },
+      },
+    });
+
+    const onDigest = vi.fn();
+    const client = createDashboardStreamClient({ transport: 'sse' });
+    client.subscribe({ token: 'token', onDigest, onControl: vi.fn(), onError: vi.fn(), onReconnect: vi.fn() });
+
+    await vi.waitFor(() => expect(onDigest).toHaveBeenCalledWith(expect.objectContaining({ cursor_offset: 7 })));
+  });
+
+  it('builds websocket URLs and dispatches shared envelopes', async () => {
+    const openSockets = [];
+    class WebSocketStub {
+      constructor(url, protocols) {
+        this.url = url;
+        this.protocols = protocols;
+        openSockets.push(this);
+        queueMicrotask(() => {
+          this.onopen?.();
+          this.onmessage?.({
+            data: JSON.stringify({
+              event: 'control',
+              id: '9',
+              data: JSON.stringify({ kind: 'heartbeat', cursor_offset: 9, dropped_events: 0 }),
+            }),
+          });
+          this.onclose?.();
+        });
+      }
+
+      close() {}
+    }
+    global.WebSocket = WebSocketStub;
+
+    const onControl = vi.fn();
+    const client = createDashboardStreamClient({ transport: 'websocket', webSocketEndpoint: '/dashboard/ws' });
+    const unsubscribe = client.subscribe({ token: 'token', onDigest: vi.fn(), onControl, onError: vi.fn(), onReconnect: vi.fn() });
+
+    await vi.waitFor(() => expect(onControl).toHaveBeenCalledWith(expect.objectContaining({ kind: 'heartbeat' })));
+    expect(openSockets[0].url).toBe(toWebSocketUrl('/dashboard/ws', null));
+    expect(openSockets[0].protocols).toEqual(['token']);
+    unsubscribe();
+  });
+});

--- a/tests/integration/test_dashboard_stream.py
+++ b/tests/integration/test_dashboard_stream.py
@@ -1,8 +1,8 @@
 import json
 
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from ume.api import app, configure_graph
 from ume.config import settings
 from ume.event_ledger import EventLedger
 from ume.graph import MockGraph
@@ -17,12 +17,13 @@ class _VectorStoreStub:
         return None
 
 
-def _token(client: TestClient) -> str:
-    response = client.post(
-        "/auth/token",
-        data={"username": settings.UME_OAUTH_USERNAME, "password": settings.UME_OAUTH_PASSWORD},
-    )
-    return response.json()["access_token"]
+def _build_client(graph: MockGraph, vector_store: _VectorStoreStub) -> TestClient:
+    app = FastAPI()
+    app.include_router(dashboard_routes.router)
+    app.dependency_overrides[dashboard_routes.get_current_role] = lambda: settings.UME_OAUTH_ROLE
+    dashboard_routes.get_graph = lambda: graph
+    dashboard_routes.get_vector_store = lambda: vector_store
+    return TestClient(app)
 
 
 def _seed_ledger(ledger: EventLedger, count: int) -> None:
@@ -40,33 +41,44 @@ def _seed_ledger(ledger: EventLedger, count: int) -> None:
         )
 
 
-def _read_dashboard_digest_payloads(
+def _read_dashboard_frames(
     client: TestClient,
     *,
-    token: str,
     expected: int,
     headers: dict[str, str] | None = None,
-) -> list[dict[str, object]]:
-    payloads: list[dict[str, object]] = []
-    req_headers = {"Authorization": f"Bearer {token}", "Accept": "text/event-stream"}
+    query: str = "",
+) -> tuple[list[dict[str, object]], str | None]:
+    frames: list[dict[str, object]] = []
+    req_headers = {"Authorization": "Bearer test-token", "Accept": "text/event-stream"}
     if headers:
         req_headers.update(headers)
 
-    with client.stream("GET", f"/dashboard/stream?max_events={expected}", headers=req_headers) as response:
+    content_type = None
+    with client.stream("GET", f"/dashboard/stream?max_events={expected}{query}", headers=req_headers) as response:
         assert response.status_code == 200
-        pending = False
+        content_type = response.headers.get("content-type")
+        current: dict[str, str] = {}
         for line in response.iter_lines():
-            if not line:
-                continue
-            if line.startswith("event: dashboard_digest"):
-                pending = True
-                continue
-            if pending and line.startswith("data: "):
-                payloads.append(json.loads(line[len("data: ") :]))
-                pending = False
-                if len(payloads) >= expected:
+            if line == "":
+                if current.get("data"):
+                    frames.append(
+                        {
+                            "event": current.get("event", "message"),
+                            "id": current.get("id"),
+                            "data": json.loads(current["data"]),
+                        }
+                    )
+                current = {}
+                if len(frames) >= expected:
                     break
-    return payloads
+                continue
+            if line.startswith("event:"):
+                current["event"] = line.split(":", 1)[1].strip()
+            elif line.startswith("id:"):
+                current["id"] = line.split(":", 1)[1].strip()
+            elif line.startswith("data:"):
+                current["data"] = current.get("data", "") + line.split(":", 1)[1].strip()
+    return frames, content_type
 
 
 def test_dashboard_stream_emits_sanitized_updates(tmp_path, monkeypatch) -> None:
@@ -74,39 +86,54 @@ def test_dashboard_stream_emits_sanitized_updates(tmp_path, monkeypatch) -> None
     graph.add_node("n0", {})
     graph.add_node("n1", {})
     graph.add_edge("n0", "n1", "L")
-    configure_graph(graph)
-    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
-    app.state.vector_store = _VectorStoreStub()
+    vector_store = _VectorStoreStub()
 
     ledger = EventLedger(str(tmp_path / "dashboard_stream.db"))
     _seed_ledger(ledger, 2)
     monkeypatch.setattr(dashboard_routes, "event_ledger", ledger)
 
-    with TestClient(app) as client:
-        payloads = _read_dashboard_digest_payloads(client, token=_token(client), expected=2)
+    with _build_client(graph, vector_store) as client:
+        frames, content_type = _read_dashboard_frames(client, expected=2)
 
-    assert [item["cursor_offset"] for item in payloads] == [0, 1]
-    latest = payloads[-1]
+    assert content_type is not None and content_type.startswith("text/event-stream")
+    assert [frame["event"] for frame in frames] == ["dashboard_digest", "dashboard_digest"]
+    assert [frame["id"] for frame in frames] == ["0", "1"]
+    assert [frame["data"]["cursor_offset"] for frame in frames] == [0, 1]
+    latest = frames[-1]["data"]
     assert latest["stats"] == {"node_count": 2, "edge_count": 1, "vector_index_size": 2}
     assert isinstance(latest["recent_events"], list)
     assert "payload_hash" in latest["recent_events"][0]
+    assert "payload" not in latest["recent_events"][0]
 
 
-def test_dashboard_stream_resumes_with_last_event_id(tmp_path, monkeypatch) -> None:
-    configure_graph(MockGraph())
-    app.state.query_engine = type("QE", (), {"execute_cypher": lambda self, q: []})()
-    app.state.vector_store = _VectorStoreStub()
-
+def test_dashboard_stream_resumes_with_last_event_id_header_precedence(tmp_path, monkeypatch) -> None:
     ledger = EventLedger(str(tmp_path / "dashboard_stream_resume.db"))
-    _seed_ledger(ledger, 4)
+    _seed_ledger(ledger, 5)
     monkeypatch.setattr(dashboard_routes, "event_ledger", ledger)
 
-    with TestClient(app) as client:
-        resumed = _read_dashboard_digest_payloads(
+    with _build_client(MockGraph(), _VectorStoreStub()) as client:
+        frames, _ = _read_dashboard_frames(
             client,
-            token=_token(client),
             expected=2,
             headers={"Last-Event-ID": "1"},
+            query="&lastEventId=0",
         )
 
-    assert [item["cursor_offset"] for item in resumed] == [2, 3]
+    assert [frame["id"] for frame in frames] == ["2", "3"]
+    assert [frame["data"]["cursor_offset"] for frame in frames] == [2, 3]
+
+
+def test_dashboard_stream_uses_greater_of_cursor_and_replay_marker(tmp_path, monkeypatch) -> None:
+    ledger = EventLedger(str(tmp_path / "dashboard_stream_cursor.db"))
+    _seed_ledger(ledger, 5)
+    monkeypatch.setattr(dashboard_routes, "event_ledger", ledger)
+
+    with _build_client(MockGraph(), _VectorStoreStub()) as client:
+        frames, _ = _read_dashboard_frames(
+            client,
+            expected=1,
+            query="&cursor=4&lastEventId=1",
+        )
+
+    assert [frame["id"] for frame in frames] == ["4"]
+    assert frames[0]["data"]["cursor_offset"] == 4


### PR DESCRIPTION
### Motivation

- Define a canonical, transport-neutral dashboard real-time contract (SSE/WebSocket) so future frontend frameworks and migrations share the same expectations for auth, replay, and payloads.  
- Make switching transport implementations a runtime configuration rather than a view-layer rewrite to reduce migration surface and support a Next.js migration path.  
- Lock contract behavior with automated backend and frontend tests to avoid regressions in replay/envelope semantics.

### Description

- Add a formal transport contract and envelope schema to `docs/FRONTEND_ARCHITECTURE.md` describing supported transports, auth model, `lastEventId` replay rules, `control` semantics, and envelope requirements.  
- Refactor the frontend stream logic into a transport abstraction in `frontend/src/realtimeStream.js` with `createDashboardStreamClient({transport})`, shared envelope dispatch, SSE reconnect/replay handling, and an optional WebSocket implementation; preserve a compatibility helper `subscribeDashboardStream`.  
- Update app wiring in `frontend/src/App.jsx` to use the new `createDashboardStreamClient` with runtime transport selection via Vite env flags and enhance stream status reporting.  
- Add a small Next.js reference wrapper at `frontend/src/next/dashboardStreamClient.js` that reuses the shared transport client to ease migrations.  
- Add frontend unit tests `frontend/src/realtimeStream.test.js` for replay marker behavior, SSE envelope parsing, and WebSocket envelope dispatch.  
- Replace/extend the dashboard stream integration test at `tests/integration/test_dashboard_stream.py` to run the router via a local `FastAPI()` TestClient and assert SSE content-type, monotonic `id` assignment, sanitized `recent_events`, `Last-Event-ID` header precedence, and cursor-vs-replay selection.

### Testing

- Ran `python -m ruff check src tests` and lint checks passed.  
- Ran backend conformance tests with `PYTHONPATH=src python -m pytest tests/integration/test_dashboard_stream.py` and all tests passed (`3 passed`).  
- Ran frontend unit tests with `npm test -- --run realtimeStream.test.js` and the transport tests passed.  
- Built the frontend with `npm run build` and Vite completed successfully (produced bundle; reported chunk-size advisory only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69babd6c4e08832685c1ca9aaad918fc)