### PR TITLE
Add adapter-scoped auth profiles and explicit CLI dev/strict auth behavior

### DIFF
--- a/src/ume/cli/prompt.py
+++ b/src/ume/cli/prompt.py
@@ -16,7 +16,7 @@ _src_path = Path(__file__).resolve().parents[3] / "src"
 if _src_path.exists() and str(_src_path) not in sys.path:
     sys.path.insert(0, str(_src_path))
 
-from ume.config import settings
+from ume.config import settings, get_auth_profile_for_adapter
 from ume.events.contract import canonicalize_event
 from ume.audit import get_audit_entries, log_audit_entry
 from ume.auto_snapshot import enable_snapshot_autosave_and_restore
@@ -73,6 +73,18 @@ class UMEPrompt(Cmd):
         self.current_timestamp += timedelta(seconds=1)
         return self.current_timestamp.isoformat()
 
+    def _with_cli_auth_profile(self, event_data: dict[str, object]) -> dict[str, object]:
+        _, auth_profile = get_auth_profile_for_adapter("cli")
+        if not bool(auth_profile.get("inject_local_producer_metadata", False)):
+            return event_data
+        local_event = dict(event_data)
+        local_event.setdefault("producerId", "cli-local-dev")
+        local_event.setdefault("tenant", "local-dev")
+        local_event.setdefault(
+            "signature", "jwt:sub=cli-local-dev;tenant=local-dev;acl_allow=true"
+        )
+        return local_event
+
     # ----- Node commands -----
     def do_new_node(self, arg: str) -> None:
         """new_node <node_id> <json_attributes>"""
