### PR TITLE
docs: unify canonical event contract docs and add legacy-term CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ jobs:
         if: steps.changes.outputs.run == 'true'
         run: python scripts/check_arch_terms.py
 
+      - name: Check deprecated contract terminology legacy labeling
+        if: steps.changes.outputs.run == 'true'
+        run: python scripts/check_contract_terms.py
+
       - name: Check deprecated internal callsites
         if: steps.changes.outputs.run == 'true'
         run: poetry run python scripts/check_deprecated_callsites.py

--- a/README.md
+++ b/README.md
@@ -131,40 +131,104 @@ The current system consists of the following main components:
     *   In the demo, it connects to the Kafka/Redpanda broker at `localhost:9092`, subscribes to the `ume-clean-events` topic using the group ID `ume_client_group`.
     *   Upon receiving an event, it logs the event's content. In a more complete system, this component would be responsible for parsing the event, updating the memory graph, triggering actions, or other processing tasks.
 
-### Event Schema
+### Event Contract (Canonical Documentation)
 
-The events exchanged in UME follow a single flat external producer contract. Each event contains a minimal
-set of common fields and any number of type‑specific attributes.
+UME uses a two-stage event contract model:
 
-**Example Event:**
+1. **External transport shape** (producer-facing, flat keys).
+2. **Internal canonical event structure** (runtime-facing, structured sections).
+
+#### Accepted external transport shape
+
+Ingress accepts a flat producer payload (for example `eventType`, `eventId`, `timestamp`, `sourceService`, `node_id`, `target_node_id`, `label`, `payload`).
 
 ```json
 {
-  "eventType": "DEMO_EVENT",
-  "timestamp": "2024-03-15T12:00:00Z",
-  "payload": {"message": "Hello from producer_demo!"},
+  "eventType": "CREATE_EDGE",
   "eventId": "evt-123",
-  "correlationId": "demo-1",
+  "timestamp": "2024-03-15T12:05:21Z",
+  "schemaVersion": "3.0.0",
+  "sourceService": "producer_demo",
+  "producerId": "producer-1",
+  "tenant": "acme",
+  "signature": "sig-abc",
+  "correlationId": "corr-1",
   "subjectEntity": {"id": "demo", "type": "example"},
-  "sourceService": "producer_demo"
+  "node_id": "source_node_alpha",
+  "target_node_id": "target_node_beta",
+  "label": "RELATES_TO",
+  "payload": {"attributes": {"confidence": 0.91}}
 }
 ```
 
-**Canonical Fields**
+#### Internal canonical event structure shape
 
-| Field | Description |
-|-------|-------------|
-| `eventType` | Type of event such as `CREATE_NODE` or `RESEARCH_JOB_STARTED`. |
-| `timestamp` | Event time as either epoch `int` or ISO&nbsp;8601 string; `parse_event()` normalizes it to an epoch integer in the parsed `Event`. |
-| `eventId` | Unique identifier for this event. |
-| `correlationId` | Identifier linking related events. |
-| `subjectEntity` | Object with `id` and `type` describing the entity the event concerns. |
-| `sourceService` | Name of the service that emitted the event. |
-| `payload` | Event‑specific attributes. |
+After canonicalization, runtime code parses this internal envelope:
 
