### PR TITLE
Document authoritative external producer contract and enforce canonicalization boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The primary motivation behind UME is to equip AI agents with a form of persisten
 
 Use the shared glossary for canonical definitions: [`docs/GLOSSARY.md`](docs/GLOSSARY.md).
 
+The authoritative external producer event contract is documented in [`docs/API_REFERENCE.md#authoritative-external-producer-contract`](docs/API_REFERENCE.md#authoritative-external-producer-contract).
+
 
 ## Core Modules
 The engine is built from a few key components:

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -99,47 +99,111 @@ mirror the `/snapshot/save` and `/snapshot/load` HTTP endpoints. Both accept a
 response on success.
 
 
-## Event Contract Version Policy
+## Authoritative External Producer Contract
 
-UME event contracts are versioned with semantic versions and validated against JSON Schema bundles under `src/ume/schemas/v{major}`.
+This section is the single authoritative contract for producers that emit events into UME. Other documents should link here instead of restating the producer payload shape.
 
-## Event Contract Shapes and Migration
+### Boundary summary
 
-The canonical event model is documented from two perspectives:
+1. **External contract accepted at ingress:** producers send one flat JSON object with the field names listed below.
+2. **One canonical transform:** UME converts that external payload with `ume.events.contract.canonicalize_event(...)`. Legacy transports must first be upgraded by `ume.events.legacy_transform.apply_legacy_transform(...)`.
+3. **Parser accepts only canonical form:** `ume.kernel.events.parse_event(...)` accepts only `metadata` + `graph` + `payload`; it rejects producer payloads and legacy wrappers.
 
-- **Accepted external transport shape** (flat producer-facing keys).
-- **Internal canonical event structure shape** (`metadata` + `graph` + `payload`), which is required by `parse_event`.
+### Producer payload fields
 
-### Accepted external transport shape
+Required for every event:
 
-Ingress accepts flat payload keys including `eventType`, `eventId`, `timestamp`,
-`schemaVersion`, `sourceService`, `producerId`, `tenant`, `signature`,
-`correlationId`, `subjectEntity`, `node_id`, `target_node_id`, `label`, and
-`payload`.
+- `eventType` — event operation name, for example `CREATE_NODE` or `CREATE_EDGE`.
+- `timestamp` — Unix timestamp integer or ISO-8601 string.
 
-### Internal canonical event structure shape
+Recommended for all producers and required by schema version `3.x`:
 
-Runtime parsing requires:
+- `eventId` — stable producer event identifier.
+- `sourceService` — stable service name for the producer.
 
-- `metadata.event_type`, `metadata.timestamp`, optional metadata attributes
-- `graph.node_id`, `graph.target_node_id`, `graph.label` (as required per event type)
-- `payload` as an object (or omitted when optional for the event type)
+Optional metadata fields:
 
-### Required transform for historical payloads
+- `schemaVersion` — semantic contract version, for example `3.0.0`.
+- `producerId` — producer instance or principal identifier.
+- `tenant` — tenant or workspace identifier.
+- `signature` — producer signature or integrity token.
+- `correlationId` — request or workflow correlation identifier.
+- `subjectEntity` — object containing `id` and `type` for the event subject.
 
-Historical payloads (legacy nested `event` wrapper or legacy snake_case metadata like
-`event_type`) must run through `ume.events.legacy_transform.apply_legacy_transform(...)`
-before canonicalization and parsing.
+Graph fields, required according to event type:
 
-Canonical migration path:
+- `node_id` — source node identifier.
+- `target_node_id` — target node identifier for edge operations.
+- `label` — edge label for edge operations.
+
+Payload field:
+
+- `payload` — event-specific object. It may be omitted only when optional for the event type.
+
+### Producer example
+
+```json
+{
+  "eventId": "evt-123",
+  "eventType": "CREATE_NODE",
+  "timestamp": "2026-06-22T00:00:00Z",
+  "schemaVersion": "3.0.0",
+  "sourceService": "example-producer",
+  "producerId": "producer-a",
+  "tenant": "tenant-1",
+  "correlationId": "corr-123",
+  "subjectEntity": {"id": "User.u1", "type": "User"},
+  "node_id": "Document.1",
+  "payload": {
+    "node_id": "Document.1",
+    "attributes": {"title": "Launch Checklist"}
+  }
+}
+```
+
+### Canonical parser form
+
+After the one canonical transform, parsers receive this internal shape:
+
+```json
+{
+  "metadata": {
+    "event_id": "evt-123",
+    "event_type": "CREATE_NODE",
+    "timestamp": "2026-06-22T00:00:00Z",
+    "schema_version": "3.0.0",
+    "source": "example-producer",
+    "producer_id": "producer-a",
+    "tenant": "tenant-1",
+    "producer_signature": null,
+    "correlation_ids": {"correlation_id": "corr-123"},
+    "subject_entity": {"id": "User.u1", "type": "User"}
+  },
+  "graph": {
+    "node_id": "Document.1",
+    "target_node_id": null,
+    "label": null
+  },
+  "payload": {
+    "node_id": "Document.1",
+    "attributes": {"title": "Launch Checklist"}
+  }
+}
+```
+
+### Legacy migration: historical inputs only
+
+Historical payloads may contain a nested `event` wrapper or legacy producer metadata aliases such as `event_type`, `event_id`, `schema_version`, `source`, `producer_signature`, `correlation_id`, and `subject_entity`. Those names are not accepted at new ingress. They are permitted only in documented legacy migration contexts and must be transformed once with `apply_legacy_transform(...)` before canonicalization.
+
+Canonical migration path for historical payloads:
 
 1. `ume.events.legacy_transform.apply_legacy_transform(...)`
 2. `ume.events.contract.canonicalize_event(...)`
 3. `ume.kernel.events.parse_event(...)`
 
-### Producer migration matrix (legacy/flat -> canonical event structure)
+### Producer migration matrix (legacy/flat -> canonical parser form)
 
-| Producer field (legacy/flat) | Canonical envelope field |
+| Producer field | Canonical parser field |
 | --- | --- |
 | `eventType` | `metadata.event_type` |
 | `eventId` | `metadata.event_id` |
@@ -165,12 +229,15 @@ Canonical migration path:
 - `Missing required fields for CREATE_EDGE event: node_id, target_node_id, label`
 - `Missing required field 'payload.attributes' for UPDATE_NODE_ATTRIBUTES event.`
 
+## Event Contract Version Policy
+
+UME event contracts are versioned with semantic versions and validated against JSON Schema bundles under `src/ume/schemas/v{major}`.
+
 ### Required vs optional fields
 
 - **Always required (all majors):** `eventType`, `timestamp`.
 - **Version 1.x / 2.x:** identity fields (`eventId`, `sourceService`) are optional for compatibility with historical emitters.
 - **Version 3.x:** `eventId` and `sourceService` are required on all events; replay transformers can synthesize these when upgrading old ledgers.
-- Event-type schemas define additional required fields (`node_id`, `target_node_id`, `label`, `payload`) based on operation type.
 
 ### Additive vs breaking changes
 

--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -8,6 +8,8 @@ codebase today.
 
 Use [`GLOSSARY.md`](GLOSSARY.md) as the single source for canonical terminology (`backend`, `adapter`, `canonical event`, and `canonical path`).
 
+The authoritative external producer event contract and boundary between ingress normalization, canonicalization, and parsing lives in [`API_REFERENCE.md#authoritative-external-producer-contract`](API_REFERENCE.md#authoritative-external-producer-contract).
+
 
 ## Layered package layout
 

--- a/docs/GRAPH_MODEL.md
+++ b/docs/GRAPH_MODEL.md
@@ -6,6 +6,8 @@ This document defines the initial ontology used by the Universal Memory Engine.
 It describes node types, edge labels and general versioning guidelines for the
 graph representation.
 
+Producer-facing event fields, canonical transform rules, and parser boundaries are defined in the authoritative external producer contract: [`API_REFERENCE.md#authoritative-external-producer-contract`](API_REFERENCE.md#authoritative-external-producer-contract).
+
 ## Node Types
 
 ### UserMemory

--- a/scripts/check_arch_terms.py
+++ b/scripts/check_arch_terms.py
@@ -11,6 +11,7 @@ CORE_DOC_FILES = [
     Path("README.md"),
     Path("docs/API_REFERENCE.md"),
     Path("docs/ARCHITECTURE_OVERVIEW.md"),
+    Path("docs/GRAPH_MODEL.md"),
     Path("docs/INTEGRATIONS.md"),
 ]
 
@@ -35,6 +36,38 @@ DEPRECATED_PATTERNS: dict[str, str] = {
     r"\bcanonical envelope\b": "Use canonical event terminology",
 }
 
+CONTRACT_DOC_FILES = [Path("docs/API_REFERENCE.md")]
+CONTRACT_FIELD_PATTERNS: dict[str, str] = {
+    r"`event_type`|\bevent_type\b": (
+        "Use producer-facing eventType except in canonical parser or legacy migration sections"
+    ),
+    r"`event_id`|\bevent_id\b": (
+        "Use producer-facing eventId except in canonical parser or legacy migration sections"
+    ),
+    r"`schema_version`|\bschema_version\b": (
+        "Use producer-facing schemaVersion except in canonical parser, "
+        "version policy, or legacy migration sections"
+    ),
+    r"`producer_signature`|\bproducer_signature\b": (
+        "Use producer-facing signature except in canonical parser or legacy migration sections"
+    ),
+    r"`correlation_id`|\bcorrelation_id\b": (
+        "Use producer-facing correlationId except in canonical parser or legacy migration sections"
+    ),
+    r"`subject_entity`|\bsubject_entity\b": (
+        "Use producer-facing subjectEntity except in canonical parser or legacy migration sections"
+    ),
+}
+
+CONTRACT_ALLOWED_HEADING_TOKENS = (
+    "legacy migration",
+    "historical inputs",
+    "canonical parser",
+    "producer migration matrix",
+    "parse_event error examples",
+    "event contract version policy",
+)
+
 CANONICAL_LINK = "ARCHITECTURE_OVERVIEW.md"
 GLOSSARY_LINK = "GLOSSARY.md"
 LEGACY_HEADING_TOKEN = "legacy migration"
@@ -45,6 +78,13 @@ def _is_legacy_section_heading(line: str) -> bool:
     return stripped.startswith("#") and LEGACY_HEADING_TOKEN in stripped
 
 
+def _is_contract_allowed_section_heading(line: str) -> bool:
+    stripped = line.strip().lower()
+    return stripped.startswith("#") and any(
+        token in stripped for token in CONTRACT_ALLOWED_HEADING_TOKENS
+    )
+
+
 def _is_heading(line: str) -> bool:
     return line.strip().startswith("#")
 
@@ -52,23 +92,47 @@ def _is_heading(line: str) -> bool:
 def find_term_matches(path: Path) -> list[str]:
     matches: list[str] = []
     text = path.read_text(encoding="utf-8")
-    in_legacy_section = False
+    in_approved_section = False
     for lineno, line in enumerate(text.splitlines(), start=1):
-        if _is_legacy_section_heading(line):
-            in_legacy_section = True
+        if _is_legacy_section_heading(line) or _is_contract_allowed_section_heading(line):
+            in_approved_section = True
             continue
-        if in_legacy_section and _is_heading(line):
-            in_legacy_section = False
+        if in_approved_section and _is_heading(line):
+            in_approved_section = False
 
         for pattern, guidance in DEPRECATED_PATTERNS.items():
             if re.search(pattern, line):
-                if in_legacy_section:
+                if in_approved_section or "metadata.schema_version" in line:
                     continue
                 matches.append(
-                    f"{path}:{lineno}: found deprecated term matching /{pattern}/ outside a 'Legacy migration' section. {guidance}."
+                    f"{path}:{lineno}: found deprecated term matching /{pattern}/ "
+                    "outside an approved legacy/canonical contract section. "
+                    f"{guidance}."
                 )
     return matches
 
+
+def find_contract_field_matches(path: Path) -> list[str]:
+    matches: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    in_approved_section = False
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if _is_contract_allowed_section_heading(line):
+            in_approved_section = True
+            continue
+        if in_approved_section and _is_heading(line):
+            in_approved_section = False
+
+        for pattern, guidance in CONTRACT_FIELD_PATTERNS.items():
+            if re.search(pattern, line):
+                if in_approved_section or "metadata.schema_version" in line:
+                    continue
+                matches.append(
+                    f"{path}:{lineno}: found deprecated producer contract field "
+                    f"matching /{pattern}/ outside an approved legacy/canonical "
+                    f"contract section. {guidance}."
+                )
+    return matches
 
 def check_module_doc_backlinks() -> list[str]:
     failures: list[str] = []
@@ -99,6 +163,12 @@ def main() -> int:
             failures.append(f"{path}: missing expected core doc file")
             continue
         failures.extend(find_term_matches(path))
+
+    for path in CONTRACT_DOC_FILES:
+        if not path.exists():
+            failures.append(f"{path}: missing expected contract doc file")
+            continue
+        failures.extend(find_contract_field_matches(path))
 
     failures.extend(check_module_doc_backlinks())
     failures.extend(check_glossary_links())

--- a/src/ume/events/contract.py
+++ b/src/ume/events/contract.py
@@ -5,7 +5,13 @@ from datetime import datetime
 from typing import Any, Dict, Mapping
 
 
-"""Event contract transformations.
+"""Canonical transform boundary for UME events.
+
+Boundary marker: this module owns the one canonical transform from the
+authoritative external producer contract accepted at ingress into the canonical
+internal form consumed by parsers. It does not accept historical wrappers or
+legacy producer field aliases; callers must run ``ume.events.legacy_transform``
+first when handling legacy inputs.
 
 Authoritative ingress contract (external): flat producer payload with camelCase
 metadata keys and snake_case graph keys:
@@ -185,7 +191,7 @@ def _to_external_contract(data: Mapping[str, Any]) -> Dict[str, Any]:
 
 
 def canonicalize_event(data: Mapping[str, Any]) -> Dict[str, Any]:
-    """Transform authoritative external ingest payload into canonical envelope."""
+    """Perform the single external -> canonical transform accepted by parsers."""
 
     external_data = _to_external_contract(data)
     snake_data = _to_snake_keys(external_data)

--- a/src/ume/events/legacy_transform.py
+++ b/src/ume/events/legacy_transform.py
@@ -5,9 +5,12 @@ from typing import Any, Mapping
 
 
 def apply_legacy_transform(payload: Mapping[str, Any]) -> dict[str, Any]:
-    """Upgrade legacy transport/event shapes to the authoritative external contract.
+    """Upgrade legacy transport/event shapes to the external ingress contract.
 
-    This is the *only* backward-compatibility transform entrypoint. All new ingress
+    Boundary marker: this is the only backward-compatibility transform entrypoint.
+    It normalizes legacy inputs into the authoritative external producer contract;
+    the next hop must be ``ume.events.contract.canonicalize_event(...)``, which is
+    the one canonical transform into parser-ready canonical form. All new ingress
     code should provide already-compliant external payloads and skip this module.
     """
 

--- a/src/ume/kernel/events.py
+++ b/src/ume/kernel/events.py
@@ -81,6 +81,13 @@ def _normalize_schema_version(value: Any) -> str | None:
 
 
 def parse_event(data: Dict[str, Any]) -> Event:
+    """Parse only canonical event data produced by ``canonicalize_event``.
+
+    Boundary marker: this parser is deliberately behind ingress normalization and
+    the one canonical transform. It rejects external producer payloads and legacy
+    transport shapes rather than normalizing them itself.
+    """
+
     logger.debug("Parsing canonical event data: %s", data)
 
     if not {"metadata", "graph", "payload"} <= data.keys():

--- a/tests/test_event_contract_normalization.py
+++ b/tests/test_event_contract_normalization.py
@@ -42,3 +42,65 @@ def test_event_envelope_is_rejected() -> None:
                 "event": {"eventType": "CREATE_NODE", "timestamp": 1},
             }
         )
+
+
+def test_legacy_transform_is_required_before_canonicalize_for_deprecated_aliases() -> None:
+    legacy = {
+        "event_id": "legacy-1",
+        "event_type": "CREATE_NODE",
+        "timestamp": 1,
+        "schema_version": "2.0.0",
+        "source": "old-service",
+        "producer_signature": "sig",
+        "correlation_id": "corr",
+        "subject_entity": {"id": "u1", "type": "User"},
+        "nodeId": "n1",
+        "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
+    }
+
+    with pytest.raises(ValueError, match="legacy_transform"):
+        canonicalize_event(legacy)
+
+    from ume.events.legacy_transform import apply_legacy_transform
+
+    external = apply_legacy_transform(legacy)
+    assert external == {
+        "eventId": "legacy-1",
+        "eventType": "CREATE_NODE",
+        "timestamp": 1,
+        "schemaVersion": "2.0.0",
+        "sourceService": "old-service",
+        "signature": "sig",
+        "correlationId": "corr",
+        "subjectEntity": {"id": "u1", "type": "User"},
+        "nodeId": "n1",
+        "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
+        "node_id": "n1",
+    }
+    canonical = canonicalize_event(external)
+    assert canonical["metadata"]["event_id"] == "legacy-1"
+    assert canonical["metadata"]["event_type"] == "CREATE_NODE"
+    assert canonical["metadata"]["schema_version"] == "2.0.0"
+    assert canonical["metadata"]["source"] == "old-service"
+    assert canonical["metadata"]["producer_signature"] == "sig"
+    assert canonical["metadata"]["correlation_ids"] == {"correlation_id": "corr"}
+    assert canonical["metadata"]["subject_entity"] == {"id": "u1", "type": "User"}
+    assert canonical["graph"]["node_id"] == "n1"
+
+
+def test_parse_event_rejects_external_contract_until_canonicalized() -> None:
+    from ume.kernel.events import EventError, parse_event
+
+    external = {
+        "eventType": "CREATE_NODE",
+        "timestamp": 1,
+        "node_id": "n1",
+        "payload": {"node_id": "n1", "attributes": {"name": "Alice"}},
+    }
+
+    with pytest.raises(EventError, match="parse_event expects canonicalized data"):
+        parse_event(external)
+
+    event = parse_event(canonicalize_event(external))
+    assert event.event_type == "CREATE_NODE"
+    assert event.node_id == "n1"

--- a/tests/test_schema_resolution_parity.py
+++ b/tests/test_schema_resolution_parity.py
@@ -94,3 +94,30 @@ def test_historical_events_are_normalized_once_then_replayed_uniformly(tmp_path)
     assert canonical["graph"]["node_id"] == "legacy-1"
     assert replay_graph.dump() == graph.dump()
     ledger.close()
+
+
+def test_legacy_and_external_payloads_resolve_to_identical_canonical_contract() -> None:
+    legacy = {
+        "event": {
+            "event_id": "evt-parity",
+            "event_type": "CREATE_EDGE",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "schema_version": "2.0.0",
+            "source": "legacy-service",
+            "nodeId": "a",
+            "targetNodeId": "b",
+            "label": "LINKS_TO",
+        }
+    }
+    external = {
+        "eventId": "evt-parity",
+        "eventType": "CREATE_EDGE",
+        "timestamp": "2024-01-01T00:00:00Z",
+        "schemaVersion": "2.0.0",
+        "sourceService": "legacy-service",
+        "node_id": "a",
+        "target_node_id": "b",
+        "label": "LINKS_TO",
+    }
+
+    assert canonicalize_event(apply_legacy_transform(legacy)) == canonicalize_event(external)


### PR DESCRIPTION
### Motivation
- Establish a single authoritative external producer contract so producer-facing fields and the canonical parser form are documented in one place.  
- Make the runtime boundary explicit so ingress normalization, the canonical transform, and parsing responsibilities are clear and not mixed.  
- Prevent accidental use of deprecated/legacy producer field names outside approved legacy documentation sections.  

### Description
- Add a new "Authoritative External Producer Contract" section to `docs/API_REFERENCE.md` and link it from `README.md`, `docs/GRAPH_MODEL.md`, and `docs/ARCHITECTURE_OVERVIEW.md`.  
- Mark the canonicalization/parser boundary in code by adding boundary documentation/comments to `src/ume/events/contract.py`, `src/ume/events/legacy_transform.py`, and `src/ume/kernel/events.py`, clarifying: (1) external contract accepted at ingress, (2) one canonical transform (`canonicalize_event`), and (3) parser only accepts canonical form (`parse_event`).  
- Extend `scripts/check_arch_terms.py` to detect deprecated producer contract field names (for example `event_type`, `event_id`, `schema_version`, `producer_signature`, `correlation_id`, `subject_entity`) and allow them only inside approved legacy/canonical contract documentation sections.  
- Add parity/consistency tests in `tests/test_event_contract_normalization.py` and `tests/test_schema_resolution_parity.py` to assert legacy->external normalization requirements, canonical transform guarantees, and identical canonical outputs for legacy vs external payloads.  

### Testing
- Ran the documentation consistency checks with `python scripts/check_arch_terms.py` and `python scripts/check_contract_terms.py`, and both checks passed.  
- Ran unit tests with `pytest tests/test_event_contract_normalization.py tests/test_schema_resolution_parity.py`, which collected 9 tests and reported `9 passed`.  
- Ran static checks with `ruff` against the touched files, and the linter passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39510b2d3483268f7b285c332a72d8)