### PR TITLE
Canonicalize graph adapter contract imports to kernel

### DIFF
--- a/src/ume/__init__.py
+++ b/src/ume/__init__.py
@@ -9,7 +9,7 @@ from typing import Any
 from .bootstrap.config import load_config
 from .deprecations import warn_deprecated
 from .event import Event, EventError, EventType, parse_event
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 
 # Load only configuration by default. Optional runtimes are initialized via
 # ``ume.bootstrap.runtime.bootstrap_runtime`` in application entry points.

--- a/src/ume/adapters/registry.py
+++ b/src/ume/adapters/registry.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable, Mapping, Set as AbstractSet
 from importlib import import_module
 from typing import NotRequired, TypedDict, cast
 
-from ume.graph_adapter import IGraphAdapter
+from ume.kernel.graph_adapter import IGraphAdapter
 from ume.plugins.registry import (
     ConstructorMetadata,
     PluginRegistrationError,

--- a/src/ume/analytics.py
+++ b/src/ume/analytics.py
@@ -15,7 +15,7 @@ except ImportError:  # networkx>=3 removes the top-level pagerank helper
         pagerank as _nx_pagerank,
     )
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 
 
 def _to_networkx(graph: IGraphAdapter) -> nx.DiGraph:

--- a/src/ume/api.py
+++ b/src/ume/api.py
@@ -49,7 +49,7 @@ from .retention import (
 )
 
 from .rbac_adapter import AccessDeniedError
-from .graph_adapter import IGraphAdapter  # noqa: F401
+from .kernel.graph_adapter import IGraphAdapter  # noqa: F401
 from .vector_store import VectorStoreListener
 from .vector_outbox import VectorOutboxDispatcher
 from .factories import create_vector_store, get_capability_manifest

--- a/src/ume/api_deps.py
+++ b/src/ume/api_deps.py
@@ -14,7 +14,7 @@ from fastapi.security import OAuth2PasswordBearer
 
 from .config import settings
 from .rbac_adapter import RoleBasedGraphAdapter
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .async_graph_adapter import IAsyncGraphAdapter
 from .query import Neo4jQueryEngine
 from .vector_store import VectorStore

--- a/src/ume/arango_graph.py
+++ b/src/ume/arango_graph.py
@@ -5,7 +5,7 @@ import importlib
 import time
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Iterable, cast
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .graph_algorithms import GraphAlgorithmsMixin
 from .audit import log_audit_entry

--- a/src/ume/async_graph_adapter.py
+++ b/src/ume/async_graph_adapter.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple, cast
 from .persistent_graph import PersistentGraph
 from .processing import DEFAULT_VERSION, apply_event_to_graph
 from .event import Event, EventError
-from .graph_adapter import IGraphAdapter, AsyncAdapterMixin
+from .kernel.graph_adapter import IGraphAdapter, AsyncAdapterMixin
 from .services.mutate import MutationError, raise_for_rejected_outcome
 from .services.event_processor import EventProcessorService
 

--- a/src/ume/auto_snapshot.py
+++ b/src/ume/auto_snapshot.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Union
 import logging
 from collections.abc import Callable
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .snapshot import snapshot_graph_to_file, load_graph_into_existing
 
 logger = logging.getLogger(__name__)

--- a/src/ume/calendar_layer_routes.py
+++ b/src/ume/calendar_layer_routes.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from typing import List, cast
 
 from . import api_deps as deps
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .calendar_routes import _ensure_user_node
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError

--- a/src/ume/calendar_routes.py
+++ b/src/ume/calendar_routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from . import api_deps as deps
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .processing import ProcessingError

--- a/src/ume/cli/prompt.py
+++ b/src/ume/cli/prompt.py
@@ -23,7 +23,7 @@ from ume.auto_snapshot import enable_snapshot_autosave_and_restore
 from ume.benchmarks import benchmark_vector_store
 from ume.event import EventError
 from ume.factories import create_graph_adapter
-from ume.graph_adapter import IGraphAdapter
+from ume.kernel.graph_adapter import IGraphAdapter
 from ume.rbac_adapter import RoleBasedGraphAdapter
 from ume.schema_manager import DEFAULT_SCHEMA_MANAGER
 from ume.services.event_processor import DEFAULT_EVENT_PROCESSOR

--- a/src/ume/dashboard_routes.py
+++ b/src/ume/dashboard_routes.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, Header, Query
 from sse_starlette.sse import EventSourceResponse
 
 from .audit import get_audit_entries
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .api_deps import get_current_role, get_graph, get_vector_store
 from .event_ledger import event_ledger
 from .realtime_contracts import DashboardDigestEvent, GraphDigestControlEvent

--- a/src/ume/decisions_routes.py
+++ b/src/ume/decisions_routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from . import api_deps as deps
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .processing import ProcessingError