-Ingress accepts one authoritative external contract only (`eventType`, `eventId`, `schemaVersion`, `sourceService`, `node_id`, ...). That external shape is transformed exactly once into UME's internal canonical event (`metadata` + `graph` + `payload`) before parsing.
-Timestamps are accepted as Unix epoch integers or ISO&nbsp;8601 strings (including `Z` suffix) and are normalized internally to an
-epoch integer on the parsed `Event`.
+```json
+{
+  "metadata": {
+    "event_id": "evt-123",
+    "event_type": "CREATE_EDGE",
+    "timestamp": "2024-03-15T12:05:21Z",
+    "schema_version": "3.0.0",
+    "source": "producer_demo",
+    "producer_id": "producer-1",
+    "tenant": "acme",
+    "producer_signature": "sig-abc",
+    "correlation_ids": {"correlation_id": "corr-1"},
+    "subject_entity": {"id": "demo", "type": "example"}
+  },
+  "graph": {
+    "node_id": "source_node_alpha",
+    "target_node_id": "target_node_beta",
+    "label": "RELATES_TO"
+  },
+  "payload": {"attributes": {"confidence": 0.91}}
+}
+```
+
+#### Required legacy transform path
+
+If a producer sends historical shapes (for example nested `event` envelopes or snake_case metadata like `event_type`), ingestion must run:
+
+1. `ume.events.legacy_transform.apply_legacy_transform(...)`
+2. `ume.events.contract.canonicalize_event(...)`
+3. `ume.kernel.events.parse_event(...)`
+
+Direct parsing of historical payloads is intentionally rejected on the canonical parser path.
+
+#### Producer migration matrix (legacy -> canonical event structure)
+
+| Producer field (legacy/flat) | Canonical envelope field |
+| --- | --- |
+| `eventType` | `metadata.event_type` |
+| `eventId` | `metadata.event_id` |
+| `timestamp` | `metadata.timestamp` |
+| `schemaVersion` | `metadata.schema_version` |
+| `sourceService` | `metadata.source` |
+| `producerId` | `metadata.producer_id` |
+| `tenant` | `metadata.tenant` |
+| `signature` | `metadata.producer_signature` |
+| `correlationId` | `metadata.correlation_ids.correlation_id` |
+| `subjectEntity` | `metadata.subject_entity` |
+| `node_id` | `graph.node_id` |
+| `target_node_id` | `graph.target_node_id` |
+| `label` | `graph.label` |
+| `payload` | `payload` |
+
+#### `parse_event` error examples
+
+Representative parser errors include:
+
+- `parse_event expects canonicalized data with 'metadata', 'graph', and 'payload'; apply ume.events.legacy_transform before canonicalization for historical transport shapes`
+- `Missing required event field: eventType`
+- `Invalid canonical metadata`
+- `Invalid timestamp format`
+- `Missing required fields for CREATE_EDGE event: node_id, target_node_id, label`
+- `Missing required field 'payload.attributes' for UPDATE_NODE_ATTRIBUTES event.`
+
+Timestamps are accepted as Unix epoch integers or ISO&nbsp;8601 strings (including `Z` suffix) and normalized to epoch seconds in the parsed `Event`.
 
 All official event types such as `CREATE_NODE` or `CREATE_EDGE` have
 corresponding JSON Schema definitions under `src/ume/schemas`.  Producers

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -103,6 +103,68 @@ response on success.
 
 UME event contracts are versioned with semantic versions and validated against JSON Schema bundles under `src/ume/schemas/v{major}`.
 
+## Event Contract Shapes and Migration
+
+The canonical event model is documented from two perspectives:
+
+- **Accepted external transport shape** (flat producer-facing keys).
+- **Internal canonical event structure shape** (`metadata` + `graph` + `payload`), which is required by `parse_event`.
+
+### Accepted external transport shape
+
+Ingress accepts flat payload keys including `eventType`, `eventId`, `timestamp`,
+`schemaVersion`, `sourceService`, `producerId`, `tenant`, `signature`,
+`correlationId`, `subjectEntity`, `node_id`, `target_node_id`, `label`, and
+`payload`.
+
+### Internal canonical event structure shape
+
+Runtime parsing requires:
+
+- `metadata.event_type`, `metadata.timestamp`, optional metadata attributes
+- `graph.node_id`, `graph.target_node_id`, `graph.label` (as required per event type)
+- `payload` as an object (or omitted when optional for the event type)
+
+### Required transform for historical payloads
+
+Historical payloads (legacy nested `event` wrapper or legacy snake_case metadata like
+`event_type`) must run through `ume.events.legacy_transform.apply_legacy_transform(...)`
+before canonicalization and parsing.
+
+Canonical migration path:
+
+1. `ume.events.legacy_transform.apply_legacy_transform(...)`
+2. `ume.events.contract.canonicalize_event(...)`
+3. `ume.kernel.events.parse_event(...)`
+
+### Producer migration matrix (legacy/flat -> canonical event structure)
+
+| Producer field (legacy/flat) | Canonical envelope field |
+| --- | --- |
+| `eventType` | `metadata.event_type` |
+| `eventId` | `metadata.event_id` |
+| `timestamp` | `metadata.timestamp` |
+| `schemaVersion` | `metadata.schema_version` |
+| `sourceService` | `metadata.source` |
+| `producerId` | `metadata.producer_id` |
+| `tenant` | `metadata.tenant` |
+| `signature` | `metadata.producer_signature` |
+| `correlationId` | `metadata.correlation_ids.correlation_id` |
+| `subjectEntity` | `metadata.subject_entity` |
+| `node_id` | `graph.node_id` |
+| `target_node_id` | `graph.target_node_id` |
+| `label` | `graph.label` |
+| `payload` | `payload` |
+
+### `parse_event` error examples
+
+- `parse_event expects canonicalized data with 'metadata', 'graph', and 'payload'; apply ume.events.legacy_transform before canonicalization for historical transport shapes`
+- `Missing required event field: eventType`
+- `Invalid type for 'payload': expected dict, got list`
+- `Invalid timestamp format`
+- `Missing required fields for CREATE_EDGE event: node_id, target_node_id, label`
+- `Missing required field 'payload.attributes' for UPDATE_NODE_ATTRIBUTES event.`
+
 ### Required vs optional fields
 
 - **Always required (all majors):** `eventType`, `timestamp`.

