### PR TITLE
Require strict vector backend entry point specs

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -255,6 +255,24 @@ plugin discovery:
 - Optional providers are available through plugin modules/entry points (for
   example Pinecone or Milvus integrations)
 
+External vector entry points use the same strict shape as graph backend plugins:
+entry point targets must resolve to either a single backend spec or to a mapping
+of backend names to specs. A vector backend spec is a mapping with this required
+format:
+
+```python
+{
+    "constructor": MemoryBackend,
+    "capabilities": {"vector_similarity", "bulk_write"},
+    # optional: "name": "memory",
+}
+```
+
+The `constructor` value must be callable, and `capabilities` must be a set-like
+collection. Entry points that load a backend class directly, or that omit
+`capabilities`, are rejected during discovery with a vector backend registration
+error that identifies the entry point/backend name and expected schema.
+
 `VectorStore` remains available as a compatibility constructor, but new code
 should use `create_vector_store()`.
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -177,14 +177,39 @@ class MemoryBackend(VectorBackend):
 
     # save/load omitted for brevity
 
-register_backend("memory", MemoryBackend)
+register_backend(
+    "memory",
+    MemoryBackend,
+    capabilities={"vector_similarity", "bulk_write"},
+)
 ```
 
-Expose the backend automatically by declaring an entry point in your package:
+Expose the backend automatically by declaring an entry point in your package.
+The entry point target must resolve to a backend spec (or to a mapping of backend
+names to specs), not directly to the backend class. Each spec must include a
+callable `constructor` and a set-like `capabilities` collection; omitting
+`capabilities` is rejected during discovery with a registration error.
+
+```python
+# yourpkg/memory_backend.py
+VECTOR_BACKEND = {
+    "constructor": MemoryBackend,
+    "capabilities": {"vector_similarity", "bulk_write"},
+}
+
+# For one entry point that contributes multiple backends, expose a mapping:
+VECTOR_BACKENDS = {
+    "memory": {
+        "constructor": MemoryBackend,
+        "capabilities": {"vector_similarity", "bulk_write"},
+    }
+}
+```
 
 ```toml
 [project.entry-points."ume.vector_backends"]