@@ -90,7 +102,7 @@ class UMEPrompt(Cmd):
                 "timestamp": self._get_timestamp(),
             }
             DEFAULT_EVENT_PROCESSOR.mutate_graph_or_raise(
-                canonicalize_event(event_data),
+                canonicalize_event(self._with_cli_auth_profile(event_data)),
                 graph=self.graph,
                 source="cli_prompt",
                 adapter="cli",
@@ -119,7 +131,7 @@ class UMEPrompt(Cmd):
                 "timestamp": self._get_timestamp(),
             }
             DEFAULT_EVENT_PROCESSOR.mutate_graph_or_raise(
-                canonicalize_event(event_data),
+                canonicalize_event(self._with_cli_auth_profile(event_data)),
                 graph=self.graph,
                 source="cli_prompt",
                 adapter="cli",
@@ -148,7 +160,7 @@ class UMEPrompt(Cmd):
                 "timestamp": self._get_timestamp(),
             }
             DEFAULT_EVENT_PROCESSOR.mutate_graph_or_raise(
-                canonicalize_event(event_data),
+                canonicalize_event(self._with_cli_auth_profile(event_data)),
                 graph=self.graph,
                 source="cli_prompt",
                 adapter="cli",
@@ -456,4 +468,3 @@ class UMEPrompt(Cmd):
     def do_EOF(self, arg: str) -> bool:
         print("\nGoodbye!")
         return True
-

--- a/src/ume/config/__init__.py
+++ b/src/ume/config/__init__.py
@@ -1,11 +1,34 @@
 import logging
 import os
-from typing import Any
+from typing import Any, Literal
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 DEFAULT_AUDIT_SIGNING_KEY = "default-key"
+AuthProfileName = Literal["strict", "signed", "local-dev"]
+IngressAdapterName = Literal["cli", "api", "kafka", "grpc", "default"]
+
+AUTH_PROFILES: dict[AuthProfileName, dict[str, Any]] = {
+    "strict": {
+        "require_authenticated": True,
+        "require_authorized": True,
+        "allowed_methods": ("jwt", "signature", "acl"),
+        "inject_local_producer_metadata": False,
+    },
+    "signed": {
+        "require_authenticated": True,
+        "require_authorized": True,
+        "allowed_methods": ("jwt", "signature"),
+        "inject_local_producer_metadata": False,
+    },
+    "local-dev": {
+        "require_authenticated": False,
+        "require_authorized": False,
+        "allowed_methods": ("jwt", "signature", "acl", "none"),
+        "inject_local_producer_metadata": True,
+    },
+}
 
 
 class Settings(BaseSettings):  # type: ignore[misc]
@@ -108,6 +131,10 @@ class Settings(BaseSettings):  # type: ignore[misc]
 
     # gRPC authentication token
     UME_GRPC_TOKEN: str | None = None
+    UME_AUTH_PROFILE_CLI: AuthProfileName | None = None
+    UME_AUTH_PROFILE_API: AuthProfileName | None = None
+    UME_AUTH_PROFILE_KAFKA: AuthProfileName | None = None
+    UME_AUTH_PROFILE_GRPC: AuthProfileName | None = None
 
     # Remote OPA configuration
     OPA_URL: str | None = None
@@ -214,4 +241,38 @@ load_settings.cache_clear()
 # Create a single, importable instance
 settings = load_settings()
 
-__all__ = ["Settings", "settings", "load_settings", "DEFAULT_AUDIT_SIGNING_KEY"]
+
+def _default_adapter_auth_profiles() -> dict[str, AuthProfileName]:
+    dev_mode = settings.UME_ENV.lower() in {"dev", "development", "test"}
+    return {
+        "cli": "local-dev" if dev_mode else "strict",
+        "api": "strict",
+        "kafka": "signed",
+        "grpc": "strict",
+    }
+
+
+def get_auth_profile_for_adapter(adapter: IngressAdapterName) -> tuple[AuthProfileName, dict[str, Any]]:
+    normalized = "api" if adapter == "default" else adapter
+    defaults = _default_adapter_auth_profiles()
+    overrides = {
+        "cli": settings.UME_AUTH_PROFILE_CLI,
+        "api": settings.UME_AUTH_PROFILE_API,
+        "kafka": settings.UME_AUTH_PROFILE_KAFKA,
+        "grpc": settings.UME_AUTH_PROFILE_GRPC,
+    }
+    profile_name = overrides.get(normalized) or defaults.get(normalized, "strict")
+    profile = AUTH_PROFILES[profile_name]
+    return profile_name, dict(profile)
+
+
+__all__ = [
+    "Settings",
+    "settings",
+    "load_settings",
+    "DEFAULT_AUDIT_SIGNING_KEY",
+    "AUTH_PROFILES",
+    "AuthProfileName",
+    "IngressAdapterName",
+    "get_auth_profile_for_adapter",
+]

--- a/src/ume/kernel/policy.py
+++ b/src/ume/kernel/policy.py
@@ -8,6 +8,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict
 
 from .events import Event
+from ..events.ingress import IngressAdapter
 
 if TYPE_CHECKING:
     from .graph_adapter import IGraphAdapter
@@ -23,6 +24,7 @@ class PolicyDecision(str, Enum):
 @dataclass
 class PolicyContext:
     source: str
+    adapter: IngressAdapter = "default"
     raw_payload: bytes | None = None
     transport_data: Dict[str, Any] | None = None
     canonical_event: Dict[str, Any] | None = None

--- a/src/ume/pipeline/core.py
+++ b/src/ume/pipeline/core.py
@@ -104,6 +104,7 @@ class EventPipelineOrchestrator:
         self,
         *,
         source: str,
+        adapter: IngressAdapter,
         raw_payload: bytes | None,
         decoded: dict[str, Any],
         canonical: dict[str, Any],
@@ -115,6 +116,7 @@ class EventPipelineOrchestrator:
         resolution_source = metadata.get("schema_resolution_source") if isinstance(metadata, Mapping) else None
         context = PolicyContext(
             source=source,
+            adapter=adapter,
             raw_payload=raw_payload,
             transport_data=decoded,
             canonical_event=canonical,
@@ -290,6 +292,7 @@ class EventPipelineOrchestrator:
 
             context = self._base_context(
                 source=source,
+                adapter=adapter,
                 raw_payload=raw_payload,
                 decoded=decoded,
                 canonical=canonical,
@@ -436,6 +439,7 @@ class EventPipelineOrchestrator:
 
         context = self._base_context(
             source=source,
+            adapter=adapter,
             raw_payload=raw_payload,
             decoded=decoded,
             canonical=canonical,

--- a/src/ume/policy/pipeline.py
+++ b/src/ume/policy/pipeline.py
@@ -31,7 +31,7 @@ from ..events.contract import canonical_to_camel_dict, canonicalize_event
 from ..events.schema_resolution import annotate_canonical_schema
 from ..plugins.alignment import PolicyViolationError, get_plugins, load_plugins
 from ..policy.graph_view import build_graph_read_view
-from ..config import settings
+from ..config import settings, get_auth_profile_for_adapter
 from ..schema_utils import validate_event_dict
 
 logger = logging.getLogger(__name__)
@@ -182,6 +182,7 @@ class ProducerAuthStage:
     name = "pre_apply_producer_auth"
 
     def run(self, context: PolicyContext) -> Optional[PolicyResult]:
+        profile_name, auth_profile = get_auth_profile_for_adapter(context.adapter)
         event = context.effective_event
         if event is None:
             return _result(
@@ -228,6 +229,11 @@ class ProducerAuthStage:
             if isinstance(allowed, list):
                 authorized = str(producer_id) in {str(item) for item in allowed}
 
+        allowed_methods = set(auth_profile.get("allowed_methods", ()))
+        if allowed_methods and auth_method not in allowed_methods:
+            authenticated = False
+            authorized = False
+
         context.producer_auth = {
             "authenticated": authenticated,
             "authorized": authorized,
@@ -243,17 +249,27 @@ class ProducerAuthStage:
                 "producer_authorized": authorized,
                 "producer_id": producer_id,
                 "tenant": tenant,
+                "producer_auth_profile": profile_name,
+                "producer_auth_require_authenticated": bool(
+                    auth_profile.get("require_authenticated", True)
+                ),
+                "producer_auth_require_authorized": bool(
+                    auth_profile.get("require_authorized", True)
+                ),
             }
         )
 
-        if not authenticated:
+        require_authenticated = bool(auth_profile.get("require_authenticated", True))
+        require_authorized = bool(auth_profile.get("require_authorized", True))
+
+        if require_authenticated and not authenticated:
             return _result(
                 PolicyDecision.DENY,
                 context,
                 stage=self.name,
                 reason="producer_not_authenticated",
             )
-        if not authorized:
+        if require_authorized and not authorized:
             return _result(
                 PolicyDecision.DENY,
                 context,

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -300,6 +300,60 @@ def test_cli_set_peer_and_sync_calls_replicator(monkeypatch: pytest.MonkeyPatch)
     assert "stop" in called
 
 
+def test_cli_dev_profile_injects_local_producer_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    import ume.cli.prompt as prompt_mod
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        prompt_mod,
+        "get_auth_profile_for_adapter",
+        lambda _adapter: (
+            "local-dev",
+            {"inject_local_producer_metadata": True},
+        ),
+    )
+    monkeypatch.setattr(prompt_mod, "canonicalize_event", lambda event: event)
+
+    def fake_mutate(event: dict[str, object], **_: object) -> None:
+        captured.update(event)
+
+    monkeypatch.setattr(prompt_mod.DEFAULT_EVENT_PROCESSOR, "mutate_graph_or_raise", fake_mutate)
+    prompt = prompt_mod.UMEPrompt()
+    prompt.do_new_node('n1 "{}"')
+
+    assert captured["producerId"] == "cli-local-dev"
+    assert captured["tenant"] == "local-dev"
+    assert str(captured["signature"]).startswith("jwt:sub=cli-local-dev")
+
+
+def test_cli_strict_profile_does_not_inject_local_producer_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import ume.cli.prompt as prompt_mod
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        prompt_mod,
+        "get_auth_profile_for_adapter",
+        lambda _adapter: (
+            "strict",
+            {"inject_local_producer_metadata": False},
+        ),
+    )
+    monkeypatch.setattr(prompt_mod, "canonicalize_event", lambda event: event)
+
+    def fake_mutate(event: dict[str, object], **_: object) -> None:
+        captured.update(event)
+
+    monkeypatch.setattr(prompt_mod.DEFAULT_EVENT_PROCESSOR, "mutate_graph_or_raise", fake_mutate)
+    prompt = prompt_mod.UMEPrompt()
+    prompt.do_new_node('n1 "{}"')
+
+    assert "producerId" not in captured
+    assert "tenant" not in captured
+    assert "signature" not in captured
+
+
 def test_cli_up_and_down(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
     import importlib
     import ume_cli as cli
@@ -1090,4 +1144,3 @@ def test_wrapper_script_runs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) ->
     env["PATH"] = f"{bin_dir}{os.pathsep}" + env.get("PATH", "")
     result = subprocess.run(["bash", str(script), "--no-confirm"], env=env, capture_output=True, text=True)
     assert result.returncode == 0
-

--- a/tests/test_policy_pipeline_ordering.py
+++ b/tests/test_policy_pipeline_ordering.py
@@ -7,10 +7,12 @@ from ume.policy.pipeline import (
     PolicyDecision,
     build_default_policy_pipeline,
 )
+from ume.config import settings
 
 
 def _event(payload: dict[str, object] | None = None) -> dict[str, object]:
     event_payload = dict(payload or {"attributes": {"name": "Alice"}})
+    event_payload.setdefault("node_id", "n1")
     event_payload.setdefault("acl", {"tenant-a": ["producer-1"]})
     return {
         "eventType": "CREATE_NODE",
@@ -170,3 +172,38 @@ def test_policy_input_contains_authenticated_producer_claims(monkeypatch) -> Non
     assert plugin.last_input["producer"]["authenticated"] is True
     assert plugin.last_input["producer"]["authorized"] is True
     assert plugin.last_input["producer"]["claims"]["sub"] == "producer-1"
+
+
+def test_producer_auth_profile_cli_local_dev_allows_missing_credentials(monkeypatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+    monkeypatch.setattr("ume.policy.pipeline.get_plugins", lambda: [])
+    monkeypatch.setattr(settings, "UME_AUTH_PROFILE_CLI", "local-dev")
+
+    event = _event()
+    event.pop("signature", None)
+    event.pop("producerId", None)
+
+    pipeline = build_default_policy_pipeline(redactor=lambda payload: (payload, False))
+    result = pipeline.evaluate(
+        PolicyContext(source="cli_prompt", adapter="cli", transport_data=event)
+    )
+
+    assert result.decision == PolicyDecision.ALLOW
+    assert result.context.details["producer_auth_profile"] == "local-dev"
+
+
+def test_producer_auth_profile_kafka_signed_requires_signature(monkeypatch) -> None:
+    monkeypatch.setattr("ume.policy.pipeline.load_plugins", lambda: None)
+    monkeypatch.setattr("ume.policy.pipeline.get_plugins", lambda: [])
+    monkeypatch.setattr(settings, "UME_AUTH_PROFILE_KAFKA", "signed")
+
+    event = _event()
+    event.pop("signature", None)
+
+    pipeline = build_default_policy_pipeline(redactor=lambda payload: (payload, False))
+    result = pipeline.evaluate(
+        PolicyContext(source="kafka_ingest", adapter="kafka", transport_data=event)
+    )
+
+    assert result.decision == PolicyDecision.DENY
+    assert result.audit_event.reason == "producer_not_authenticated"


### PR DESCRIPTION
### Motivation

- Introduce adapter-scoped authentication profiles so different ingress adapters can enforce different producer auth policies (e.g., strict production vs local-dev convenience).
- Ensure producer auth enforcement is driven by an explicit profile rather than implicit behavior in the `ProducerAuthStage`.
- Make CLI behavior deterministic in dev workflows by injecting local producer metadata only when an explicit dev profile enables it.
- Make strict-vs-dev expectations explicit in tests to avoid accidental implicit behavior changes.

### Description

- Added adapter-scoped auth profile support in `src/ume/config/__init__.py` with `AUTH_PROFILES`, `AuthProfileName`, `IngressAdapterName`, and the helper `get_auth_profile_for_adapter` plus per-adapter override settings (`UME_AUTH_PROFILE_{CLI,API,KAFKA,GRPC}`).
- Propagated ingress adapter identity through the stack by adding `adapter: IngressAdapter` to `PolicyContext` and wiring it in `EventPipelineOrchestrator._base_context` and call sites in `src/ume/pipeline/core.py`.
- Refactored `ProducerAuthStage` (`src/ume/policy/pipeline.py`) to resolve the adapter profile via `get_auth_profile_for_adapter`, enforce `allowed_methods`, and obey `require_authenticated` / `require_authorized` gating; profile details are recorded into `context.details` for observability.
- Updated CLI prompt (`src/ume/cli/prompt.py`) to call a new internal `_with_cli_auth_profile` which injects deterministic `producerId`/`tenant`/`signature` for `local-dev` profile while leaving production/strict behavior unchanged.
- Added and adjusted tests: `tests/test_policy_pipeline_ordering.py` now includes adapter-aware producer-auth test cases and ensures event fixtures meet parser requirements, and `tests/test_cli_smoke.py` adds focused smoke tests that assert explicit CLI dev vs strict injection behavior.

### Testing

- Ran linter: `ruff check src/ume/config/__init__.py src/ume/kernel/policy.py src/ume/pipeline/core.py src/ume/policy/pipeline.py src/ume/cli/prompt.py tests/test_policy_pipeline_ordering.py tests/test_cli_smoke.py` and it passed.
- Ran targeted unit tests: `pytest tests/test_policy_pipeline_ordering.py -q` which succeeded (`8 passed`).
- Ran focused CLI smoke tests: `pytest tests/test_cli_smoke.py -q -k "dev_profile_injects_local_producer_metadata or strict_profile_does_not_inject_local_producer_metadata"` which succeeded (`2 passed`).
- Note: a broader run of the full CLI smoke suite in this container surfaced unrelated environment/subprocess and optional-dependency issues (e.g., missing `jsonschema` in subprocess paths and test stubbing for top-level CLI subprocesses); the changes here were validated via the focused unit tests above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e405937c83268ad2c0879d64ad85)