--- a/scripts/check_contract_terms.py
+++ b/scripts/check_contract_terms.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Fail when deprecated contract terminology is not explicitly marked legacy."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+DOC_FILES = [
+    Path("README.md"),
+    Path("docs/API_REFERENCE.md"),
+    Path("docs/ARCHITECTURE_OVERVIEW.md"),
+]
+
+DEPRECATED_CONTRACT_PATTERNS = [
+    r"\bflat external producer contract\b",
+    r"\bevent envelope contract\b",
+    r"\bsnake_case ingest fields\b",
+    r"\bhistorical transport shape(s)?\b",
+]
+
+
+def _is_heading(line: str) -> bool:
+    return line.lstrip().startswith("#")
+
+
+def _has_legacy_label(line: str) -> bool:
+    return re.search(r"\blegacy(?:\b|[_-])", line, flags=re.IGNORECASE) is not None
+
+
+def check_file(path: Path) -> list[str]:
+    failures: list[str] = []
+    active_heading = ""
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if _is_heading(line):
+            active_heading = line
+        for pattern in DEPRECATED_CONTRACT_PATTERNS:
+            if re.search(pattern, line, flags=re.IGNORECASE):
+                if _has_legacy_label(line) or _has_legacy_label(active_heading):
+                    continue
+                failures.append(
+                    f"{path}:{lineno}: deprecated contract term '{pattern}' must include an explicit legacy label (line or active heading)."
+                )
+    return failures
+
+
+def main() -> int:
+    failures: list[str] = []
+    for path in DOC_FILES:
+        if not path.exists():
+            failures.append(f"{path}: missing expected documentation file")
+            continue
+        failures.extend(check_file(path))
+
+    if failures:
+        print("Contract terminology check failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("Contract terminology check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
### Motivation

- Consolidate scattered event contract documentation into a single canonical description so transport vs runtime shapes and migration paths are unambiguous.
- Make it explicit that historical/snaked/`event`-wrapped payloads must be transformed via the legacy transform before canonicalization and parsing to avoid ambiguous ingress behavior.
- Prevent accidental reintroduction of deprecated contract terminology in docs by enforcing an explicit “legacy” label where legacy terms are mentioned.

### Description

- Added a canonical event contract section to `README.md` describing the accepted external transport shape, the internal canonical envelope (`metadata`/`graph`/`payload`), the required transform sequence (`ume.events.legacy_transform.apply_legacy_transform`, `ume.events.contract.canonicalize_event`, `ume.kernel.events.parse_event`), and an example JSON for each shape.
- Added the same canonical contract, a producer migration matrix (mapping legacy flat fields like `eventType`/`node_id` to `metadata`/`graph` fields), and representative `parse_event` error examples to `docs/API_REFERENCE.md`.
- Added `scripts/check_contract_terms.py`, a new CI doc-check that fails when deprecated contract terminology appears without an explicit legacy label on the same line or active heading.
- Wired the new check into CI by updating `.github/workflows/ci.yml` to run `scripts/check_contract_terms.py` in the lint/install job.

### Testing

- Ran `python scripts/check_contract_terms.py` which passed locally against the updated docs.
- Ran `python scripts/check_arch_terms.py` to validate architecture-term/linking consistency and it passed after edits.
- Compiled the new script with `python -m compileall scripts/check_contract_terms.py` to confirm it is syntactically valid and the compile step succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8caf392008326a8d95e5760de1acd)