-memory = "yourpkg.memory_backend:MemoryBackend"
+memory = "yourpkg.memory_backend:VECTOR_BACKEND"
+# or: memory_backends = "yourpkg.memory_backend:VECTOR_BACKENDS"
 ```
 
 Setting `UME_VECTOR_BACKEND=memory` will then use the plugin when creating a

--- a/src/ume/vector_backends/__init__.py
+++ b/src/ume/vector_backends/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Dict, Iterable, cast
+from collections.abc import Mapping, Set as AbstractSet
+from typing import Callable, Dict, Iterable, NotRequired, TypedDict, cast
 from types import TracebackType
 import json
 import logging
@@ -20,6 +21,7 @@ from ..vector_store import VectorBackend
 from typing import TYPE_CHECKING
 from ..plugins.registry import (
     ConstructorMetadata,
+    PluginRegistrationError,
     discover_plugins_from_entry_points,
     get_plugin_constructor,
     list_plugins,
@@ -61,6 +63,20 @@ logger = logging.getLogger(__name__)
 
 VECTOR_BACKEND_CAPABILITY = "vector_backend"
 ENTRYPOINT_GROUP = "ume.vector_backends"
+VectorBackendConstructor = Callable[..., VectorBackend]
+
+
+class ExternalVectorBackendSpec(TypedDict):
+    """Strict shape for externally discovered vector backend registrations."""
+
+    constructor: VectorBackendConstructor
+    capabilities: AbstractSet[str]
+    name: NotRequired[str]
+
+
+class VectorBackendRegistrationError(PluginRegistrationError):
+    """Raised when vector backend registration metadata is invalid."""
+
 
 def register_backend(
     name: str,
@@ -70,7 +86,9 @@ def register_backend(
 ) -> None:
     """Register a vector backend class under ``name``."""
     if capabilities is None:
-        raise ValueError(f"Vector backend '{name}' must declare capabilities")
+        raise VectorBackendRegistrationError(
+            f"Vector backend '{name}' must declare capabilities"
+        )
     declared = frozenset(capabilities)
     register_plugin(
         VECTOR_BACKEND_CAPABILITY,
@@ -97,33 +115,115 @@ def available_backends() -> Iterable[str]:
     return [item["name"] for item in list_plugins(capability=VECTOR_BACKEND_CAPABILITY)]
 
 
-def load_entrypoints() -> None:
-    """Load and register backends from ``ENTRYPOINT_GROUP`` entry points."""
-    def _load(name: str, loaded: object) -> None:
-        if not callable(loaded):
-            raise TypeError(f"Vector backend entry point '{name}' is not callable")
-        register_plugin(
-            VECTOR_BACKEND_CAPABILITY,
-            name,
-            loaded,
-            metadata=ConstructorMetadata(
-                source="entry_point",
-                entry_point_group=ENTRYPOINT_GROUP,
-                capabilities=frozenset(),
-                details={
-                    "capability_schema": build_capability_schema(
-                        domain="vector",
-                        backend=name,
-                        declared=frozenset(),
-                    ).as_dict()
-                },
-            ),
+def _expected_vector_spec_schema() -> str:
+    return (
+        "Expected schema: mapping with 'constructor' (callable), "
+        "'capabilities' (set-like collection of strings), and optional 'name' (string)."
+    )
+
+
+def _parse_external_backend_spec(
+    entry_name: str,
+    backend_name: str,
+    spec: object,
+) -> tuple[str, VectorBackendConstructor, AbstractSet[str]]:
+    schema = _expected_vector_spec_schema()
+    if not isinstance(spec, Mapping):
+        raise VectorBackendRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' must provide a "
+            f"backend spec. {schema}"
         )
 
+    constructor = spec.get("constructor")
+    if not callable(constructor):
+        raise VectorBackendRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' must declare a "
+            f"callable constructor. {schema}"
+        )
+
+    capabilities = spec.get("capabilities")
+    if capabilities is None:
+        raise VectorBackendRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' must declare "
+            f"capabilities. {schema}"
+        )
+    if not isinstance(capabilities, AbstractSet):
+        raise VectorBackendRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' capabilities must "
+            f"be a set-like collection. {schema}"
+        )
+
+    resolved_name = spec.get("name")
+    if resolved_name is not None and not isinstance(resolved_name, str):
+        raise VectorBackendRegistrationError(
+            f"Entry point '{entry_name}' backend '{backend_name}' name override must "
+            f"be a string. {schema}"
+        )
+
+    return (
+        resolved_name or backend_name,
+        cast(VectorBackendConstructor, constructor),
+        capabilities,
+    )
+
+
+def _register_external_backend(
+    name: str,
+    constructor: VectorBackendConstructor,
+    capabilities: AbstractSet[str],
+) -> None:
+    declared = frozenset(capabilities)
+    register_plugin(
+        VECTOR_BACKEND_CAPABILITY,
+        name,
+        constructor,
+        metadata=ConstructorMetadata(
+            source="entry_point",
+            entry_point_group=ENTRYPOINT_GROUP,
+            capabilities=declared,
+            details={
+                "capability_schema": build_capability_schema(
+                    domain="vector",
+                    backend=name,
+                    declared=declared,
+                ).as_dict()
+            },
+        ),
+    )
+
+
+def _register_external_loaded_object(name: str, loaded: object) -> None:
+    if isinstance(loaded, Mapping):
+        if "constructor" in loaded or "capabilities" in loaded:
+            backend_name, constructor, capabilities = _parse_external_backend_spec(
+                name,
+                name,
+                loaded,
+            )
+            _register_external_backend(backend_name, constructor, capabilities)
+            return
+
+        for backend_name, spec in loaded.items():
+            resolved_name, constructor, capabilities = _parse_external_backend_spec(
+                name,
+                str(backend_name),
+                spec,
+            )
+            _register_external_backend(resolved_name, constructor, capabilities)
+        return
+
+    raise VectorBackendRegistrationError(
+        f"Entry point '{name}' must load a vector backend spec or backend-spec "
+        f"mapping. {_expected_vector_spec_schema()}"
+    )
+
+
+def load_entrypoints() -> None:
+    """Load and register backends from ``ENTRYPOINT_GROUP`` entry points."""
     discover_plugins_from_entry_points(
         capability=VECTOR_BACKEND_CAPABILITY,
         group=ENTRYPOINT_GROUP,
-        loader=_load,
+        loader=_register_external_loaded_object,
     )
 
 

--- a/tests/test_vector_backend_registry.py
+++ b/tests/test_vector_backend_registry.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import types
+from collections.abc import Iterator
+
+import pytest
+
+
+@pytest.fixture()
+def vector_backend_module() -> Iterator[types.ModuleType]:
+    root = Path(__file__).resolve().parents[1] / "src" / "ume"
+    module_names = [
+        "ume",
+        "ume.capability_schema",
+        "ume.config",
+        "ume.plugins",
+        "ume.plugins.registry",
+        "ume.vector_store",
+        "ume.vector_backends",
+        "numpy",
+        "numpy.typing",
+        "prometheus_client",
+    ]
+    old_modules = {name: sys.modules.get(name) for name in module_names}
+
+    class _NDArray:
+        def __class_getitem__(cls, item: object) -> type[_NDArray]:
+            return cls
+
+    try:
+        package = types.ModuleType("ume")
+        package.__path__ = [str(root)]
+        sys.modules["ume"] = package
+
+        plugins_package = types.ModuleType("ume.plugins")
+        plugins_package.__path__ = [str(root / "plugins")]
+        sys.modules["ume.plugins"] = plugins_package
+
+        numpy_stub = types.ModuleType("numpy")
+        numpy_stub.float64 = float  # type: ignore[attr-defined]
+        sys.modules["numpy"] = numpy_stub
+        numpy_typing_stub = types.ModuleType("numpy.typing")
+        numpy_typing_stub.NDArray = _NDArray  # type: ignore[attr-defined]
+        sys.modules["numpy.typing"] = numpy_typing_stub
+
+        prometheus_stub = types.ModuleType("prometheus_client")
+        prometheus_stub.Gauge = object  # type: ignore[attr-defined]
+        prometheus_stub.Histogram = object  # type: ignore[attr-defined]
+        sys.modules["prometheus_client"] = prometheus_stub
+
+        config_stub = types.ModuleType("ume.config")
+        config_stub.settings = types.SimpleNamespace(  # type: ignore[attr-defined]
+            UME_VECTOR_INDEX="vectors.faiss",
+            UME_VECTOR_USE_GPU=False,
+            UME_VECTOR_GPU_MEM_MB=256,
+            UME_MILVUS_URI="http://localhost:19530",
+            UME_MILVUS_USER=None,
+            UME_MILVUS_PASSWORD=None,
+        )
+        sys.modules["ume.config"] = config_stub
+
+        vector_store_stub = types.ModuleType("ume.vector_store")
+
+        class VectorBackend:
+            pass
+
+        vector_store_stub.VectorBackend = VectorBackend  # type: ignore[attr-defined]
+        sys.modules["ume.vector_store"] = vector_store_stub
+
+        for module_name, path in [
+            ("ume.capability_schema", root / "capability_schema.py"),
+            ("ume.plugins.registry", root / "plugins" / "registry.py"),
+            ("ume.vector_backends", root / "vector_backends" / "__init__.py"),
+        ]:
+            spec = importlib.util.spec_from_file_location(module_name, path)
+            assert spec and spec.loader
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = module
+            spec.loader.exec_module(module)
+
+        yield sys.modules["ume.vector_backends"]
+    finally:
+        for name, module in old_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def test_vector_entry_point_rejects_missing_capabilities(
+    vector_backend_module: types.ModuleType,
+) -> None:
+    class MemoryBackend:
+        pass
+
+    with pytest.raises(
+        vector_backend_module.VectorBackendRegistrationError,
+        match=(
+            "Entry point 'memory' backend 'memory' must declare capabilities.*"
+            "Expected schema: mapping with 'constructor'.*'capabilities'"
+        ),
+    ):
+        vector_backend_module._register_external_loaded_object(
+            "memory",
+            {"constructor": MemoryBackend},
+        )
+
+
+def test_vector_entry_point_accepts_valid_backend_spec(
+    vector_backend_module: types.ModuleType,
+) -> None:
+    class MemoryBackend:
+        pass
+
+    vector_backend_module._register_external_loaded_object(
+        "memory",
+        {
+            "constructor": MemoryBackend,
+            "capabilities": {"vector_similarity", "bulk_write"},
+        },
+    )
+
+    registry = sys.modules["ume.plugins.registry"]
+    metadata = registry.get_plugin_metadata(
+        vector_backend_module.VECTOR_BACKEND_CAPABILITY,
+        "memory",
+    )
+
+    assert vector_backend_module.get_backend("memory") is MemoryBackend
+    assert metadata.capabilities == frozenset({"vector_similarity", "bulk_write"})
+    assert metadata.details["capability_schema"]["domain"] == "vector"
+    assert metadata.details["capability_schema"]["declared"] == [
+        "bulk_write",
+        "vector_similarity",
+    ]


### PR DESCRIPTION
### Motivation

- Align vector backend plugin discovery with the existing graph backend contract by requiring an explicit backend spec (constructor + capabilities) from entry points. 
- Prevent silent/ambiguous registrations and runtime capability mismatches by rejecting entry points that omit capability sets. 
- Provide clear, actionable registration error messages that identify the entry point/backend and the expected schema.

### Description

- Update `src/ume/vector_backends/__init__.py` to introduce a `VectorBackendConstructor` alias, an `ExternalVectorBackendSpec` `TypedDict`, and a `VectorBackendRegistrationError` type, and to change `register_backend` to raise the new error when `capabilities` is missing. 
- Add parsing/validation helpers (`_expected_vector_spec_schema`, `_parse_external_backend_spec`, `_register_external_backend`, `_register_external_loaded_object`) and update `load_entrypoints` to expect either a backend spec mapping or a mapping of backend names to specs, rejecting malformed specs with descriptive errors. 
- Update documentation in `docs/ARCHITECTURE_OVERVIEW.md` and `docs/INTEGRATIONS.md` to show the required vector plugin spec format and recommend exposing `VECTOR_BACKEND` / `VECTOR_BACKENDS` objects from entry-point targets. 
- Add `tests/test_vector_backend_registry.py` to validate that discovery rejects specs missing `capabilities` and accepts valid specs, and verify metadata registration including capability schema details.

### Testing

- Ran `pytest tests/test_vector_backend_registry.py tests/test_factories.py` and all tests passed. 
- Ran `ruff check src/ume/vector_backends/__init__.py tests/test_vector_backend_registry.py tests/test_factories.py` and linter checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297d8c535c8326a8ea3afd1fed54fe)