--- a/src/ume/factories.py
+++ b/src/ume/factories.py
@@ -24,7 +24,7 @@ from .capabilities import (
 from .capability_schema import build_capability_schema
 from .memory import EpisodicMemory, SemanticMemory
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .tracing import TracingGraphAdapter, is_tracing_enabled
 
 

--- a/src/ume/financial_account_routes.py
+++ b/src/ume/financial_account_routes.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from . import api_deps as deps
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .schema_manager import DEFAULT_SCHEMA_MANAGER

--- a/src/ume/graph.py
+++ b/src/ume/graph.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .graph_algorithms import GraphAlgorithmsMixin
 from .graph_schema import DEFAULT_SCHEMA
 from .processing import ProcessingError

--- a/src/ume/graph_algorithms.py
+++ b/src/ume/graph_algorithms.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Tuple, cast
 
 from .processing import ProcessingError
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 
 
 def shortest_path(graph: IGraphAdapter, source_id: str, target_id: str) -> List[str]:

--- a/src/ume/graph_mutations.py
+++ b/src/ume/graph_mutations.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .graph_schema import DEFAULT_SCHEMA, GraphSchema
 from .processing import ProcessingError
 from .schema_validation import validate_edge, validate_node_attributes

--- a/src/ume/graph_queries.py
+++ b/src/ume/graph_queries.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 
 
 def constrained_path(

--- a/src/ume/graph_routes.py
+++ b/src/ume/graph_routes.py
@@ -24,7 +24,7 @@ from .config import settings
 from .document_guru import reformat_document
 from .reliability import filter_low_confidence
 import inspect
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .async_graph_adapter import IAsyncGraphAdapter, ingest_event_async
 from .permissions_adapter import PermissionsGraphAdapter
 from .query import Neo4jQueryEngine, build_events_query

--- a/src/ume/neo4j_graph.py
+++ b/src/ume/neo4j_graph.py
@@ -11,7 +11,7 @@ from neo4j import GraphDatabase, Driver
 from .schema_manager import DEFAULT_SCHEMA_MANAGER
 from .processing import DEFAULT_VERSION
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .graph_algorithms import GraphAlgorithmsMixin
 from .replay_mixin import ReplayMixin

--- a/src/ume/ontology.py
+++ b/src/ume/ontology.py
@@ -7,7 +7,7 @@ from typing import Dict, List
 
 from .embedding import generate_embedding
 from .event import Event, EventType
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .processing import apply_event_to_graph
 from ._internal.listeners import GraphListener
 

--- a/src/ume/permissions_adapter.py
+++ b/src/ume/permissions_adapter.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .rbac_adapter import AccessDeniedError
 from .graph_schema import DEFAULT_SCHEMA
 

--- a/src/ume/permissions_routes.py
+++ b/src/ume/permissions_routes.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 from fastapi import APIRouter, Depends, HTTPException
 
 from . import api_deps as deps
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .permissions_adapter import PermissionsGraphAdapter
 from .utils import ensure_group_member
 

--- a/src/ume/persistent_graph.py
+++ b/src/ume/persistent_graph.py
@@ -2,7 +2,7 @@ import sqlite3
 import json
 import time
 from typing import Dict, Any, Optional, List, Tuple, cast
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .audit import log_audit_entry
 from .config import settings

--- a/src/ume/postgres_graph.py
+++ b/src/ume/postgres_graph.py
@@ -6,7 +6,7 @@ import json
 import time
 from typing import Any, Dict, List, Optional, Tuple, cast, TYPE_CHECKING
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .graph_algorithms import GraphAlgorithmsMixin
 from .audit import log_audit_entry

--- a/src/ume/rbac_adapter.py
+++ b/src/ume/rbac_adapter.py
@@ -2,7 +2,7 @@
 
 from typing import Dict, Any, Optional, List
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 
 
 class AccessDeniedError(PermissionError):

--- a/src/ume/redis_graph_adapter.py
+++ b/src/ume/redis_graph_adapter.py
@@ -5,7 +5,7 @@ import importlib
 import json
 from typing import Any, Dict, List, Optional, Tuple, cast, TYPE_CHECKING
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 from .graph_algorithms import GraphAlgorithmsMixin
 from .audit import log_audit_entry

--- a/src/ume/replay.py
+++ b/src/ume/replay.py
@@ -4,7 +4,7 @@ from enum import Enum
 from typing import TYPE_CHECKING
 from time import time
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .policy.pipeline import PolicyContext, PolicyDecision, build_default_policy_pipeline
 from .processing_errors import ProcessingError
 from .metrics import PIPELINE_REPLAY_LAG_SECONDS

--- a/src/ume/replay_mixin.py
+++ b/src/ume/replay_mixin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .events.contract import canonicalize_event
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only

--- a/src/ume/resources.py
+++ b/src/ume/resources.py
@@ -3,7 +3,7 @@
 
 from typing import Callable
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .factories import create_graph_adapter as _create_base_adapter
 from .vector_store import VectorBackend, create_default_store
 

--- a/src/ume/schema_manager.py
+++ b/src/ume/schema_manager.py
@@ -6,7 +6,7 @@ from importlib import import_module, resources
 from types import ModuleType
 from typing import Any, Dict, Iterable, Optional
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 
 from .graph_schema import GraphSchema, load_default_schema
 

--- a/src/ume/snapshot.py
+++ b/src/ume/snapshot.py
@@ -4,7 +4,7 @@ from typing import Union, List, Tuple, Any, Dict
 import pathlib  # For type hinting path-like objects
 
 from .persistent_graph import PersistentGraph
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .processing import ProcessingError
 
 

--- a/src/ume/snapshot_routes.py
+++ b/src/ume/snapshot_routes.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from .api_deps import get_graph, get_current_role
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .snapshot import snapshot_graph_to_file, load_graph_into_existing
 from .event_ledger import event_ledger
 from .replay import build_graph_from_ledger

--- a/src/ume/tracing.py
+++ b/src/ume/tracing.py
@@ -21,7 +21,7 @@ except Exception:  # pragma: no cover - allow tests without opentelemetry instal
 
 
 from .config import settings
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 
 
 class _DummyTracer:

--- a/src/ume/users_routes.py
+++ b/src/ume/users_routes.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from . import api_deps as deps
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .models import create_user, create_user_group
 from .permissions_adapter import PermissionsGraphAdapter
 from .rbac_adapter import AccessDeniedError

--- a/src/ume/utils.py
+++ b/src/ume/utils.py
@@ -3,7 +3,7 @@ import os
 
 from fastapi import HTTPException
 
-from .graph_adapter import IGraphAdapter
+from .kernel.graph_adapter import IGraphAdapter
 from .events.contract import canonicalize_event, canonical_to_camel_dict, canonical_to_legacy_dict
 
 

--- a/tests/architecture/test_graph_adapter_facade.py
+++ b/tests/architecture/test_graph_adapter_facade.py
@@ -1,0 +1,30 @@
+import ast
+from pathlib import Path
+
+from ume import graph_adapter as facade
+from ume.kernel import graph_adapter as kernel
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _class_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    return {node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)}
+
+
+def test_graph_adapter_contract_has_single_source_file() -> None:
+    kernel_path = ROOT / "src/ume/kernel/graph_adapter.py"
+    facade_path = ROOT / "src/ume/graph_adapter.py"
+
+    kernel_classes = _class_names(kernel_path)
+    facade_classes = _class_names(facade_path)
+
+    assert {"IGraphAdapter", "AsyncAdapterMixin"}.issubset(kernel_classes)
+    assert "IGraphAdapter" not in facade_classes
+    assert "AsyncAdapterMixin" not in facade_classes
+
+
+def test_graph_adapter_facade_exports_aliases() -> None:
+    assert facade.IGraphAdapter is kernel.IGraphAdapter
+    assert facade.AsyncAdapterMixin is kernel.AsyncAdapterMixin


### PR DESCRIPTION
### Motivation

- Centralize the graph adapter contract so `src/ume/kernel/graph_adapter.py` is the single canonical source of `IGraphAdapter` and `AsyncAdapterMixin` to avoid duplicated/ divergent contract definitions. 
- Keep a top-level compatibility facade that only re-exports symbols so external callers are not broken while first-party code depends on the kernel package. 
- Align the `graph_adapter` facade pattern with existing facades like `event.py` and `processing.py` to maintain consistent module boundaries.

### Description

- Replaced `src/ume/graph_adapter.py` with a minimal compatibility facade that does `from .kernel.graph_adapter import AsyncAdapterMixin, IGraphAdapter` and exposes `__all__ = ["IGraphAdapter", "AsyncAdapterMixin"]` so the types are aliases to the kernel definitions. 
- Updated first-party imports across `src/ume/**` to import `IGraphAdapter` / `AsyncAdapterMixin` from `ume.kernel.graph_adapter` (or equivalent relative kernel paths) instead of the top-level facade, touching the modules that consume the contract (e.g. `tracing.py`, `cli/prompt.py`, `adapters/registry.py`, and many graph adapter implementations). 
- Added a regression test `tests/architecture/test_graph_adapter_facade.py` which asserts that the concrete contract classes live only in `src/ume/kernel/graph_adapter.py` and that the facade exports are actual aliases to the kernel symbols.

### Testing

- Ran `ruff check src/ume tests/architecture/test_graph_adapter_facade.py`, which completed with no linter errors. 
- Ran `pytest tests/architecture/test_graph_adapter_facade.py tests/architecture/test_dependency_boundaries.py tests/architecture/test_domain_extension_points.py`, where the new facade regression test and domain extension tests passed but `test_dependency_boundaries` failed due to pre-existing kernel code importing non-kernel modules (`src/ume/kernel/events.py` imports `ume.events.contract` and `ume.events.contract_registry`), which is unrelated to this change. 
- The new architecture regression test `tests/architecture/test_graph_adapter_facade.py` passed, confirming the facade exports are aliases and there are no duplicate class definitions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69c2ad5212d4832682580bb309e99a59)